### PR TITLE
fix: add --fail flag to curl commands in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ esac
 # Resolve version
 if [ -z "$VERSION" ]; then
     echo "Fetching latest release..."
-    VERSION="$(curl -sSL -H "Accept: application/vnd.github+json" \
+    VERSION="$(curl -fsSL -H "Accept: application/vnd.github+json" \
         "https://api.github.com/repos/${REPO}/releases/latest" \
         | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
     if [ -z "$VERSION" ]; then
@@ -70,8 +70,8 @@ trap 'rm -rf "$TMPDIR"' EXIT
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 
 # Download binary and checksums
-curl -sSL -o "${TMPDIR}/${BINARY}" "${BASE_URL}/${BINARY}"
-curl -sSL -o "${TMPDIR}/checksums.txt" "${BASE_URL}/checksums.txt"
+curl -fsSL -o "${TMPDIR}/${BINARY}" "${BASE_URL}/${BINARY}"
+curl -fsSL -o "${TMPDIR}/checksums.txt" "${BASE_URL}/checksums.txt"
 
 # Verify checksum
 echo "Verifying checksum..."


### PR DESCRIPTION
## Summary
- Add `-f` (`--fail`) flag to all `curl` calls in `install.sh` so HTTP errors (4xx/5xx) cause immediate failure instead of silently saving error pages as valid files
- Fixes a confusing "checksum not found" error when release assets aren't fully propagated on GitHub CDN

## Test plan
- [x] Run `curl -sSL https://raw.githubusercontent.com/siyuqian/devpilot/fix/install-curl-fail-flag/install.sh | sh` and verify successful install
- [x] Verify that pointing at a non-existent version (`--version v99.99.99`) now fails with a clear curl error instead of a checksum error

🤖 Generated with [Claude Code](https://claude.com/claude-code)