### PR TITLE
style(review): align with Google Go style guide

### DIFF
--- a/internal/review/commands.go
+++ b/internal/review/commands.go
@@ -12,7 +12,7 @@ import (
 
 // RegisterCommands adds the review subcommand to the given parent command.
 func RegisterCommands(parent *cobra.Command) {
-	reviewCmd.Flags().String("model", "", "Override Claude model (default: "+DefaultReviewModel+")")
+	reviewCmd.Flags().String("model", "", "Override Claude model (default: "+DefaultModel+")")
 	reviewCmd.Flags().Bool("dry-run", false, "Print assembled prompt without executing Claude")
 	reviewCmd.Flags().Int("timeout", 10, "Review timeout in minutes")
 	reviewCmd.Flags().Bool("no-post", false, "Skip posting review to GitHub PR")
@@ -29,7 +29,7 @@ func resolveModel(cmd *cobra.Command) string {
 	if m := cfg.ModelFor("review"); m != "" {
 		return m
 	}
-	return DefaultReviewModel
+	return DefaultModel
 }
 
 var reviewCmd = &cobra.Command{

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -1,3 +1,5 @@
+// Package review performs AI-powered code reviews of GitHub pull requests
+// by delegating to the Claude CLI and parsing its structured output.
 package review
 
 import (
@@ -6,8 +8,8 @@ import (
 	"github.com/siyuqian/devpilot/internal/executor"
 )
 
-// DefaultReviewModel is the default Claude model used for code reviews.
-const DefaultReviewModel = "claude-opus-4-6"
+// DefaultModel is the default Claude model used for code reviews.
+const DefaultModel = "claude-opus-4-6"
 
 // Option configures a review invocation.
 type Option func(*options)
@@ -80,7 +82,7 @@ func BuildFixPrompt(prURL string) string {
 
 func resolveOptions(opts []Option) *options {
 	o := &options{
-		model:        DefaultReviewModel,
+		model:        DefaultModel,
 		postToGitHub: true,
 	}
 	for _, opt := range opts {

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -178,7 +178,7 @@ func TestBuildPrompt_WithPostingDisabled(t *testing.T) {
 }
 
 func TestNewReviewExecutor_RestrictedTools(t *testing.T) {
-	o := &options{model: DefaultReviewModel}
+	o := &options{model: DefaultModel}
 	exec := newReviewExecutor(o)
 	args := exec.Args()
 	found := false

--- a/internal/review/url.go
+++ b/internal/review/url.go
@@ -19,7 +19,7 @@ var prURLPattern = regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+)/pull
 func ParsePRURL(url string) (*PRInfo, error) {
 	matches := prURLPattern.FindStringSubmatch(url)
 	if matches == nil {
-		return nil, fmt.Errorf("invalid GitHub PR URL: %s (expected https://github.com/{owner}/{repo}/pull/{number})", url)
+		return nil, fmt.Errorf("invalid GitHub PR URL: %q (expected https://github.com/{owner}/{repo}/pull/{number})", url)
 	}
 	return &PRInfo{
 		Owner:  matches[1],


### PR DESCRIPTION
## Summary
- Rename `DefaultReviewModel` to `DefaultModel` so callers see `review.DefaultModel` instead of the stuttering `review.DefaultReviewModel`.
- Add a package doc comment to `internal/review`.
- Use `%q` for the user-supplied URL in the `ParsePRURL` error message, per the Google Go Style Guide recommendation for quoting user-facing strings.

## Test plan
- [x] `go build ./internal/review/...`
- [x] `go test ./internal/review/...`
- [x] `gofmt -l internal/review/` (clean)
- [x] `golangci-lint run ./internal/review/...` (0 issues)

Generated with [Claude Code](https://claude.com/claude-code)