### PR TITLE
style(skillmgr): align with Google Go style guide

### DIFF
--- a/internal/skillmgr/catalog.go
+++ b/internal/skillmgr/catalog.go
@@ -1,3 +1,6 @@
+// Package skillmgr manages Claude Code skills: discovering them in a remote
+// catalog, downloading their files, installing them into a project or user
+// directory, and recording installation metadata.
 package skillmgr
 
 import "context"


### PR DESCRIPTION
## Summary
- Audit of internal/skillmgr/ against the Google Go Style Guide
- Add a package-level doc comment on skillmgr (previously missing)

All other files in internal/skillmgr/ were already compliant: MixedCaps naming, correct initialism casing (URL, ID, HTTP, JSON), exported symbol doc comments starting with the name, error wrapping with %w, lowercase error strings, context.Context as first parameter on functions that take it, early-return error flow, standard import grouping, and no interface{} in production code. The only surgical fix is the missing package doc.

## Test plan
- [x] go build ./internal/skillmgr/...
- [x] go test ./internal/skillmgr/... (pass)
- [x] make lint (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)