### PR TITLE
feat(review): post review results to GitHub PR as review comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,11 @@ devpilot skill add <name>@<ref>                            # Install at specific
 devpilot skill list                                        # List available skills with install status
 devpilot skill list --installed                            # List only installed skills
 
+devpilot review <pr-url>                                   # AI-powered code review, posts to PR as GitHub review
+devpilot review <pr-url> --no-post                         # Review without posting to PR
+devpilot review <pr-url> --model claude-sonnet-4-6-20250514  # Review with custom model
+devpilot review <pr-url> --dry-run                         # Print assembled prompt without executing
+
 devpilot commit                                            # Generate commit message from staged changes
 devpilot readme                                            # Generate or improve README.md
 ```

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -38,6 +38,11 @@ type Executor struct {
 	claudeEventHandler ClaudeEventHandler
 }
 
+// Args returns the command arguments. Useful for testing.
+func (e *Executor) Args() []string {
+	return e.args
+}
+
 type ExecutorOption func(*Executor)
 
 // WithCommand sets the command and arguments for the executor to run.

--- a/internal/review/commands.go
+++ b/internal/review/commands.go
@@ -15,6 +15,7 @@ func RegisterCommands(parent *cobra.Command) {
 	reviewCmd.Flags().String("model", "", "Override Claude model (default: "+DefaultReviewModel+")")
 	reviewCmd.Flags().Bool("dry-run", false, "Print assembled prompt without executing Claude")
 	reviewCmd.Flags().Int("timeout", 10, "Review timeout in minutes")
+	reviewCmd.Flags().Bool("no-post", false, "Skip posting review to GitHub PR")
 
 	parent.AddCommand(reviewCmd)
 }
@@ -41,6 +42,8 @@ var reviewCmd = &cobra.Command{
 		model := resolveModel(cmd)
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		timeoutMin, _ := cmd.Flags().GetInt("timeout")
+		noPost, _ := cmd.Flags().GetBool("no-post")
+		postToGitHub := !noPost
 
 		// Validate PR URL early
 		pr, err := ParsePRURL(prURL)
@@ -50,7 +53,7 @@ var reviewCmd = &cobra.Command{
 		}
 
 		if dryRun {
-			prompt := BuildPrompt(pr)
+			prompt := BuildPrompt(pr, postToGitHub)
 			fmt.Println(prompt)
 			return
 		}
@@ -59,7 +62,7 @@ var reviewCmd = &cobra.Command{
 		defer cancel()
 
 		streamer := newReviewStreamer()
-		result, err := Review(ctx, prURL, WithModel(model), WithEventHandler(streamer.HandleEvent))
+		result, err := Review(ctx, prURL, WithModel(model), WithPostToGitHub(postToGitHub), WithEventHandler(streamer.HandleEvent))
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error:", err)
 			os.Exit(1)

--- a/internal/review/embed.go
+++ b/internal/review/embed.go
@@ -7,3 +7,6 @@ var reviewPromptMD string
 
 //go:embed review-template.md
 var reviewTemplateMD string
+
+//go:embed review-posting.md
+var reviewPostingMD string

--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -7,7 +7,7 @@ import (
 
 // BuildPrompt assembles the complete review prompt from instructions, template,
 // and the PR URL. Context discovery is delegated to Claude via prompt instructions.
-func BuildPrompt(pr *PRInfo) string {
+func BuildPrompt(pr *PRInfo, postToGitHub bool) string {
 	var b strings.Builder
 
 	// Review instructions (includes clone + context discovery instructions)
@@ -17,6 +17,12 @@ func BuildPrompt(pr *PRInfo) string {
 	// Output template
 	b.WriteString(reviewTemplateMD)
 	b.WriteString("\n\n")
+
+	// Posting instructions (conditional)
+	if postToGitHub {
+		b.WriteString(reviewPostingMD)
+		b.WriteString("\n\n")
+	}
 
 	// PR URL
 	b.WriteString(fmt.Sprintf("## Task\n\nReview this pull request: %s\n", pr.URL))

--- a/internal/review/review-posting.md
+++ b/internal/review/review-posting.md
@@ -1,0 +1,74 @@
+# Posting Review to GitHub
+
+After completing your review, post the results directly to the pull request as a GitHub PR review using the `gh api` command.
+
+## Steps
+
+1. **Get PR author**: Run `gh pr view <pr-url> --json author --jq .author.login` to get the author's GitHub username.
+
+2. **Construct the review body** using this template:
+
+   ```
+   Nice work on this PR, @{author}! Here are some thoughts from my review.
+
+   {summary}
+
+   **Verdict: {APPROVED or NEEDS ATTENTION}**
+
+   {overall assessment}
+
+   — Automated review by DevPilot
+   ```
+
+   - Use `APPROVED` when your verdict is APPROVE.
+   - Use `NEEDS ATTENTION` when your verdict is REQUEST_CHANGES.
+
+3. **Determine the GitHub event**:
+   - If verdict is APPROVE → use event `APPROVE`
+   - If verdict is REQUEST_CHANGES → use event `COMMENT` (do NOT use `REQUEST_CHANGES`)
+
+4. **Build inline comments** for each finding:
+   - Each finding becomes an inline comment with:
+     - `path`: the file path relative to the repo root
+     - `line`: the line number in the file (new version / RIGHT side of diff)
+     - `side`: always `RIGHT`
+     - `body`: formatted as `[SEVERITY] Title\n\nExplanation\n\n```suggestion\ncode fix\n```\n` (include the suggestion block only if you have a concrete fix)
+   - **Important**: The `line` must be within the diff range for that file. If a finding is on a line outside the diff, include it in the review body instead of as an inline comment.
+
+5. **Post the review** using `gh api`:
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+     --method POST \
+     -f body="<review body>" \
+     -f event="<APPROVE or COMMENT>" \
+     -f 'comments[0][path]=<file>' \
+     -f 'comments[0][line]=<line number>' \
+     -f 'comments[0][side]=RIGHT' \
+     -f 'comments[0][body]=<comment body>'
+   ```
+
+   Repeat the `comments[N]` fields for each inline comment (increment N).
+
+6. **Handle errors**: If the `gh api` call fails, report the error clearly in your output. The review text has already been streamed to the terminal, so a posting failure does not lose the review.
+
+## Inline Comment Format
+
+```
+[WARNING] Missing error check
+
+`StreamEvents` returns an error but it's being silently discarded here. Consider logging or propagating.
+
+```suggestion
+if err := s.StreamEvents(ctx); err != nil {
+    return fmt.Errorf("stream events: %w", err)
+}
+```
+```
+
+## Notes
+
+- Always use the `line`/`side` parameters, NOT the legacy `position` parameter.
+- The `line` value is the file line number on the RIGHT (new) side of the diff.
+- Verify each finding's line is within the diff range before adding it as an inline comment.
+- If no findings require inline comments, submit the review with just the body (no `comments` fields).

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -14,6 +14,7 @@ type Option func(*options)
 
 type options struct {
 	model        string
+	postToGitHub bool
 	execOpts     []executor.ExecutorOption
 	eventHandler executor.ClaudeEventHandler
 }
@@ -32,6 +33,13 @@ func WithEventHandler(handler executor.ClaudeEventHandler) Option {
 	}
 }
 
+// WithPostToGitHub controls whether posting instructions are included in the prompt.
+func WithPostToGitHub(post bool) Option {
+	return func(o *options) {
+		o.postToGitHub = post
+	}
+}
+
 // WithExecutorOptions passes additional executor options (e.g., for streaming).
 func WithExecutorOptions(opts ...executor.ExecutorOption) Option {
 	return func(o *options) {
@@ -47,7 +55,7 @@ func Review(ctx context.Context, prURL string, opts ...Option) (*executor.Execut
 	}
 
 	o := resolveOptions(opts)
-	prompt := BuildPrompt(pr)
+	prompt := BuildPrompt(pr, o.postToGitHub)
 	exec := newReviewExecutor(o)
 	return exec.Run(ctx, prompt)
 }
@@ -72,7 +80,8 @@ func BuildFixPrompt(prURL string) string {
 
 func resolveOptions(opts []Option) *options {
 	o := &options{
-		model: DefaultReviewModel,
+		model:        DefaultReviewModel,
+		postToGitHub: true,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -81,7 +90,7 @@ func resolveOptions(opts []Option) *options {
 }
 
 func newReviewExecutor(o *options) *executor.Executor {
-	args := []string{"-p", "--thinking", "enabled", "--model", o.model, "--verbose", "--output-format", "stream-json", "--allowedTools=*"}
+	args := []string{"-p", "--thinking", "enabled", "--model", o.model, "--verbose", "--output-format", "stream-json", "--allowedTools=Read,Grep,Glob,Bash"}
 	allOpts := []executor.ExecutorOption{executor.WithCommand("claude", args...)}
 	if o.eventHandler != nil {
 		allOpts = append(allOpts, executor.WithClaudeEventHandler(o.eventHandler))

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -3,6 +3,8 @@ package review
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // --- URL validation tests ---
@@ -120,7 +122,7 @@ something unexpected here
 func TestBuildPrompt_ContainsReviewInstructions(t *testing.T) {
 	pr := &PRInfo{Owner: "owner", Repo: "repo", Number: "1", URL: "https://github.com/owner/repo/pull/1"}
 
-	prompt := BuildPrompt(pr)
+	prompt := BuildPrompt(pr, false)
 
 	if !strings.Contains(prompt, "Code Review Instructions") {
 		t.Error("prompt should contain review instructions")
@@ -136,7 +138,7 @@ func TestBuildPrompt_ContainsReviewInstructions(t *testing.T) {
 func TestBuildPrompt_ContainsCloneInstructions(t *testing.T) {
 	pr := &PRInfo{Owner: "owner", Repo: "repo", Number: "1", URL: "https://github.com/owner/repo/pull/1"}
 
-	prompt := BuildPrompt(pr)
+	prompt := BuildPrompt(pr, false)
 
 	if !strings.Contains(prompt, "Repository Setup") {
 		t.Error("prompt should contain repository setup section")
@@ -149,6 +151,65 @@ func TestBuildPrompt_ContainsCloneInstructions(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "CLAUDE.md") {
 		t.Error("prompt should mention CLAUDE.md as a convention file to look for")
+	}
+}
+
+func TestBuildPrompt_WithPostingEnabled(t *testing.T) {
+	pr := &PRInfo{Owner: "owner", Repo: "repo", Number: "1", URL: "https://github.com/owner/repo/pull/1"}
+
+	prompt := BuildPrompt(pr, true)
+
+	if !strings.Contains(prompt, "Posting Review to GitHub") {
+		t.Error("prompt should contain posting instructions when posting is enabled")
+	}
+	if !strings.Contains(prompt, "gh api") {
+		t.Error("prompt should contain gh api instructions when posting is enabled")
+	}
+}
+
+func TestBuildPrompt_WithPostingDisabled(t *testing.T) {
+	pr := &PRInfo{Owner: "owner", Repo: "repo", Number: "1", URL: "https://github.com/owner/repo/pull/1"}
+
+	prompt := BuildPrompt(pr, false)
+
+	if strings.Contains(prompt, "Posting Review to GitHub") {
+		t.Error("prompt should NOT contain posting instructions when posting is disabled")
+	}
+}
+
+func TestNewReviewExecutor_RestrictedTools(t *testing.T) {
+	o := &options{model: DefaultReviewModel}
+	exec := newReviewExecutor(o)
+	args := exec.Args()
+	found := false
+	for _, arg := range args {
+		if arg == "--allowedTools=*" {
+			t.Error("review executor should NOT use --allowedTools=*")
+		}
+		if arg == "--allowedTools=Read,Grep,Glob,Bash" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("review executor should use --allowedTools=Read,Grep,Glob,Bash, got args: %v", args)
+	}
+}
+
+// --- Flag tests ---
+
+func TestReviewCmd_NoPostFlag(t *testing.T) {
+	parent := &cobra.Command{Use: "test"}
+	RegisterCommands(parent)
+	cmd, _, err := parent.Find([]string{"review"})
+	if err != nil {
+		t.Fatalf("could not find review command: %v", err)
+	}
+	val, err2 := cmd.Flags().GetBool("no-post")
+	if err2 != nil {
+		t.Fatalf("--no-post flag should exist: %v", err2)
+	}
+	if val != false {
+		t.Error("--no-post default should be false")
 	}
 }
 

--- a/openspec/changes/review-post-to-pr/.openspec.yaml
+++ b/openspec/changes/review-post-to-pr/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/review-post-to-pr/design.md
+++ b/openspec/changes/review-post-to-pr/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Currently `devpilot review <pr-url>` runs Claude with `--allowedTools=*` and streams the structured review output to the terminal. The review output includes Summary, Verdict, Findings (with file paths and line numbers), and Overall Assessment. However, nothing is posted to the GitHub PR — the output stays local.
+
+The review executor at `internal/review/review.go:84` passes `--allowedTools=*`, which grants Claude Write/Edit access that a read-only review operation should not have.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Claude posts review results directly to the PR as a GitHub review (summary + inline comments) via `gh api`
+- Tighten `--allowedTools` to only what review needs (read tools + Bash for `gh`/`git`)
+- Add `--no-post` flag to skip posting when user just wants terminal output
+- Use APPROVE status when verdict is approve; use COMMENT status otherwise (never REQUEST_CHANGES)
+
+**Non-Goals:**
+- Changing the `devpilot run` (runner) review flow — runner still only uses stdout for verdict parsing
+- Implementing Go-side parsing of review output to construct API calls
+- Adding posting support for non-GitHub platforms (GitLab, Bitbucket)
+- Tightening `newFixExecutor` tools — fix needs Write/Edit to modify code, so `--allowedTools=*` is correct there
+
+## Decisions
+
+### Decision 1: Claude posts via `gh api` (prompt-driven, not Go-parsed)
+
+Instead of parsing Claude's structured output in Go and constructing GitHub API calls, we add instructions to the review prompt telling Claude to post the review itself using `gh api`.
+
+**Why:** Claude already knows every finding's file, line, severity, and content. Parsing this in Go would require a brittle parser that breaks if the output format changes. Claude can directly construct the API payload with full fidelity.
+
+**Alternative considered:** Go-side parsing + `gh api` call. Rejected because it adds a fragile parser layer with no benefit — Claude is already the source of truth for the findings.
+
+### Decision 2: Tighten allowedTools to read + Bash only
+
+Change from `--allowedTools=*` to `--allowedTools=Read,Grep,Glob,Bash` (or the equivalent comma-separated list). This removes Write/Edit access since review is a read-only operation.
+
+**Why:** Principle of least privilege. A review tool should not be able to modify code. The only "write" action it takes is posting via `gh api` through Bash.
+
+### Decision 3: Posting instructions as a separate embedded prompt section
+
+Add a new `review-posting.md` embedded file with posting instructions, appended after the existing review prompt and template. The posting section tells Claude:
+1. After completing the review, construct a GitHub PR review via `gh api`
+2. Use `APPROVE` event when verdict is APPROVE; use `COMMENT` event otherwise
+3. Include the Summary + Overall Assessment as the review body
+4. Add each finding as an inline comment on the relevant file and line
+
+**Why:** Keeping posting instructions separate from review instructions maintains clean separation of concerns. The review prompt focuses on *how to review*; the posting prompt focuses on *how to publish*.
+
+### Decision 4: `--no-post` flag controls posting
+
+A new `--no-post` boolean flag on `devpilot review`. When set, the posting instructions are omitted from the prompt entirely (not included in the assembled prompt). Default: false (posting enabled).
+
+**Why:** Omitting the instructions entirely is cleaner than adding a conditional "don't post" instruction. It also saves tokens.
+
+### Decision 5: GitHub review API via `gh api`
+
+Claude will use the GitHub PR review API with the newer `line`/`side` parameters (instead of the legacy `position` field):
+
+```
+gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  --method POST \
+  -f body="..." \
+  -f event="APPROVE|COMMENT" \
+  -f 'comments[0][path]=...' \
+  -f 'comments[0][line]=...' \
+  -f 'comments[0][side]=RIGHT' \
+  -f 'comments[0][body]=...'
+```
+
+The `line` field is the file line number in the diff's RIGHT side (new version), which is much more intuitive than the legacy `position` field (diff hunk offset). Claude already knows file line numbers from the review findings, so no mapping is needed.
+
+**Why `line`/`side` over `position`:** The `position` field requires counting lines within a diff hunk, which is error-prone. The `line`/`side` API (available since 2022) accepts the actual file line number directly.
+
+## Risks / Trade-offs
+
+**[Risk] Claude may fail to post correctly** → The review output is still streamed to terminal regardless, so the user always sees the review. A failed post is a degraded experience, not a lost review. The prompt should instruct Claude to report any posting errors clearly.
+
+**[Risk] Inline comment may land on wrong line** → Using `line`/`side` parameters (file line numbers) instead of `position` (diff offset) significantly reduces this risk. Claude already knows file line numbers from the review. Lines outside the diff range will be rejected by GitHub API — Claude should fall back to a non-inline comment in that case.
+
+**[Risk] Token cost increases slightly** → Claude must read the diff (already does) and make `gh api` calls. The incremental cost is small relative to the review itself.
+
+**[Trade-off] Prompt-driven posting is less deterministic than Go-parsed posting** → Accepted. The benefit of zero parsing code and natural accuracy outweighs the small risk of posting errors.

--- a/openspec/changes/review-post-to-pr/proposal.md
+++ b/openspec/changes/review-post-to-pr/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`devpilot review` produces structured code review output but only displays it in the terminal. The review results are not visible on the GitHub PR itself, so team members must run the tool locally to see findings. Posting the review directly to the PR as a GitHub review with inline comments makes the feedback visible to everyone and integrates into the normal PR workflow.
+
+## What Changes
+
+- Add prompt instructions for Claude to post review results to the PR via `gh api` after completing the review
+- Tighten the `--allowedTools` flag on the review executor to only permit read and shell tools (no Write/Edit), since review should be a read-only operation
+- Design a GitHub review comment template: a summary body + inline comments for each finding
+- Add `--no-post` flag to `devpilot review` to skip posting (default: post to PR)
+- When verdict is APPROVE, submit as GitHub `APPROVE` review; when verdict is REQUEST_CHANGES, submit as `COMMENT` review (never `REQUEST_CHANGES` status, to avoid blocking PRs)
+
+## Capabilities
+
+### New Capabilities
+- `review-github-posting`: Instructions and template for Claude to post review results to the PR as a GitHub review with inline comments via `gh api`
+
+### Modified Capabilities
+- `review-command`: Add `--no-post` flag, tighten `--allowedTools` to exclude Write/Edit
+- `review-prompt`: Add posting instructions section; update review template to include inline-comment-friendly output format
+
+## Impact
+
+- `internal/review/review-prompt.md` — add posting instructions
+- `internal/review/review-template.md` — update output format to support inline comments
+- `internal/review/review.go` — update executor args (`--allowedTools`)
+- `internal/review/commands.go` — add `--no-post` flag
+- No impact on `devpilot run` (runner mode unchanged)

--- a/openspec/changes/review-post-to-pr/specs/review-command/spec.md
+++ b/openspec/changes/review-post-to-pr/specs/review-command/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: CLI review command
+The system SHALL provide a `devpilot review <pr-url>` command that performs an AI-powered code review on the specified pull request, displaying real-time streaming progress during execution, and by default posts the review results to the PR as a GitHub review.
+
+#### Scenario: Review a GitHub PR
+- **WHEN** user runs `devpilot review https://github.com/owner/repo/pull/123`
+- **THEN** the system shows real-time progress on stderr, streams review text to stdout as it is generated, posts the review to the PR as a GitHub review, and exits with code 0 on success
+
+#### Scenario: Review with custom model
+- **WHEN** user runs `devpilot review <pr-url> --model claude-sonnet-4-6-20250514`
+- **THEN** the system uses the specified model instead of the default Opus 4.6
+
+#### Scenario: Review with model from config
+- **WHEN** user runs `devpilot review <pr-url>` and `.devpilot.yaml` has `models.review: claude-sonnet-4-6-20250514`
+- **THEN** the system uses the config model when no `--model` flag is provided
+
+#### Scenario: Dry run review
+- **WHEN** user runs `devpilot review <pr-url> --dry-run`
+- **THEN** the system prints the assembled prompt to stdout without executing Claude (no streaming, no posting), and the prompt SHALL reflect `--no-post` if set (omitting posting instructions)
+
+#### Scenario: Default timeout
+- **WHEN** user runs `devpilot review <pr-url>` without `--timeout`
+- **THEN** the system uses a default timeout of 10 minutes
+
+#### Scenario: Invalid PR URL
+- **WHEN** user runs `devpilot review not-a-url`
+- **THEN** the system exits with an error message indicating an invalid PR URL
+
+#### Scenario: No-post flag skips GitHub posting
+- **WHEN** user runs `devpilot review <pr-url> --no-post`
+- **THEN** the system performs the review and streams output to the terminal but does NOT post to the PR
+
+## ADDED Requirements
+
+### Requirement: Restricted tool access for review
+The review executor SHALL use a restricted `--allowedTools` list instead of `--allowedTools=*`.
+
+#### Scenario: Review executor permitted tools
+- **WHEN** the review executor is constructed
+- **THEN** `--allowedTools` SHALL be set to `Read,Grep,Glob,Bash` (no Write or Edit)
+
+#### Scenario: Claude can still run gh commands
+- **WHEN** Claude needs to run `gh pr diff`, `gh pr view`, `gh api`, or `git clone` during review
+- **THEN** these commands succeed because Bash is in the allowed tools list

--- a/openspec/changes/review-post-to-pr/specs/review-github-posting/spec.md
+++ b/openspec/changes/review-post-to-pr/specs/review-github-posting/spec.md
@@ -1,0 +1,52 @@
+## Purpose
+
+Defines the prompt instructions and comment template for Claude to post review results to a GitHub PR as a formal review with inline comments.
+
+## ADDED Requirements
+
+### Requirement: Post review as GitHub PR review
+The system SHALL include embedded posting instructions (`review-posting.md`) that direct Claude to submit review results to the PR via `gh api` after completing the review.
+
+#### Scenario: Approved review posts APPROVE status
+- **WHEN** Claude completes a review with verdict APPROVE
+- **THEN** Claude SHALL submit a GitHub PR review with event `APPROVE`, body containing the Summary and Overall Assessment, and inline comments for any SUGGESTION or PRAISE findings
+
+#### Scenario: Non-approved review posts COMMENT status
+- **WHEN** Claude completes a review with verdict REQUEST_CHANGES
+- **THEN** Claude SHALL submit a GitHub PR review with event `COMMENT` (never `REQUEST_CHANGES`), body containing the Summary and Overall Assessment, and inline comments for each finding
+
+#### Scenario: Inline comments include severity and explanation
+- **WHEN** Claude posts an inline comment for a finding
+- **THEN** the comment body SHALL include the severity tag (e.g., `[CRITICAL]`, `[WARNING]`, `[SUGGESTION]`, `[PRAISE]`), a brief title, and the full explanation
+
+#### Scenario: Inline comment uses line/side parameters
+- **WHEN** Claude posts an inline comment
+- **THEN** Claude SHALL use the `line` (file line number) and `side` (`RIGHT`) parameters in the API call, NOT the legacy `position` field
+
+#### Scenario: Finding on line outside diff range
+- **WHEN** Claude has a finding on a line that is not part of the diff
+- **THEN** Claude SHALL include the finding as a top-level review body comment instead of an inline comment
+
+#### Scenario: Review body template
+- **WHEN** Claude posts the review body
+- **THEN** the body SHALL follow this structure:
+  1. Greeting: `Nice work on this PR, @{author}! Here are some thoughts from my review.` (where `{author}` is the PR author's GitHub username, obtained via `gh pr view`)
+  2. Summary (1-2 sentences describing the change and overall impression)
+  3. Verdict line: `**Verdict: APPROVED**` or `**Verdict: NEEDS ATTENTION**`
+  4. Overall Assessment (2-3 sentences on code quality and observations)
+  5. Footer: `— Automated review by DevPilot`
+
+#### Scenario: Posting failure does not block review output
+- **WHEN** the `gh api` call to post the review fails (auth error, network error, etc.)
+- **THEN** Claude SHALL report the error in its output but the review text SHALL still be fully streamed to the terminal
+
+### Requirement: Posting instructions are a separate embedded file
+The system SHALL maintain posting instructions in a separate `review-posting.md` file, embedded alongside `review-prompt.md` and `review-template.md`.
+
+#### Scenario: Posting instructions assembled into prompt
+- **WHEN** posting is enabled (no `--no-post` flag)
+- **THEN** the assembled prompt includes the posting instructions section after the review template
+
+#### Scenario: Posting instructions omitted when disabled
+- **WHEN** the `--no-post` flag is set
+- **THEN** the assembled prompt does NOT include the posting instructions section

--- a/openspec/changes/review-post-to-pr/specs/review-prompt/spec.md
+++ b/openspec/changes/review-post-to-pr/specs/review-prompt/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Prompt assembly
+The system SHALL assemble the final review prompt by combining: review instructions, comment template, posting instructions (when enabled), and the PR URL.
+
+#### Scenario: Complete prompt assembly with posting
+- **WHEN** the review command prepares to invoke Claude and posting is enabled
+- **THEN** the assembled prompt includes the review instructions, comment template, posting instructions, and the PR URL
+
+#### Scenario: Complete prompt assembly without posting
+- **WHEN** the review command prepares to invoke Claude and `--no-post` is set
+- **THEN** the assembled prompt includes the review instructions, comment template, and the PR URL but omits the posting instructions
+
+#### Scenario: Context section is optional
+- **WHEN** no project conventions are detected
+- **THEN** the prompt omits the project context section and proceeds with the remaining sections only

--- a/openspec/changes/review-post-to-pr/tasks.md
+++ b/openspec/changes/review-post-to-pr/tasks.md
@@ -1,0 +1,28 @@
+## 1. Posting Instructions
+
+- [x] 1.1 Create `internal/review/review-posting.md` with instructions for Claude to post review as GitHub PR review via `gh api` (APPROVE or COMMENT event, summary body, inline comments with severity tags)
+- [x] 1.2 Add `//go:embed review-posting.md` var in `internal/review/embed.go`
+
+## 2. Prompt Assembly
+
+- [x] 2.1 Add `postToGitHub` bool parameter to `BuildPrompt` (or a new `BuildPromptWithPosting` function) that conditionally appends posting instructions
+- [x] 2.2 Add `WithPostToGitHub(bool)` option to review options
+- [x] 2.3 Wire `postToGitHub` option from `Review()` through `resolveOptions` to `BuildPrompt` call
+
+## 3. Tool Restrictions
+
+- [x] 3.1 Change `--allowedTools=*` to `--allowedTools=Read,Grep,Glob,Bash` in `newReviewExecutor`
+
+## 4. CLI Flag
+
+- [x] 4.1 Add `--no-post` flag to `reviewCmd` in `internal/review/commands.go`
+- [x] 4.2 Pass the posting option through to `Review()` call based on flag value (default: post enabled)
+- [x] 4.3 Wire `--no-post` into dry-run path so `BuildPrompt` omits posting instructions when both flags are set
+
+## 5. Testing
+
+- [x] 5.1 Add test for `BuildPrompt` with posting enabled — verify posting instructions are included
+- [x] 5.2 Add test for `BuildPrompt` with posting disabled — verify posting instructions are omitted
+- [x] 5.3 Add test that `newReviewExecutor` args contain `--allowedTools=Read,Grep,Glob,Bash` (not `*`)
+- [x] 5.4 Add test for `--no-post` flag parsing
+- [x] 5.5 Update CLAUDE.md CLI commands section to document `--no-post` flag


### PR DESCRIPTION
## Summary

- `devpilot review` now posts results directly to the PR as a GitHub review with inline comments (via Claude + `gh api`)
- Adds `--no-post` flag to skip posting (default: posts to PR)
- Tightens review executor `--allowedTools` from `*` to `Read,Grep,Glob,Bash` (principle of least privilege)
- Uses GitHub's `line`/`side` API parameters for accurate inline comment placement

## How It Works

Instead of parsing Claude's review output in Go, the review prompt now includes posting instructions (`review-posting.md`) that tell Claude to submit the review via `gh api` after completing it. When verdict is APPROVE → GitHub `APPROVE` event; when REQUEST_CHANGES → GitHub `COMMENT` event (never blocks the PR).

## Changes

| File | What |
|------|------|
| `internal/review/review-posting.md` | New embedded posting instructions for Claude |
| `internal/review/embed.go` | Embed the posting instructions |
| `internal/review/prompt.go` | `BuildPrompt` conditionally includes posting section |
| `internal/review/review.go` | `WithPostToGitHub` option, restricted `--allowedTools` |
| `internal/review/commands.go` | `--no-post` flag, wired to review + dry-run paths |
| `internal/review/review_test.go` | 4 new tests |
| `internal/executor/executor.go` | `Args()` getter for test access |
| `CLAUDE.md` | Document `devpilot review` commands |

## Review Guide

Start with `internal/review/review-posting.md` — this is the core of the change (the prompt Claude follows to post). Then `review.go` for the option wiring, `commands.go` for the flag, and `prompt.go` for conditional assembly.

## Test Plan

- [x] All existing tests pass (`make test`)
- [x] Lint clean (`make lint`, 0 issues)
- [x] New tests: posting enabled/disabled prompt content, restricted tools verification, `--no-post` flag
- [x] Manual: run `devpilot review <pr-url>` and verify review appears on PR
- [x] Manual: run `devpilot review <pr-url> --no-post` and verify no posting

🤖 Generated with [Claude Code](https://claude.com/claude-code)