### PR TITLE
style(initcmd): align with Google Go style guide

### DIFF
--- a/internal/initcmd/commands_test.go
+++ b/internal/initcmd/commands_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestFormatStatusConfigured(t *testing.T) {
+func TestFormatStatus_Configured(t *testing.T) {
 	s := &Status{
 		HasTrelloCreds: true,
 		HasBoardConfig: true,
@@ -30,16 +30,16 @@ func TestFormatStatusConfigured(t *testing.T) {
 	}
 
 	for i, exp := range expected {
-		if !containsSubstring(lines[i], exp.prefix) {
+		if !strings.Contains(lines[i], exp.prefix) {
 			t.Errorf("line %d missing prefix %q: %s", i, exp.prefix, lines[i])
 		}
-		if !containsSubstring(lines[i], exp.label) {
+		if !strings.Contains(lines[i], exp.label) {
 			t.Errorf("line %d missing label %q: %s", i, exp.label, lines[i])
 		}
 	}
 }
 
-func TestFormatStatusGitHub(t *testing.T) {
+func TestFormatStatus_GitHub(t *testing.T) {
 	s := &Status{
 		HasSkills: true,
 		IsGitRepo: true,
@@ -50,7 +50,7 @@ func TestFormatStatusGitHub(t *testing.T) {
 
 	foundGitHub := false
 	for _, line := range lines {
-		if containsSubstring(line, "GitHub Issues") {
+		if strings.Contains(line, "GitHub Issues") {
 			foundGitHub = true
 		}
 	}
@@ -60,13 +60,13 @@ func TestFormatStatusGitHub(t *testing.T) {
 
 	// Should NOT mention Trello when source is github
 	for _, line := range lines {
-		if containsSubstring(line, "Trello") {
+		if strings.Contains(line, "Trello") {
 			t.Errorf("unexpected Trello mention in github source status: %s", line)
 		}
 	}
 }
 
-func TestFormatStatusMissing(t *testing.T) {
+func TestFormatStatus_Missing(t *testing.T) {
 	s := &Status{
 		HasTrelloCreds: false,
 		HasBoardConfig: false,
@@ -77,13 +77,13 @@ func TestFormatStatusMissing(t *testing.T) {
 	lines := formatStatus(s)
 
 	for _, line := range lines {
-		if containsSubstring(line, "✓") {
+		if strings.Contains(line, "✓") {
 			t.Errorf("expected all ✗ but got ✓ in line: %s", line)
 		}
 	}
 }
 
-func TestFormatStatusNotGitRepo(t *testing.T) {
+func TestFormatStatus_NotGitRepo(t *testing.T) {
 	s := &Status{
 		IsGitRepo: false,
 	}
@@ -92,7 +92,7 @@ func TestFormatStatusNotGitRepo(t *testing.T) {
 
 	foundGitWarning := false
 	for _, line := range lines {
-		if containsSubstring(line, "Not a git repository") {
+		if strings.Contains(line, "Not a git repository") {
 			foundGitWarning = true
 		}
 	}
@@ -145,7 +145,7 @@ func TestAllConfigured(t *testing.T) {
 	}
 }
 
-func TestShouldGenerateSkipsOnNo(t *testing.T) {
+func TestShouldGenerate_SkipsOnNo(t *testing.T) {
 	input := strings.NewReader("n\n")
 	opts := GenerateOpts{
 		Dir:         t.TempDir(),
@@ -158,7 +158,7 @@ func TestShouldGenerateSkipsOnNo(t *testing.T) {
 	}
 }
 
-func TestShouldGenerateAcceptsDefault(t *testing.T) {
+func TestShouldGenerate_AcceptsDefault(t *testing.T) {
 	input := strings.NewReader("\n")
 	opts := GenerateOpts{
 		Dir:         t.TempDir(),
@@ -171,7 +171,7 @@ func TestShouldGenerateAcceptsDefault(t *testing.T) {
 	}
 }
 
-func TestShouldGenerateNonInteractiveReturnsTrue(t *testing.T) {
+func TestShouldGenerate_NonInteractiveReturnsTrue(t *testing.T) {
 	opts := GenerateOpts{
 		Dir:         t.TempDir(),
 		Interactive: false,
@@ -180,17 +180,4 @@ func TestShouldGenerateNonInteractiveReturnsTrue(t *testing.T) {
 	if !shouldGenerate(opts, "Configure task source? [Y/n]: ") {
 		t.Error("shouldGenerate returned false in non-interactive mode, want true")
 	}
-}
-
-func containsSubstring(s, substr string) bool {
-	return len(s) >= len(substr) && findSubstring(s, substr)
-}
-
-func findSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/initcmd/detect_test.go
+++ b/internal/initcmd/detect_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/siyuqian/devpilot/internal/project"
 )
 
-func TestDetectHasBoardConfig(t *testing.T) {
+func TestDetect_HasBoardConfig(t *testing.T) {
 	dir := t.TempDir()
 
 	// Without .devpilot.yaml
@@ -36,7 +36,7 @@ func TestDetectHasBoardConfig(t *testing.T) {
 	}
 }
 
-func TestDetectHasSkills(t *testing.T) {
+func TestDetect_HasSkills(t *testing.T) {
 	dir := t.TempDir()
 
 	// Without skills dir
@@ -73,7 +73,7 @@ func TestDetectHasSkills(t *testing.T) {
 	}
 }
 
-func TestDetectIsGitRepo(t *testing.T) {
+func TestDetect_IsGitRepo(t *testing.T) {
 	dir := t.TempDir()
 
 	// Without .git
@@ -92,7 +92,7 @@ func TestDetectIsGitRepo(t *testing.T) {
 	}
 }
 
-func TestDetectWorkDir(t *testing.T) {
+func TestDetect_WorkDir(t *testing.T) {
 	dir := t.TempDir()
 	s := Detect(dir)
 	if s.WorkDir != dir {
@@ -100,7 +100,7 @@ func TestDetectWorkDir(t *testing.T) {
 	}
 }
 
-func TestDetectSource(t *testing.T) {
+func TestDetect_Source(t *testing.T) {
 	dir := t.TempDir()
 
 	// No config file: Source should be ""

--- a/internal/initcmd/generate.go
+++ b/internal/initcmd/generate.go
@@ -93,12 +93,12 @@ type ghLabel struct {
 
 // ghRequiredLabels are the labels DevPilot needs on a GitHub repository.
 var ghRequiredLabels = []ghLabel{
-	{"devpilot", "0075ca", "Task managed by DevPilot"},
-	{"in-progress", "e4e669", "Task is currently being executed by DevPilot"},
-	{"failed", "d93f0b", "DevPilot task execution failed"},
-	{"P0-critical", "b60205", "Highest priority — execute first"},
-	{"P1-high", "e99695", "High priority"},
-	{"P2-normal", "c5def5", "Normal priority (default)"},
+	{name: "devpilot", color: "0075ca", desc: "Task managed by DevPilot"},
+	{name: "in-progress", color: "e4e669", desc: "Task is currently being executed by DevPilot"},
+	{name: "failed", color: "d93f0b", desc: "DevPilot task execution failed"},
+	{name: "P0-critical", color: "b60205", desc: "Highest priority — execute first"},
+	{name: "P1-high", color: "e99695", desc: "High priority"},
+	{name: "P2-normal", color: "c5def5", desc: "Normal priority (default)"},
 }
 
 // ConfigureGitHubSource saves source=github to .devpilot.yaml and creates the
@@ -202,7 +202,7 @@ func InstallSkills(opts GenerateOpts, installOpts SkillInstallOpts) error {
 	fetchCatalogFn := installOpts.FetchCatalogFn
 	if fetchCatalogFn == nil {
 		fetchCatalogFn = func() ([]skillmgr.CatalogEntry, error) {
-			fmt.Printf("  Discovering available skills...\n")
+			fmt.Println("  Discovering available skills...")
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			catalog, err := skillmgr.FetchCatalog(ctx, "siyuqian", "devpilot", "main")

--- a/internal/initcmd/generate_test.go
+++ b/internal/initcmd/generate_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/siyuqian/devpilot/internal/skillmgr"
 )
 
-func TestConfigureBoardNonInteractiveSkips(t *testing.T) {
+func TestConfigureBoard_NonInteractiveSkips(t *testing.T) {
 	dir := t.TempDir()
 
 	opts := GenerateOpts{Dir: dir, Interactive: false}
@@ -25,7 +25,7 @@ func TestConfigureBoardNonInteractiveSkips(t *testing.T) {
 	}
 }
 
-func TestConfigureBoardInteractiveWithListBoards(t *testing.T) {
+func TestConfigureBoard_InteractiveWithListBoards(t *testing.T) {
 	dir := t.TempDir()
 
 	input := strings.NewReader("1\n")
@@ -52,7 +52,7 @@ func TestConfigureBoardInteractiveWithListBoards(t *testing.T) {
 	}
 }
 
-func TestConfigureBoardInteractiveFreeText(t *testing.T) {
+func TestConfigureBoard_InteractiveFreeText(t *testing.T) {
 	dir := t.TempDir()
 
 	input := strings.NewReader("My Custom Board\n")
@@ -75,7 +75,7 @@ func TestConfigureBoardInteractiveFreeText(t *testing.T) {
 	}
 }
 
-func TestConfigureBoardPreservesExistingConfig(t *testing.T) {
+func TestConfigureBoard_PreservesExistingConfig(t *testing.T) {
 	dir := t.TempDir()
 
 	// Write a config with existing skills entry.
@@ -107,7 +107,7 @@ func TestConfigureBoardPreservesExistingConfig(t *testing.T) {
 	}
 }
 
-func TestInstallSkillsNonInteractiveSkips(t *testing.T) {
+func TestInstallSkills_NonInteractiveSkips(t *testing.T) {
 	dir := t.TempDir()
 	opts := GenerateOpts{Dir: dir, Interactive: false}
 
@@ -137,7 +137,7 @@ func stubCatalogFn() ([]skillmgr.CatalogEntry, error) {
 	}, nil
 }
 
-func TestInstallSkillsInteractiveInstalls(t *testing.T) {
+func TestInstallSkills_InteractiveInstalls(t *testing.T) {
 	dir := t.TempDir()
 	opts := GenerateOpts{Dir: dir, Interactive: true}
 
@@ -162,7 +162,7 @@ func TestInstallSkillsInteractiveInstalls(t *testing.T) {
 	}
 }
 
-func TestInstallSkillsNoSelection(t *testing.T) {
+func TestInstallSkills_NoSelection(t *testing.T) {
 	dir := t.TempDir()
 	opts := GenerateOpts{Dir: dir, Interactive: true}
 


### PR DESCRIPTION
## Summary
- Audit `internal/initcmd/` against the Google Go Style Guide and apply minor cleanups.
- Use named fields in `ghRequiredLabels` struct literals.
- Replace hand-rolled `containsSubstring`/`findSubstring` helpers with `strings.Contains`.
- Swap a `fmt.Printf("...\n")` for `fmt.Println`.
- Rename tests to the `TestFoo_Scenario` form.

No behavior changes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/initcmd/...`
- [x] `make test`
- [x] `make lint`

Generated with Claude Code