### PR TITLE
style(slack): align with Google Go style guide

### DIFF
--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -1,3 +1,5 @@
+// Package slack provides a minimal Slack Web API client and the
+// devpilot CLI commands that drive it.
 package slack
 
 import (
@@ -12,22 +14,27 @@ import (
 
 const defaultBaseURL = "https://slack.com/api"
 
+// Client is a minimal Slack Web API client.
 type Client struct {
 	botToken   string
 	baseURL    string
 	httpClient *http.Client
 }
 
+// Option configures a Client.
 type Option func(*Client)
 
+// WithBaseURL overrides the Slack API base URL. It is primarily used in tests.
 func WithBaseURL(u string) Option {
 	return func(c *Client) { c.baseURL = u }
 }
 
+// WithHTTPClient overrides the HTTP client used to make requests.
 func WithHTTPClient(hc *http.Client) Option {
 	return func(c *Client) { c.httpClient = hc }
 }
 
+// NewClient returns a Client that authenticates with the given Slack bot token.
 func NewClient(botToken string, opts ...Option) *Client {
 	c := &Client{
 		botToken:   botToken,
@@ -40,6 +47,7 @@ func NewClient(botToken string, opts ...Option) *Client {
 	return c
 }
 
+// Channel represents a Slack conversation (channel or DM).
 type Channel struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -67,6 +75,7 @@ type conversationsOpenResponse struct {
 	} `json:"channel"`
 }
 
+// ListConversations returns all public, non-archived channels visible to the bot.
 func (c *Client) ListConversations() ([]Channel, error) {
 	var all []Channel
 	cursor := ""
@@ -105,6 +114,8 @@ func (c *Client) ListConversations() ([]Channel, error) {
 	return all, nil
 }
 
+// ResolveChannel looks up a channel by name (with or without a leading "#")
+// and returns its Slack channel ID.
 func (c *Client) ResolveChannel(name string) (string, error) {
 	name = strings.TrimPrefix(name, "#")
 
@@ -119,9 +130,11 @@ func (c *Client) ResolveChannel(name string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Channel not found: %s", name)
+	return "", fmt.Errorf("channel not found: %q", name)
 }
 
+// OpenConversation opens a direct-message channel with the given user ID and
+// returns the resulting channel ID.
 func (c *Client) OpenConversation(userID string) (string, error) {
 	params := url.Values{
 		"users": {userID},
@@ -143,6 +156,7 @@ func (c *Client) OpenConversation(userID string) (string, error) {
 	return resp.Channel.ID, nil
 }
 
+// PostMessage posts text to the given Slack channel ID.
 func (c *Client) PostMessage(channelID, text string) error {
 	params := url.Values{
 		"channel": {channelID},

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -235,7 +235,7 @@ func TestHTTPError(t *testing.T) {
 }
 
 func TestServiceName(t *testing.T) {
-	svc := NewSlackService()
+	svc := NewService()
 	if svc.Name() != "slack" {
 		t.Fatalf("expected 'slack', got '%s'", svc.Name())
 	}
@@ -245,7 +245,7 @@ func TestServiceIsLoggedIn(t *testing.T) {
 	restore := auth.OverrideConfigDir(t.TempDir())
 	defer restore()
 
-	svc := NewSlackService()
+	svc := NewService()
 	// Without credentials saved, should return false
 	if svc.IsLoggedIn() {
 		t.Fatal("expected IsLoggedIn to return false without credentials")

--- a/internal/slack/commands.go
+++ b/internal/slack/commands.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// RegisterCommands adds the "slack" command group to the given parent command.
 func RegisterCommands(parent *cobra.Command) {
 	slackCmd := &cobra.Command{
 		Use:   "slack",

--- a/internal/slack/service.go
+++ b/internal/slack/service.go
@@ -18,20 +18,24 @@ const (
 )
 
 func init() {
-	auth.Register(NewSlackService())
+	auth.Register(NewService())
 }
 
-type SlackService struct{}
+// Service implements the auth.Service interface for Slack.
+type Service struct{}
 
-func NewSlackService() *SlackService {
-	return &SlackService{}
+// NewService returns a new Slack auth service.
+func NewService() *Service {
+	return &Service{}
 }
 
-func (s *SlackService) Name() string {
+// Name returns the service name ("slack").
+func (s *Service) Name() string {
 	return "slack"
 }
 
-func (s *SlackService) Login() error {
+// Login runs the interactive Slack OAuth flow and stores credentials.
+func (s *Service) Login() error {
 	fmt.Println("Slack Login")
 	fmt.Println("===========")
 	fmt.Println()
@@ -81,7 +85,8 @@ func (s *SlackService) Login() error {
 	return nil
 }
 
-func (s *SlackService) Logout() error {
+// Logout removes stored Slack credentials.
+func (s *Service) Logout() error {
 	if err := auth.Remove(s.Name()); err != nil {
 		return err
 	}
@@ -89,12 +94,13 @@ func (s *SlackService) Logout() error {
 	return nil
 }
 
-func (s *SlackService) IsLoggedIn() bool {
+// IsLoggedIn reports whether Slack credentials are stored locally.
+func (s *Service) IsLoggedIn() bool {
 	_, err := auth.Load(s.Name())
 	return err == nil
 }
 
-func (s *SlackService) oauthConfig() auth.OAuthConfig {
+func (s *Service) oauthConfig() auth.OAuthConfig {
 	creds, _ := auth.Load(s.Name())
 	return auth.OAuthConfig{
 		ProviderName: "slack",


### PR DESCRIPTION
## Summary
- Rename `SlackService`/`NewSlackService` to `Service`/`NewService` to avoid package stutter (`slack.SlackService` → `slack.Service`)
- Add package doc comment and doc comments on all exported symbols in `internal/slack/`
- Lowercase the `channel not found` error string and format the name with `%q`

## Test plan
- [x] go build ./...
- [x] go test ./internal/slack/...
- [x] make test
- [x] make lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)