### PR TITLE
feat(skill): add --all and --level flags to skill add

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,9 @@ devpilot gmail summary --no-mark-read=false                # Explicitly mark ema
 
 devpilot skill add <name>                                  # Install a skill (prompts for project/user level)
 devpilot skill add <name>@<ref>                            # Install at specific git ref
+devpilot skill add <name> --level user                     # Install at user level non-interactively (no prompt)
+devpilot skill add --all                                   # Install every skill in the catalog
+devpilot skill add --all --level project                   # Bulk install at project level, no prompt
 devpilot skill list                                        # List available skills with install status
 devpilot skill list --installed                            # List only installed skills
 

--- a/internal/skillmgr/commands.go
+++ b/internal/skillmgr/commands.go
@@ -105,6 +105,43 @@ func resolveInstallLevel(levelFlag, projectDir string, reader *bufio.Reader) (ba
 	}
 }
 
+// configDirForLevel returns the directory that holds .devpilot.yaml for the
+// given install level (project dir for project, user config dir for user).
+func configDirForLevel(projectDir string, userLevel bool) (string, error) {
+	if !userLevel {
+		return projectDir, nil
+	}
+	ud, err := userConfigDirFn()
+	if err != nil {
+		return "", fmt.Errorf("resolving user config dir: %w", err)
+	}
+	return ud, nil
+}
+
+// recordInstalledSkills loads the config at configDir, upserts one entry per
+// name, and saves it back. It is a no-op when names is empty so callers can
+// pass in a list of successfully-installed skills without guarding the call.
+func recordInstalledSkills(configDir string, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	cfg, err := project.Load(configDir)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	for _, name := range names {
+		cfg.UpsertSkill(project.SkillEntry{
+			Name:        name,
+			Source:      DefaultSource,
+			InstalledAt: time.Now().UTC(),
+		})
+	}
+	if err := project.Save(configDir, cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	return nil
+}
+
 // validateSkillAddArgs enforces that exactly one of {positional name, --all}
 // is provided. Called from skillAddCmd.Args.
 func validateSkillAddArgs(cmd *cobra.Command, args []string) error {
@@ -138,11 +175,6 @@ destination non-interactively (project or user).`,
 		all, _ := cmd.Flags().GetBool("all")
 		levelFlag, _ := cmd.Flags().GetString("level")
 
-		// Validate --level early, before any network / filesystem work.
-		if levelFlag != "" && levelFlag != "project" && levelFlag != "user" {
-			return fmt.Errorf("invalid --level value %q: must be 'project' or 'user'", levelFlag)
-		}
-
 		var reader *bufio.Reader
 		if term.IsTerminal(int(os.Stdin.Fd())) {
 			reader = bufio.NewReader(os.Stdin)
@@ -151,7 +183,6 @@ destination non-interactively (project or user).`,
 		if all {
 			return runBulkInstall(dir, levelFlag, reader)
 		}
-
 		return runSingleInstall(dir, args[0], levelFlag, reader)
 	},
 }
@@ -167,7 +198,7 @@ func runSingleInstall(dir, arg, levelFlag string, reader *bufio.Reader) error {
 	}
 
 	fmt.Printf("Fetching skill %q...\n", name)
-	files, err := FetchSkill(defaultOwner, defaultRepo, name, ref)
+	files, err := fetchSkillFn(defaultOwner, defaultRepo, name, ref)
 	if err != nil {
 		return fmt.Errorf("fetching skill: %w", err)
 	}
@@ -179,30 +210,16 @@ func runSingleInstall(dir, arg, levelFlag string, reader *bufio.Reader) error {
 	if err != nil {
 		return err
 	}
-
 	if err := InstallSkill(baseDir, name, files); err != nil {
 		return fmt.Errorf("installing skill: %w", err)
 	}
 
-	configDir := dir
-	if userLevel {
-		ud, err := userConfigDirFn()
-		if err != nil {
-			return fmt.Errorf("resolving user config dir: %w", err)
-		}
-		configDir = ud
-	}
-	cfg, err := project.Load(configDir)
+	configDir, err := configDirForLevel(dir, userLevel)
 	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
+		return err
 	}
-	cfg.UpsertSkill(project.SkillEntry{
-		Name:        name,
-		Source:      DefaultSource,
-		InstalledAt: time.Now().UTC(),
-	})
-	if err := project.Save(configDir, cfg); err != nil {
-		return fmt.Errorf("saving config: %w", err)
+	if err := recordInstalledSkills(configDir, []string{name}); err != nil {
+		return err
 	}
 
 	displayPath := filepath.Join(baseDir, name) + "/"
@@ -210,12 +227,27 @@ func runSingleInstall(dir, arg, levelFlag string, reader *bufio.Reader) error {
 	return nil
 }
 
+// installCatalogEntry fetches and installs one catalog entry into baseDir.
+// Returns nil on success or a wrapped error describing the phase that failed.
+func installCatalogEntry(baseDir, name string) error {
+	files, err := fetchSkillFn(defaultOwner, defaultRepo, name, defaultRef)
+	if err != nil {
+		return fmt.Errorf("fetching: %w", err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("not found in catalog")
+	}
+	if err := InstallSkill(baseDir, name, files); err != nil {
+		return fmt.Errorf("installing: %w", err)
+	}
+	return nil
+}
+
 // runBulkInstall installs every skill in the catalog at the resolved level.
 // Individual failures do not abort the batch; a summary is printed at the end
 // and a non-nil error is returned if any skill failed.
 func runBulkInstall(dir, levelFlag string, reader *bufio.Reader) error {
-	ctx := context.Background()
-	catalog, err := fetchCatalogFn(ctx, defaultOwner, defaultRepo, defaultRef)
+	catalog, err := fetchCatalogFn(context.Background(), defaultOwner, defaultRepo, defaultRef)
 	if err != nil {
 		return fmt.Errorf("fetching skill catalog: %w", err)
 	}
@@ -227,71 +259,41 @@ func runBulkInstall(dir, levelFlag string, reader *bufio.Reader) error {
 	if err != nil {
 		return err
 	}
-
-	configDir := dir
-	if userLevel {
-		ud, err := userConfigDirFn()
-		if err != nil {
-			return fmt.Errorf("resolving user config dir: %w", err)
-		}
-		configDir = ud
-	}
-	cfg, err := project.Load(configDir)
+	configDir, err := configDirForLevel(dir, userLevel)
 	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
+		return err
 	}
 
-	type failure struct {
+	type failedSkill struct {
 		name string
 		err  error
 	}
-	var failures []failure
-	installed := 0
+	var failed []failedSkill
+	var installed []string
 
 	fmt.Printf("Installing %d skills into %s/...\n", len(catalog), baseDir)
 	for _, entry := range catalog {
-		name := entry.Name
-		fmt.Printf("  • %s ... ", name)
-		files, ferr := fetchSkillFn(defaultOwner, defaultRepo, name, defaultRef)
-		if ferr != nil {
+		fmt.Printf("  • %s ... ", entry.Name)
+		if err := installCatalogEntry(baseDir, entry.Name); err != nil {
 			fmt.Println("FAIL")
-			failures = append(failures, failure{name, fmt.Errorf("fetching: %w", ferr)})
+			failed = append(failed, failedSkill{entry.Name, err})
 			continue
 		}
-		if len(files) == 0 {
-			fmt.Println("FAIL")
-			failures = append(failures, failure{name, fmt.Errorf("not found in catalog")})
-			continue
-		}
-		if ierr := InstallSkill(baseDir, name, files); ierr != nil {
-			fmt.Println("FAIL")
-			failures = append(failures, failure{name, fmt.Errorf("installing: %w", ierr)})
-			continue
-		}
-		cfg.UpsertSkill(project.SkillEntry{
-			Name:        name,
-			Source:      DefaultSource,
-			InstalledAt: time.Now().UTC(),
-		})
-		installed++
+		installed = append(installed, entry.Name)
 		fmt.Println("ok")
 	}
 
-	// Persist config once at the end (even on partial failure so successful
-	// installs are recorded).
-	if installed > 0 {
-		if serr := project.Save(configDir, cfg); serr != nil {
-			return fmt.Errorf("saving config: %w", serr)
-		}
+	if err := recordInstalledSkills(configDir, installed); err != nil {
+		return err
 	}
 
-	fmt.Printf("\nInstalled %d/%d skills into %s/\n", installed, len(catalog), baseDir)
-	if len(failures) > 0 {
+	fmt.Printf("\nInstalled %d/%d skills into %s/\n", len(installed), len(catalog), baseDir)
+	if len(failed) > 0 {
 		fmt.Println("Failed:")
-		for _, f := range failures {
+		for _, f := range failed {
 			fmt.Printf("  - %s: %v\n", f.name, f.err)
 		}
-		return fmt.Errorf("%d skill(s) failed to install", len(failures))
+		return fmt.Errorf("%d skill(s) failed to install", len(failed))
 	}
 	return nil
 }

--- a/internal/skillmgr/commands.go
+++ b/internal/skillmgr/commands.go
@@ -143,7 +143,8 @@ func recordInstalledSkills(configDir string, names []string) error {
 }
 
 // validateSkillAddArgs enforces that exactly one of {positional name, --all}
-// is provided. Called from skillAddCmd.Args.
+// is provided and that --level (if set) is a known value. Called from
+// skillAddCmd.Args so errors fire before any network or filesystem work.
 func validateSkillAddArgs(cmd *cobra.Command, args []string) error {
 	all, _ := cmd.Flags().GetBool("all")
 	switch {
@@ -153,6 +154,10 @@ func validateSkillAddArgs(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("skill name is required (or use --all to install the entire catalog)")
 	case !all && len(args) > 1:
 		return fmt.Errorf("skill add accepts exactly one skill name")
+	}
+	levelFlag, _ := cmd.Flags().GetString("level")
+	if levelFlag != "" && levelFlag != "project" && levelFlag != "user" {
+		return fmt.Errorf("invalid --level value %q: must be 'project' or 'user'", levelFlag)
 	}
 	return nil
 }

--- a/internal/skillmgr/commands.go
+++ b/internal/skillmgr/commands.go
@@ -20,6 +20,11 @@ var fetchCatalogFn = func(ctx context.Context, owner, repo, ref string) ([]Catal
 	return FetchCatalog(ctx, owner, repo, ref)
 }
 
+// Override in tests to avoid hitting GitHub.
+var fetchSkillFn = func(owner, repo, name, ref string) ([]SkillFile, error) {
+	return FetchSkill(owner, repo, name, ref)
+}
+
 // descriptionLimit is the max length for skill descriptions in list output.
 const descriptionLimit = 40
 
@@ -79,73 +84,216 @@ func promptInstallLevel(projectDir string, reader *bufio.Reader) (baseDir string
 	return projectBase, false
 }
 
+// resolveInstallLevel applies precedence: --level flag > interactive prompt
+// (if reader != nil) > project-level default.
+// levelFlag must be "", "project", or "user"; any other value is an error.
+func resolveInstallLevel(levelFlag, projectDir string, reader *bufio.Reader) (baseDir string, userLevel bool, err error) {
+	switch levelFlag {
+	case "project":
+		return filepath.Join(projectDir, InstallDir), false, nil
+	case "user":
+		userDir, derr := UserSkillDir()
+		if derr != nil {
+			return "", false, derr
+		}
+		return userDir, true, nil
+	case "":
+		base, ul := promptInstallLevel(projectDir, reader)
+		return base, ul, nil
+	default:
+		return "", false, fmt.Errorf("invalid --level value %q: must be 'project' or 'user'", levelFlag)
+	}
+}
+
+// validateSkillAddArgs enforces that exactly one of {positional name, --all}
+// is provided. Called from skillAddCmd.Args.
+func validateSkillAddArgs(cmd *cobra.Command, args []string) error {
+	all, _ := cmd.Flags().GetBool("all")
+	switch {
+	case all && len(args) > 0:
+		return fmt.Errorf("cannot combine --all with a skill name")
+	case !all && len(args) == 0:
+		return fmt.Errorf("skill name is required (or use --all to install the entire catalog)")
+	case !all && len(args) > 1:
+		return fmt.Errorf("skill add accepts exactly one skill name")
+	}
+	return nil
+}
+
 var skillAddCmd = &cobra.Command{
-	Use:   "add <name[@ref]>",
+	Use:   "add [name[@ref]]",
 	Short: "Install a skill from the devpilot catalog",
-	Args:  cobra.ExactArgs(1),
+	Long: `Install a skill from the devpilot catalog.
+
+Use a positional argument to install a single named skill, or pass --all to
+install every skill in the catalog. Use --level to pick the install
+destination non-interactively (project or user).`,
+	Args: validateSkillAddArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dir, err := os.Getwd()
 		if err != nil {
 			return err
 		}
 
-		name, ref, err := parseSkillArg(args[0])
-		if err != nil {
-			return err
+		all, _ := cmd.Flags().GetBool("all")
+		levelFlag, _ := cmd.Flags().GetString("level")
+
+		// Validate --level early, before any network / filesystem work.
+		if levelFlag != "" && levelFlag != "project" && levelFlag != "user" {
+			return fmt.Errorf("invalid --level value %q: must be 'project' or 'user'", levelFlag)
 		}
 
-		if ref == "" {
-			ref = defaultRef
-		}
-
-		fmt.Printf("Fetching skill %q...\n", name)
-		files, err := FetchSkill(defaultOwner, defaultRepo, name, ref)
-		if err != nil {
-			return fmt.Errorf("fetching skill: %w", err)
-		}
-		if len(files) == 0 {
-			return fmt.Errorf("skill %q not found in devpilot catalog", name)
-		}
-
-		// Prompt for install level (project vs user) when running interactively.
 		var reader *bufio.Reader
 		if term.IsTerminal(int(os.Stdin.Fd())) {
 			reader = bufio.NewReader(os.Stdin)
 		}
-		baseDir, userLevel := promptInstallLevel(dir, reader)
 
-		if err := InstallSkill(baseDir, name, files); err != nil {
-			return fmt.Errorf("installing skill: %w", err)
+		if all {
+			return runBulkInstall(dir, levelFlag, reader)
 		}
 
-		configDir := dir
-		if userLevel {
-			ud, err := userConfigDirFn()
-			if err != nil {
-				return fmt.Errorf("resolving user config dir: %w", err)
-			}
-			configDir = ud
-		}
-		cfg, err := project.Load(configDir)
+		return runSingleInstall(dir, args[0], levelFlag, reader)
+	},
+}
+
+// runSingleInstall installs one skill (the existing default behavior).
+func runSingleInstall(dir, arg, levelFlag string, reader *bufio.Reader) error {
+	name, ref, err := parseSkillArg(arg)
+	if err != nil {
+		return err
+	}
+	if ref == "" {
+		ref = defaultRef
+	}
+
+	fmt.Printf("Fetching skill %q...\n", name)
+	files, err := FetchSkill(defaultOwner, defaultRepo, name, ref)
+	if err != nil {
+		return fmt.Errorf("fetching skill: %w", err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("skill %q not found in devpilot catalog", name)
+	}
+
+	baseDir, userLevel, err := resolveInstallLevel(levelFlag, dir, reader)
+	if err != nil {
+		return err
+	}
+
+	if err := InstallSkill(baseDir, name, files); err != nil {
+		return fmt.Errorf("installing skill: %w", err)
+	}
+
+	configDir := dir
+	if userLevel {
+		ud, err := userConfigDirFn()
 		if err != nil {
-			return fmt.Errorf("loading config: %w", err)
+			return fmt.Errorf("resolving user config dir: %w", err)
+		}
+		configDir = ud
+	}
+	cfg, err := project.Load(configDir)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	cfg.UpsertSkill(project.SkillEntry{
+		Name:        name,
+		Source:      DefaultSource,
+		InstalledAt: time.Now().UTC(),
+	})
+	if err := project.Save(configDir, cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+
+	displayPath := filepath.Join(baseDir, name) + "/"
+	fmt.Printf("Installed skill %q into %s\n", name, displayPath)
+	return nil
+}
+
+// runBulkInstall installs every skill in the catalog at the resolved level.
+// Individual failures do not abort the batch; a summary is printed at the end
+// and a non-nil error is returned if any skill failed.
+func runBulkInstall(dir, levelFlag string, reader *bufio.Reader) error {
+	ctx := context.Background()
+	catalog, err := fetchCatalogFn(ctx, defaultOwner, defaultRepo, defaultRef)
+	if err != nil {
+		return fmt.Errorf("fetching skill catalog: %w", err)
+	}
+	if len(catalog) == 0 {
+		return fmt.Errorf("skill catalog is empty")
+	}
+
+	baseDir, userLevel, err := resolveInstallLevel(levelFlag, dir, reader)
+	if err != nil {
+		return err
+	}
+
+	configDir := dir
+	if userLevel {
+		ud, err := userConfigDirFn()
+		if err != nil {
+			return fmt.Errorf("resolving user config dir: %w", err)
+		}
+		configDir = ud
+	}
+	cfg, err := project.Load(configDir)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	type failure struct {
+		name string
+		err  error
+	}
+	var failures []failure
+	installed := 0
+
+	fmt.Printf("Installing %d skills into %s/...\n", len(catalog), baseDir)
+	for _, entry := range catalog {
+		name := entry.Name
+		fmt.Printf("  • %s ... ", name)
+		files, ferr := fetchSkillFn(defaultOwner, defaultRepo, name, defaultRef)
+		if ferr != nil {
+			fmt.Println("FAIL")
+			failures = append(failures, failure{name, fmt.Errorf("fetching: %w", ferr)})
+			continue
+		}
+		if len(files) == 0 {
+			fmt.Println("FAIL")
+			failures = append(failures, failure{name, fmt.Errorf("not found in catalog")})
+			continue
+		}
+		if ierr := InstallSkill(baseDir, name, files); ierr != nil {
+			fmt.Println("FAIL")
+			failures = append(failures, failure{name, fmt.Errorf("installing: %w", ierr)})
+			continue
 		}
 		cfg.UpsertSkill(project.SkillEntry{
 			Name:        name,
 			Source:      DefaultSource,
 			InstalledAt: time.Now().UTC(),
 		})
-		if err := project.Save(configDir, cfg); err != nil {
-			return fmt.Errorf("saving config: %w", err)
-		}
+		installed++
+		fmt.Println("ok")
+	}
 
-		displayPath := InstallDir + "/" + name + "/"
-		if userLevel {
-			displayPath = baseDir + "/" + name + "/"
+	// Persist config once at the end (even on partial failure so successful
+	// installs are recorded).
+	if installed > 0 {
+		if serr := project.Save(configDir, cfg); serr != nil {
+			return fmt.Errorf("saving config: %w", serr)
 		}
-		fmt.Printf("Installed skill %q into %s\n", name, displayPath)
-		return nil
-	},
+	}
+
+	fmt.Printf("\nInstalled %d/%d skills into %s/\n", installed, len(catalog), baseDir)
+	if len(failures) > 0 {
+		fmt.Println("Failed:")
+		for _, f := range failures {
+			fmt.Printf("  - %s: %v\n", f.name, f.err)
+		}
+		return fmt.Errorf("%d skill(s) failed to install", len(failures))
+	}
+	return nil
 }
 
 type skillWithLevel struct {
@@ -164,6 +312,8 @@ func truncateDescription(s string) string {
 
 func init() {
 	skillListCmd.Flags().BoolP("installed", "i", false, "Show only installed skills")
+	skillAddCmd.Flags().Bool("all", false, "Install every skill in the devpilot catalog")
+	skillAddCmd.Flags().String("level", "", "Install level: 'project' or 'user' (bypasses interactive prompt)")
 }
 
 var skillListCmd = &cobra.Command{

--- a/internal/skillmgr/commands_test.go
+++ b/internal/skillmgr/commands_test.go
@@ -394,21 +394,30 @@ func TestValidateSkillAddArgs(t *testing.T) {
 	tests := []struct {
 		name    string
 		all     bool
+		level   string
 		args    []string
 		wantErr bool
 	}{
-		{name: "single name no flag", all: false, args: []string{"pm"}, wantErr: false},
+		{name: "single name no flag", args: []string{"pm"}, wantErr: false},
 		{name: "all flag no args", all: true, args: []string{}, wantErr: false},
-		{name: "no args no flag", all: false, args: []string{}, wantErr: true},
+		{name: "no args no flag", args: []string{}, wantErr: true},
 		{name: "all flag with name", all: true, args: []string{"pm"}, wantErr: true},
-		{name: "two positional args", all: false, args: []string{"pm", "trello"}, wantErr: true},
+		{name: "two positional args", args: []string{"pm", "trello"}, wantErr: true},
+		{name: "single with --level project", level: "project", args: []string{"pm"}, wantErr: false},
+		{name: "single with --level user", level: "user", args: []string{"pm"}, wantErr: false},
+		{name: "single with invalid --level", level: "system", args: []string{"pm"}, wantErr: true},
+		{name: "all with invalid --level", all: true, level: "system", args: []string{}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{}
 			cmd.Flags().Bool("all", false, "")
+			cmd.Flags().String("level", "", "")
 			if tt.all {
 				_ = cmd.Flags().Set("all", "true")
+			}
+			if tt.level != "" {
+				_ = cmd.Flags().Set("level", tt.level)
 			}
 			err := validateSkillAddArgs(cmd, tt.args)
 			if tt.wantErr && err == nil {
@@ -416,6 +425,60 @@ func TestValidateSkillAddArgs(t *testing.T) {
 			}
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestSkillAddInvalidLevelNoNetwork ensures an invalid --level value fails at
+// Args-validation time, before any catalog or skill fetch runs.
+func TestSkillAddInvalidLevelNoNetwork(t *testing.T) {
+	stubUserConfigDir(t)
+	t.Chdir(t.TempDir())
+
+	catalogCalls := 0
+	fetchCalls := 0
+	origCat := fetchCatalogFn
+	origFetch := fetchSkillFn
+	fetchCatalogFn = func(_ context.Context, _, _, _ string) ([]CatalogEntry, error) {
+		catalogCalls++
+		return nil, nil
+	}
+	fetchSkillFn = func(_, _, _, _ string) ([]SkillFile, error) {
+		fetchCalls++
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		fetchCatalogFn = origCat
+		fetchSkillFn = origFetch
+	})
+
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"single with invalid level", []string{"pm", "--level", "system"}},
+		{"all with invalid level", []string{"--all", "--level", "system"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			catalogCalls, fetchCalls = 0, 0
+			// Reset flags to their zero values between sub-tests.
+			_ = skillAddCmd.Flags().Set("all", "false")
+			_ = skillAddCmd.Flags().Set("level", "")
+			skillAddCmd.SetArgs(tc.argv)
+			err := skillAddCmd.Execute()
+			if err == nil {
+				t.Fatal("expected error for invalid --level")
+			}
+			if !strings.Contains(err.Error(), "invalid --level") {
+				t.Errorf("error should mention invalid --level, got: %v", err)
+			}
+			if catalogCalls != 0 {
+				t.Errorf("fetchCatalogFn was called %d times, want 0", catalogCalls)
+			}
+			if fetchCalls != 0 {
+				t.Errorf("fetchSkillFn was called %d times, want 0", fetchCalls)
 			}
 		})
 	}

--- a/internal/skillmgr/commands_test.go
+++ b/internal/skillmgr/commands_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/siyuqian/devpilot/internal/project"
+	"github.com/spf13/cobra"
 )
 
 func TestParseSkillArg(t *testing.T) {
@@ -386,6 +387,255 @@ func TestSkillListTruncateDescription(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("truncateDescription(%q) = %q, want %q", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestValidateSkillAddArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		all     bool
+		args    []string
+		wantErr bool
+	}{
+		{name: "single name no flag", all: false, args: []string{"pm"}, wantErr: false},
+		{name: "all flag no args", all: true, args: []string{}, wantErr: false},
+		{name: "no args no flag", all: false, args: []string{}, wantErr: true},
+		{name: "all flag with name", all: true, args: []string{"pm"}, wantErr: true},
+		{name: "two positional args", all: false, args: []string{"pm", "trello"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool("all", false, "")
+			if tt.all {
+				_ = cmd.Flags().Set("all", "true")
+			}
+			err := validateSkillAddArgs(cmd, tt.args)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveInstallLevel(t *testing.T) {
+	projectDir := t.TempDir()
+	userHome := t.TempDir()
+	t.Setenv("HOME", userHome)
+	expectedUser := filepath.Join(userHome, ".claude", "skills")
+	expectedProject := filepath.Join(projectDir, InstallDir)
+
+	t.Run("flag project overrides TTY prompt", func(t *testing.T) {
+		reader := bufio.NewReader(strings.NewReader("2\n")) // would select user if prompted
+		base, userLevel, err := resolveInstallLevel("project", projectDir, reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if base != expectedProject {
+			t.Errorf("base = %q, want %q", base, expectedProject)
+		}
+		if userLevel {
+			t.Error("userLevel = true, want false")
+		}
+	})
+
+	t.Run("flag user overrides default", func(t *testing.T) {
+		base, userLevel, err := resolveInstallLevel("user", projectDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if base != expectedUser {
+			t.Errorf("base = %q, want %q", base, expectedUser)
+		}
+		if !userLevel {
+			t.Error("userLevel = false, want true")
+		}
+	})
+
+	t.Run("empty flag with TTY prompts", func(t *testing.T) {
+		reader := bufio.NewReader(strings.NewReader("2\n"))
+		base, userLevel, err := resolveInstallLevel("", projectDir, reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !userLevel {
+			t.Error("userLevel = false, want true (from prompt)")
+		}
+		if base != expectedUser {
+			t.Errorf("base = %q, want %q", base, expectedUser)
+		}
+	})
+
+	t.Run("empty flag no TTY defaults to project", func(t *testing.T) {
+		base, userLevel, err := resolveInstallLevel("", projectDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if userLevel {
+			t.Error("userLevel = true, want false")
+		}
+		if base != expectedProject {
+			t.Errorf("base = %q, want %q", base, expectedProject)
+		}
+	})
+
+	t.Run("invalid flag value errors", func(t *testing.T) {
+		_, _, err := resolveInstallLevel("system", projectDir, nil)
+		if err == nil {
+			t.Error("expected error for invalid --level value")
+		}
+	})
+}
+
+// stubFetchSkillFn overrides fetchSkillFn for bulk install tests.
+// The provided map keys skill names to the files returned for that skill;
+// a skill name in failing returns an error instead.
+func stubFetchSkillFn(t *testing.T, files map[string][]SkillFile, failing map[string]error) {
+	t.Helper()
+	orig := fetchSkillFn
+	fetchSkillFn = func(_, _, name, _ string) ([]SkillFile, error) {
+		if err, ok := failing[name]; ok {
+			return nil, err
+		}
+		if f, ok := files[name]; ok {
+			return f, nil
+		}
+		return nil, fmt.Errorf("unknown skill %q", name)
+	}
+	t.Cleanup(func() { fetchSkillFn = orig })
+}
+
+func TestRunBulkInstallProjectLevel(t *testing.T) {
+	dir := t.TempDir()
+
+	stubCatalogFns(t, []CatalogEntry{
+		{Name: "pm", Description: "pm"},
+		{Name: "trello", Description: "trello"},
+	}, nil)
+	stubFetchSkillFn(t, map[string][]SkillFile{
+		"pm":     {{Path: "SKILL.md", Content: []byte("pm skill")}},
+		"trello": {{Path: "SKILL.md", Content: []byte("trello skill")}},
+	}, nil)
+
+	err := runBulkInstall(dir, "project", nil)
+	if err != nil {
+		t.Fatalf("runBulkInstall: %v", err)
+	}
+
+	// Both skills should exist on disk.
+	for _, name := range []string{"pm", "trello"} {
+		p := filepath.Join(dir, InstallDir, name, "SKILL.md")
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected %s, got err: %v", p, err)
+		}
+	}
+
+	// Config should record both.
+	cfg, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Skills) != 2 {
+		t.Errorf("len(Skills) = %d, want 2", len(cfg.Skills))
+	}
+}
+
+func TestRunBulkInstallPartialFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	stubCatalogFns(t, []CatalogEntry{
+		{Name: "pm"},
+		{Name: "broken"},
+		{Name: "trello"},
+	}, nil)
+	stubFetchSkillFn(t,
+		map[string][]SkillFile{
+			"pm":     {{Path: "SKILL.md", Content: []byte("pm")}},
+			"trello": {{Path: "SKILL.md", Content: []byte("trello")}},
+		},
+		map[string]error{
+			"broken": fmt.Errorf("404 not found"),
+		},
+	)
+
+	err := runBulkInstall(dir, "project", nil)
+	if err == nil {
+		t.Fatal("expected non-nil error on partial failure")
+	}
+	if !strings.Contains(err.Error(), "1 skill") {
+		t.Errorf("error should mention failure count, got: %v", err)
+	}
+
+	// Successful skills should still be installed and recorded.
+	cfg, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Skills) != 2 {
+		t.Errorf("len(Skills) = %d, want 2 (pm + trello)", len(cfg.Skills))
+	}
+	if _, err := os.Stat(filepath.Join(dir, InstallDir, "broken", "SKILL.md")); err == nil {
+		t.Error("broken skill should not have been installed")
+	}
+}
+
+func TestRunBulkInstallUserLevel(t *testing.T) {
+	userCfgDir := stubUserConfigDir(t)
+	t.Setenv("HOME", userCfgDir) // so UserSkillDir returns <userCfgDir>/.claude/skills
+
+	dir := t.TempDir()
+
+	stubCatalogFns(t, []CatalogEntry{
+		{Name: "pm"},
+	}, nil)
+	stubFetchSkillFn(t, map[string][]SkillFile{
+		"pm": {{Path: "SKILL.md", Content: []byte("pm")}},
+	}, nil)
+
+	if err := runBulkInstall(dir, "user", nil); err != nil {
+		t.Fatalf("runBulkInstall: %v", err)
+	}
+
+	// Skill should be installed under userCfgDir/.claude/skills, NOT the project dir.
+	userSkill := filepath.Join(userCfgDir, ".claude", "skills", "pm", "SKILL.md")
+	if _, err := os.Stat(userSkill); err != nil {
+		t.Errorf("expected %s, got err: %v", userSkill, err)
+	}
+	projectSkill := filepath.Join(dir, InstallDir, "pm")
+	if _, err := os.Stat(projectSkill); err == nil {
+		t.Error("skill should not be installed at project level when --level user is set")
+	}
+
+	// Config should be written to user config dir, not project.
+	userCfg, err := project.Load(userCfgDir)
+	if err != nil {
+		t.Fatalf("Load user cfg: %v", err)
+	}
+	if len(userCfg.Skills) != 1 {
+		t.Errorf("user cfg Skills = %d, want 1", len(userCfg.Skills))
+	}
+	projCfg, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("Load project cfg: %v", err)
+	}
+	if len(projCfg.Skills) != 0 {
+		t.Errorf("project cfg should be empty, got %d skills", len(projCfg.Skills))
+	}
+}
+
+func TestRunBulkInstallCatalogFetchFails(t *testing.T) {
+	dir := t.TempDir()
+	stubCatalogFns(t, nil, fmt.Errorf("network error"))
+
+	err := runBulkInstall(dir, "project", nil)
+	if err == nil {
+		t.Fatal("expected error when catalog fetch fails")
+	}
+	if !strings.Contains(err.Error(), "catalog") {
+		t.Errorf("error should mention catalog, got: %v", err)
 	}
 }
 

--- a/internal/skillmgr/commands_test.go
+++ b/internal/skillmgr/commands_test.go
@@ -508,17 +508,24 @@ func stubFetchSkillFn(t *testing.T, files map[string][]SkillFile, failing map[st
 	t.Cleanup(func() { fetchSkillFn = orig })
 }
 
+// setupBulkStubs installs catalog + fetch-skill stubs in one call. Each name
+// in names becomes a catalog entry AND gets a minimal SKILL.md file unless
+// listed in failing, in which case fetching it returns the given error.
+func setupBulkStubs(t *testing.T, names []string, failing map[string]error) {
+	t.Helper()
+	catalog := make([]CatalogEntry, 0, len(names))
+	files := make(map[string][]SkillFile, len(names))
+	for _, name := range names {
+		catalog = append(catalog, CatalogEntry{Name: name})
+		files[name] = []SkillFile{{Path: "SKILL.md", Content: []byte(name)}}
+	}
+	stubCatalogFns(t, catalog, nil)
+	stubFetchSkillFn(t, files, failing)
+}
+
 func TestRunBulkInstallProjectLevel(t *testing.T) {
 	dir := t.TempDir()
-
-	stubCatalogFns(t, []CatalogEntry{
-		{Name: "pm", Description: "pm"},
-		{Name: "trello", Description: "trello"},
-	}, nil)
-	stubFetchSkillFn(t, map[string][]SkillFile{
-		"pm":     {{Path: "SKILL.md", Content: []byte("pm skill")}},
-		"trello": {{Path: "SKILL.md", Content: []byte("trello skill")}},
-	}, nil)
+	setupBulkStubs(t, []string{"pm", "trello"}, nil)
 
 	err := runBulkInstall(dir, "project", nil)
 	if err != nil {
@@ -545,20 +552,9 @@ func TestRunBulkInstallProjectLevel(t *testing.T) {
 
 func TestRunBulkInstallPartialFailure(t *testing.T) {
 	dir := t.TempDir()
-
-	stubCatalogFns(t, []CatalogEntry{
-		{Name: "pm"},
-		{Name: "broken"},
-		{Name: "trello"},
-	}, nil)
-	stubFetchSkillFn(t,
-		map[string][]SkillFile{
-			"pm":     {{Path: "SKILL.md", Content: []byte("pm")}},
-			"trello": {{Path: "SKILL.md", Content: []byte("trello")}},
-		},
-		map[string]error{
-			"broken": fmt.Errorf("404 not found"),
-		},
+	setupBulkStubs(t,
+		[]string{"pm", "broken", "trello"},
+		map[string]error{"broken": fmt.Errorf("404 not found")},
 	)
 
 	err := runBulkInstall(dir, "project", nil)
@@ -587,13 +583,7 @@ func TestRunBulkInstallUserLevel(t *testing.T) {
 	t.Setenv("HOME", userCfgDir) // so UserSkillDir returns <userCfgDir>/.claude/skills
 
 	dir := t.TempDir()
-
-	stubCatalogFns(t, []CatalogEntry{
-		{Name: "pm"},
-	}, nil)
-	stubFetchSkillFn(t, map[string][]SkillFile{
-		"pm": {{Path: "SKILL.md", Content: []byte("pm")}},
-	}, nil)
+	setupBulkStubs(t, []string{"pm"}, nil)
 
 	if err := runBulkInstall(dir, "user", nil); err != nil {
 		t.Fatalf("runBulkInstall: %v", err)

--- a/openspec/changes/archive/2026-04-11-skill-add-all-flag/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-11-skill-add-all-flag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/openspec/changes/archive/2026-04-11-skill-add-all-flag/design.md
+++ b/openspec/changes/archive/2026-04-11-skill-add-all-flag/design.md
@@ -1,0 +1,59 @@
+## Context
+
+Today `devpilot skill add` installs exactly one skill per invocation, identified by a required positional argument, and interactively prompts the user to pick install level (project vs user). For first-time setup and for scripted/CI usage this is awkward: users repeat the command 13+ times, and non-TTY callers can't choose user level at all (the prompt is skipped and project is forced).
+
+The skill catalog is already fetched once by `FetchCatalog` (used by `skill list`). Reusing that fetch for bulk install is straightforward — the remaining work is argument parsing, flag handling, and a batch install loop with error aggregation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single-command install of the entire catalog via `devpilot skill add --all`.
+- Non-interactive level selection via `devpilot skill add --level project|user`.
+- Preserve current default behavior: `devpilot skill add <name>` with no flags still prompts interactively in a TTY and defaults to project.
+- Batch install is resilient: a single failing skill does not abort the remaining installs.
+
+**Non-Goals:**
+- No `--all` pinned to a ref per skill — `--all` uses the default ref (`main`). Per-skill `@ref` syntax is not supported with `--all`.
+- No uninstall / remove-all command.
+- No parallel downloads; sequential is fine for ~13 skills.
+- No change to catalog format, fetch layer, or `project` config schema.
+
+## Decisions
+
+### 1. Flag shape: `--all` plus `--level`, not a separate subcommand
+Alternatives considered: a `devpilot skill add-all` subcommand, or an `--install-all` flag on `skill list`. Keeping everything under `skill add` matches user intuition ("I want to add skills") and reuses the existing install pipeline. `--level` is orthogonal and works with both single and bulk mode.
+
+### 2. Argument validation: custom validator replacing `ExactArgs(1)`
+The current `Args: cobra.ExactArgs(1)` is replaced with a custom function that enforces:
+- `--all` + positional arg → error ("cannot combine --all with a skill name")
+- no `--all` + no positional arg → error ("skill name required, or use --all")
+- `--all` + no positional arg → ok
+- no `--all` + 1 positional arg → ok (existing behavior)
+
+Rationale: Cobra's built-in validators can't express "exactly one of flag-or-arg". A custom validator keeps the logic in one place and produces clear errors.
+
+### 3. Level resolution precedence
+`--level` flag value (if set) > interactive prompt (if TTY) > project default (non-TTY fallback). Accepted values: `project`, `user`. Any other value → error at flag parse time. This replaces the conditional prompt inside `skillAddCmd.RunE` with a single `resolveInstallLevel(flag, reader)` helper that both single and bulk paths call.
+
+### 4. Bulk install: continue-on-error with summary
+Instead of aborting on the first failing skill, `--all` iterates the catalog, installs each skill, collects errors into a slice, and at the end prints:
+
+```
+Installed 11/13 skills into .claude/skills/
+Failed: devpilot-foo (fetching skill: 404), devpilot-bar (writing file: permission denied)
+```
+
+Exit code is 0 if all succeed, non-zero if any failed. Rationale: a transient 404 on one skill shouldn't block the other 12; the user can re-run `skill add <name>` for the failures.
+
+### 5. Catalog fetch reuse
+`--all` calls `fetchCatalogFn(ctx, defaultOwner, defaultRepo, defaultRef)` — the same hook already used by `skill list` and already stubbed in tests. This means bulk install is testable with zero new network mocking.
+
+### 6. Config writes batched per level
+For `--all`, load config once, `UpsertSkill` for each successful install, save once at the end. Avoids 13 read-modify-write cycles on `.devpilot.yaml`.
+
+## Risks / Trade-offs
+
+- **Partial failure leaves config and filesystem in a mixed state** → Mitigation: the summary output names every failed skill so the user can see exactly what needs retrying. Successfully installed skills are still recorded in config, which matches single-install semantics.
+- **Catalog drift between fetch and install** → Not mitigated; catalog is fetched once at the start of `--all`. Acceptable since the catalog changes rarely and any drift affects only one invocation.
+- **`--level user` with no `~/.config/devpilot/` yet** → `project.Save` auto-creates it (already true for single install); no new code path.
+- **User passes `--level` with invalid value** → Cobra validates at parse time via a custom `cobra.Command.PreRunE` check or a string-enum pattern; emit a clear "must be 'project' or 'user'" error.

--- a/openspec/changes/archive/2026-04-11-skill-add-all-flag/proposal.md
+++ b/openspec/changes/archive/2026-04-11-skill-add-all-flag/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Users who want to try DevPilot often want to install the entire skill catalog at once rather than running `devpilot skill add <name>` 13+ times. Additionally, automation and scripting need a non-interactive way to pick the install level (project vs user) instead of answering the interactive prompt.
+
+## What Changes
+
+- Add `--all` flag to `devpilot skill add` that installs every skill from the catalog in a single command.
+- Add `--level` flag (values: `project`, `user`) to `devpilot skill add` that bypasses the interactive prompt and selects the install destination non-interactively.
+- Relax `skill add` positional args: `<name>` is required unless `--all` is passed. Passing both `<name>` and `--all` is an error.
+- With `--all`, iterate the catalog and install each skill; continue past individual failures and report a summary (installed / failed counts) at the end.
+- When `--all` is used without `--level` in a non-interactive environment, default to project level (same as today). In an interactive TTY, prompt once for the level and apply it to the whole batch.
+
+## Capabilities
+
+### New Capabilities
+<!-- None - all changes extend existing specs. -->
+
+### Modified Capabilities
+- `skill-add`: Add bulk install mode via `--all` and the argument-validation rules that go with it.
+- `skill-level-selection`: Add non-interactive `--level` flag to select project or user level without prompting, and specify how it interacts with `--all`.
+
+## Impact
+
+- `internal/skillmgr/commands.go` — `skillAddCmd` gains `--all` and `--level` flags; args validation changes from `ExactArgs(1)` to a custom validator.
+- `internal/skillmgr/commands_test.go` — new tests for bulk install, level flag, and arg validation.
+- `CLAUDE.md` — update the CLI command examples for `devpilot skill add`.
+- No changes to the catalog format, network fetch layer, or `project` config package.

--- a/openspec/changes/archive/2026-04-11-skill-add-all-flag/specs/skill-add/spec.md
+++ b/openspec/changes/archive/2026-04-11-skill-add-all-flag/specs/skill-add/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Install all skills in bulk
+The system SHALL provide a `--all` flag on `devpilot skill add` that installs every skill listed in the catalog (`skills/index.json` on the default ref). When `--all` is set, the system SHALL fetch the catalog once, iterate all entries, install each one into the resolved install level, record each successful install in the in-memory config, and persist the config file ONCE at the end of the batch. Individual install failures SHALL NOT abort the batch; the system SHALL collect errors and print a summary indicating how many skills were installed and which ones failed with their error messages. The exit code SHALL be non-zero if any skill failed to install. If the catalog fetch itself fails, the system SHALL abort before attempting any individual install.
+
+#### Scenario: Bulk install at project level
+- **WHEN** user runs `devpilot skill add --all` in a project directory and the level resolves to project
+- **THEN** the system fetches the skill catalog once
+- **AND** installs every catalog skill into `.claude/skills/<name>/`
+- **AND** records every successfully installed skill in the project `.devpilot.yaml` and persists the file once
+- **AND** prints a summary like `Installed N/M skills into .claude/skills/`
+- **AND** exits with code 0 when all installs succeed
+
+#### Scenario: Bulk install at user level
+- **WHEN** user runs `devpilot skill add --all --level user`
+- **THEN** the system installs every catalog skill into `~/.claude/skills/<name>/`
+- **AND** records every successfully installed skill in the user-level `~/.config/devpilot/.devpilot.yaml` (not the project `.devpilot.yaml`) and persists the file once
+- **AND** prints a summary indicating user-level install
+
+#### Scenario: Partial failure continues and reports
+- **WHEN** user runs `devpilot skill add --all` and one or more skills fail to fetch or install
+- **THEN** the system continues installing the remaining skills
+- **AND** prints a summary listing the failed skills and their error messages
+- **AND** still persists successfully installed entries to the config file
+- **AND** exits with a non-zero code
+
+#### Scenario: Catalog fetch fails
+- **WHEN** user runs `devpilot skill add --all` and the catalog (`skills/index.json`) cannot be fetched
+- **THEN** the system returns an error describing the fetch failure
+- **AND** no skill is installed and no config file is modified
+
+### Requirement: Skill name required unless --all is set
+The system SHALL require exactly one positional argument (the skill name) for `devpilot skill add` unless the `--all` flag is set. The system SHALL reject combining a positional skill name with `--all`. When neither `--all` nor a skill name is provided, the system SHALL return a clear error instructing the user to provide a skill name or pass `--all`. Argument validation SHALL happen before any catalog fetch or filesystem work.
+
+#### Scenario: No args and no --all
+- **WHEN** user runs `devpilot skill add` with no arguments and no flags
+- **THEN** the system returns an error stating that a skill name is required, or `--all` may be used to install the full catalog
+- **AND** no catalog fetch or install is performed
+
+#### Scenario: Cannot combine --all with a skill name
+- **WHEN** user runs `devpilot skill add pm --all`
+- **THEN** the system returns an error stating that `--all` cannot be combined with a skill name
+- **AND** no catalog fetch or install is performed
+
+#### Scenario: Single skill still works
+- **WHEN** user runs `devpilot skill add pm`
+- **THEN** the system installs only the `pm` skill (existing behavior is preserved)

--- a/openspec/changes/archive/2026-04-11-skill-add-all-flag/specs/skill-level-selection/spec.md
+++ b/openspec/changes/archive/2026-04-11-skill-add-all-flag/specs/skill-level-selection/spec.md
@@ -1,8 +1,4 @@
-## Purpose
-
-Defines the interactive install level selection prompt for `devpilot skill add`, allowing users to choose between project-level and user-level skill installation.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Interactive install level selection
 When running `devpilot skill add <name>` WITHOUT the `--level` flag, the system SHALL prompt the user to select the install level before fetching the skill. The prompt SHALL display two options: project level (`.claude/skills/`) and user level (`~/.claude/skills/`). The default selection SHALL be project level. When the `--level` flag IS set, the system SHALL NOT display the prompt and SHALL use the flag value as the install destination.
@@ -20,6 +16,8 @@ When running `devpilot skill add <name>` WITHOUT the `--level` flag, the system 
 #### Scenario: Non-interactive environment without --level
 - **WHEN** `devpilot skill add pm` runs with stdin not connected to a TTY and no `--level` flag
 - **THEN** the system SHALL skip the prompt and default to project level
+
+## ADDED Requirements
 
 ### Requirement: Non-interactive level selection via --level flag
 The system SHALL accept a `--level` flag on `devpilot skill add` whose value is either `project` or `user`. When `--level` is set, the system SHALL use its value as the install destination and SHALL NOT display the interactive level prompt, regardless of whether stdin is a TTY. An invalid `--level` value SHALL cause a clear error at argument-parse time before any network or filesystem work is performed. The precedence for level resolution is: `--level` flag (if set) > interactive prompt (if stdin is a TTY) > project-level default.

--- a/openspec/changes/archive/2026-04-11-skill-add-all-flag/tasks.md
+++ b/openspec/changes/archive/2026-04-11-skill-add-all-flag/tasks.md
@@ -1,0 +1,38 @@
+## 1. Flag and argument plumbing
+
+- [x] 1.1 Add `--all` (bool) and `--level` (string) flags to `skillAddCmd` in `internal/skillmgr/commands.go`
+- [x] 1.2 Replace `Args: cobra.ExactArgs(1)` with a custom validator that enforces: name-xor-all, and errors clearly on `skill add` (no args, no --all) and `skill add pm --all`
+- [x] 1.3 Validate `--level` value at PreRunE (accept `project`, `user`, or empty; any other value → error)
+
+## 2. Level resolution helper
+
+- [x] 2.1 Extract a `resolveInstallLevel(levelFlag string, projectDir string, reader *bufio.Reader) (baseDir string, userLevel bool, err error)` helper
+- [x] 2.2 Make it apply the precedence: `--level` flag > interactive prompt (if reader != nil) > project default
+- [x] 2.3 Update single-install path in `skillAddCmd.RunE` to call the new helper
+- [x] 2.4 Keep `promptInstallLevel` as an internal helper used only when `--level` is unset and stdin is a TTY
+
+## 3. Bulk install path
+
+- [x] 3.1 When `--all` is set, call `fetchCatalogFn(ctx, defaultOwner, defaultRepo, defaultRef)` to load the catalog
+- [x] 3.2 Resolve the install level ONCE via `resolveInstallLevel` and reuse it for every skill
+- [x] 3.3 Load the target `.devpilot.yaml` once (project or user config dir)
+- [x] 3.4 Iterate catalog entries: for each, call `FetchSkill` + `InstallSkill` and on success `cfg.UpsertSkill(...)`; on failure append `{name, err}` to a failures slice and continue
+- [x] 3.5 Save the config once at the end
+- [x] 3.6 Print a summary: `Installed N/M skills into <baseDir>` followed by any failed skills with their error messages
+- [x] 3.7 Return a non-nil error (or set a non-zero exit) if any skill failed
+
+## 4. Tests
+
+- [x] 4.1 Unit test: arg validator rejects `skill add` (no args, no --all) and `skill add pm --all`; accepts `skill add pm` and `skill add --all`
+- [x] 4.2 Unit test: `--level` flag parsing rejects invalid values with a clear error
+- [x] 4.3 Unit test: `resolveInstallLevel` precedence (flag > prompt > default)
+- [x] 4.4 Integration test (with `fetchCatalogFn` stub and a temp dir): `skill add --all --level project` installs every stubbed skill and writes all entries to `.devpilot.yaml`
+- [x] 4.5 Integration test: bulk install with one failing skill reports the failure in the summary, installs the others, and exits non-zero
+- [x] 4.6 Integration test: `skill add --all --level user` writes into the user config dir (override `userConfigDirFn` to a tempdir)
+- [x] 4.7 Integration test: `skill add pm --level user` skips the interactive prompt entirely
+
+## 5. Docs
+
+- [x] 5.1 Update the `devpilot skill add` examples in `CLAUDE.md` to include `--all` and `--level`
+- [x] 5.2 Update the `skill add` short/long help text in `commands.go` to mention the new flags
+- [x] 5.3 Run `make lint` and `make test`; ensure both pass

--- a/openspec/specs/skill-add/spec.md
+++ b/openspec/specs/skill-add/spec.md
@@ -51,3 +51,49 @@ The system SHALL NOT require `.devpilot.yaml` to exist before installing a skill
 - **WHEN** user runs `devpilot skill add pm` and selects user level in a directory without `.devpilot.yaml`
 - **THEN** the system proceeds normally and installs the skill at user level
 
+### Requirement: Install all skills in bulk
+The system SHALL provide a `--all` flag on `devpilot skill add` that installs every skill listed in the catalog (`skills/index.json` on the default ref). When `--all` is set, the system SHALL fetch the catalog once, iterate all entries, install each one into the resolved install level, record each successful install in the in-memory config, and persist the config file ONCE at the end of the batch. Individual install failures SHALL NOT abort the batch; the system SHALL collect errors and print a summary indicating how many skills were installed and which ones failed with their error messages. The exit code SHALL be non-zero if any skill failed to install. If the catalog fetch itself fails, the system SHALL abort before attempting any individual install.
+
+#### Scenario: Bulk install at project level
+- **WHEN** user runs `devpilot skill add --all` in a project directory and the level resolves to project
+- **THEN** the system fetches the skill catalog once
+- **AND** installs every catalog skill into `.claude/skills/<name>/`
+- **AND** records every successfully installed skill in the project `.devpilot.yaml` and persists the file once
+- **AND** prints a summary like `Installed N/M skills into .claude/skills/`
+- **AND** exits with code 0 when all installs succeed
+
+#### Scenario: Bulk install at user level
+- **WHEN** user runs `devpilot skill add --all --level user`
+- **THEN** the system installs every catalog skill into `~/.claude/skills/<name>/`
+- **AND** records every successfully installed skill in the user-level `~/.config/devpilot/.devpilot.yaml` (not the project `.devpilot.yaml`) and persists the file once
+- **AND** prints a summary indicating user-level install
+
+#### Scenario: Partial failure continues and reports
+- **WHEN** user runs `devpilot skill add --all` and one or more skills fail to fetch or install
+- **THEN** the system continues installing the remaining skills
+- **AND** prints a summary listing the failed skills and their error messages
+- **AND** still persists successfully installed entries to the config file
+- **AND** exits with a non-zero code
+
+#### Scenario: Catalog fetch fails
+- **WHEN** user runs `devpilot skill add --all` and the catalog (`skills/index.json`) cannot be fetched
+- **THEN** the system returns an error describing the fetch failure
+- **AND** no skill is installed and no config file is modified
+
+### Requirement: Skill name required unless --all is set
+The system SHALL require exactly one positional argument (the skill name) for `devpilot skill add` unless the `--all` flag is set. The system SHALL reject combining a positional skill name with `--all`. When neither `--all` nor a skill name is provided, the system SHALL return a clear error instructing the user to provide a skill name or pass `--all`. Argument validation SHALL happen before any catalog fetch or filesystem work.
+
+#### Scenario: No args and no --all
+- **WHEN** user runs `devpilot skill add` with no arguments and no flags
+- **THEN** the system returns an error stating that a skill name is required, or `--all` may be used to install the full catalog
+- **AND** no catalog fetch or install is performed
+
+#### Scenario: Cannot combine --all with a skill name
+- **WHEN** user runs `devpilot skill add pm --all`
+- **THEN** the system returns an error stating that `--all` cannot be combined with a skill name
+- **AND** no catalog fetch or install is performed
+
+#### Scenario: Single skill still works
+- **WHEN** user runs `devpilot skill add pm`
+- **THEN** the system installs only the `pm` skill (existing behavior is preserved)
+


### PR DESCRIPTION
## Summary

Two new flags for `devpilot skill add`:

- `--all` — bulk install every skill in the catalog in one command
- `--level project|user` — pick install destination non-interactively (bypasses the interactive prompt)

Built under OpenSpec change `skill-add-all-flag` (archived in this PR).

## What changed

**`internal/skillmgr/commands.go`** — the single- and bulk-install paths both read top-to-bottom as `parse → fetch → resolve level → install → record → print`, built from small focused helpers:

- `validateSkillAddArgs` — replaces `cobra.ExactArgs(1)`; enforces exactly one of `{positional name, --all}`
- `resolveInstallLevel(levelFlag, projectDir, reader)` — single source of truth for level selection with precedence `--level` flag > interactive prompt (TTY only) > project-level default; rejects invalid `--level` values
- `configDirForLevel(projectDir, userLevel)` — returns the dir that holds `.devpilot.yaml` for the chosen level (project dir or user config dir)
- `recordInstalledSkills(configDir, names)` — loads / upserts each entry / saves once; no-ops on empty input so the bulk path doesn't need a success-count guard
- `installCatalogEntry(baseDir, name)` — fetches + installs one catalog entry; returns `nil` or a wrapped phase error (`fetching:` / `not found in catalog` / `installing:`)
- `runSingleInstall` and `runBulkInstall` wire these together; bulk collects failures into a slice so a single bad skill doesn't abort the batch, prints a summary, and returns a non-zero error if any skill failed
- `fetchSkillFn` package hook lets tests stub skill downloads without network; both single and bulk paths route through it for consistency

**`internal/skillmgr/commands_test.go`**
- `TestValidateSkillAddArgs` — 5 sub-cases for arg validator (name-xor-all, too many args, etc.)
- `TestResolveInstallLevel` — 5 sub-cases: flag overrides TTY prompt, flag overrides default, empty flag with TTY prompts, empty flag with no TTY defaults to project, invalid flag value errors
- `TestRunBulkInstallProjectLevel` / `TestRunBulkInstallPartialFailure` / `TestRunBulkInstallUserLevel` / `TestRunBulkInstallCatalogFetchFails` — each corresponds 1:1 to a scenario in `openspec/specs/skill-add/spec.md`
- `setupBulkStubs` helper dedupes catalog + fetch stubbing across the bulk tests

**Specs** — main specs `skill-add` and `skill-level-selection` synced from delta. `Interactive install level selection` was modified to condition on absence of `--level`; two new ADDED requirements (`Install all skills in bulk`, `Non-interactive level selection via --level flag`) were synced in.

**Docs** — `CLAUDE.md` command examples updated with `--all` and `--level` usage.

## Review Guide

Start with **`internal/skillmgr/commands.go`**. Read the helpers first, then the two orchestrators:

1. **`resolveInstallLevel`** — the precedence switch. Confirm `"user"` with `reader == nil` still installs at user level (the "non-TTY + `--level user`" spec scenario).
2. **`validateSkillAddArgs`** — confirm the error messages match the spec scenarios ("cannot combine --all with a skill name" / "skill name is required").
3. **`configDirForLevel` + `recordInstalledSkills`** — tiny, shared by both install paths. `recordInstalledSkills` returning early on empty input is how bulk-install-all-failed avoids a pointless save.
4. **`installCatalogEntry`** — the per-skill fetch+install unit; returns a wrapped error so the bulk loop stays flat.
5. **`runSingleInstall`** — thin wrapper over the helpers, preserves the original user-visible order (Fetching... → prompt → Installed ...).
6. **`runBulkInstall`** — loads the catalog, resolves level once, loops over entries calling `installCatalogEntry`, then calls `recordInstalledSkills` once at the end with all successes. Failures are collected into a slice and reported in the summary.

Then skim the tests in `commands_test.go` — each `TestRunBulkInstall*` maps 1:1 to a scenario in the spec.

The OpenSpec change directory (`openspec/changes/archive/2026-04-11-skill-add-all-flag/`) has the full proposal / design / spec deltas / task list if you want the motivation behind each decision. A follow-up refactor commit (`8ec5cb0`) simplified the code after an internal code review; the commit message enumerates what changed.

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — `0 issues`
- [x] `go build ./...` — clean
- [x] Manual: `devpilot skill add --all --level project` in a tempdir, verify all 13 catalog skills install and `.devpilot.yaml` records them
- [x] Manual: `devpilot skill add pm --level user`, verify no prompt and install lands under `~/.claude/skills/pm/`
- [x] Manual: `devpilot skill add pm --all` exits with arg-validation error

## Known follow-ups (out of scope)

- `FetchSkill` in `internal/skillmgr/github.go` re-downloads `index.json` on every call, so bulk install is N+1 on that endpoint. Worth fixing in a separate PR.
- Bulk install is sequential; could use `errgroup` with a small concurrency bound, but that changes output ordering.