### PR TITLE
style(project): align with Google Go style guide

### DIFF
--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -1,3 +1,4 @@
+// Package project provides project-level configuration stored in .devpilot.yaml.
 package project
 
 import (
@@ -80,11 +81,11 @@ func Load(dir string) (*Config, error) {
 		if os.IsNotExist(err) {
 			return &Config{}, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("reading %s: %w", configFile, err)
 	}
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing %s: %w", configFile, err)
 	}
 	return &cfg, nil
 }
@@ -92,11 +93,14 @@ func Load(dir string) (*Config, error) {
 // Save writes cfg to .devpilot.yaml in dir, creating intermediate directories.
 func Save(dir string, cfg *Config) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
+		return fmt.Errorf("creating config directory: %w", err)
 	}
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(filepath.Join(dir, configFile), data, 0644)
+	if err := os.WriteFile(filepath.Join(dir, configFile), data, 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", configFile, err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- Add package doc comment to `internal/project`
- Wrap bare error returns in `Load`/`Save` with `%w` for context per the Google Go Style Guide

No behavior changes; exported identifiers unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/project/...`
- [x] `golangci-lint run ./internal/project/...`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>