### PR TITLE
style(openspec): align with Google Go style guide

### DIFF
--- a/internal/openspec/commands.go
+++ b/internal/openspec/commands.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// RegisterCommands attaches the OpenSpec subcommands (currently "sync") to
+// the given parent Cobra command.
 func RegisterCommands(parent *cobra.Command) {
 	syncCmd.Flags().String("board", "", "Trello board name (required for trello source)")
 	syncCmd.Flags().String("source", "", "Task source: trello or github (default from .devpilot.yaml)")

--- a/internal/openspec/github_target.go
+++ b/internal/openspec/github_target.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 )
 
 // GitHubTarget implements SyncTarget using the gh CLI to manage GitHub Issues.
@@ -19,6 +20,8 @@ func (g *GitHubTarget) findArgs(name string) []string {
 		"--search", name + " in:title", "--json", "number,title", "--limit", "5"}
 }
 
+// FindByName returns the number (as a string) of the open devpilot-labeled
+// issue whose title exactly matches name, or "" if none matches.
 func (g *GitHubTarget) FindByName(name string) (string, error) {
 	out, err := exec.Command("gh", g.findArgs(name)...).Output()
 	if err != nil {
@@ -33,12 +36,14 @@ func (g *GitHubTarget) FindByName(name string) (string, error) {
 	}
 	for _, issue := range issues {
 		if issue.Title == name {
-			return fmt.Sprintf("%d", issue.Number), nil
+			return strconv.Itoa(issue.Number), nil
 		}
 	}
 	return "", nil
 }
 
+// Create opens a new GitHub issue labeled "devpilot" with the given title and
+// body.
 func (g *GitHubTarget) Create(name, desc string) error {
 	_, err := exec.Command("gh", "issue", "create",
 		"--title", name, "--body", desc, "--label", "devpilot",
@@ -49,6 +54,7 @@ func (g *GitHubTarget) Create(name, desc string) error {
 	return nil
 }
 
+// Update replaces the body of the issue with the given number.
 func (g *GitHubTarget) Update(id, desc string) error {
 	_, err := exec.Command("gh", "issue", "edit", id, "--body", desc).Output()
 	if err != nil {

--- a/internal/openspec/integration_test.go
+++ b/internal/openspec/integration_test.go
@@ -13,13 +13,13 @@ func TestFullSyncFlow(t *testing.T) {
 	// Create two changes
 	for _, name := range []string{"add-auth", "fix-bug"} {
 		changeDir := filepath.Join(dir, "openspec", "changes", name)
-		if err := os.MkdirAll(changeDir, 0755); err != nil {
+		if err := os.MkdirAll(changeDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(changeDir, "proposal.md"), []byte("# "+name+"\nDescription"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(changeDir, "proposal.md"), []byte("# "+name+"\nDescription"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(changeDir, "tasks.md"), []byte("- [ ] Task 1"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(changeDir, "tasks.md"), []byte("- [ ] Task 1"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/openspec/openspec.go
+++ b/internal/openspec/openspec.go
@@ -1,3 +1,5 @@
+// Package openspec integrates OpenSpec change proposals with task boards,
+// scanning openspec/changes/ and syncing proposals to Trello or GitHub Issues.
 package openspec
 
 import (

--- a/internal/openspec/trello_target.go
+++ b/internal/openspec/trello_target.go
@@ -13,6 +13,8 @@ func NewTrelloTarget(client *trello.Client, listID string) *TrelloTarget {
 	return &TrelloTarget{client: client, listID: listID}
 }
 
+// FindByName returns the ID of the card with the given name in the configured
+// list, or an empty string if no such card exists.
 func (t *TrelloTarget) FindByName(name string) (string, error) {
 	card, err := t.client.FindCardByName(t.listID, name)
 	if err != nil {
@@ -24,11 +26,14 @@ func (t *TrelloTarget) FindByName(name string) (string, error) {
 	return card.ID, nil
 }
 
+// Create adds a new card with the given name and description to the
+// configured Trello list.
 func (t *TrelloTarget) Create(name, desc string) error {
 	_, err := t.client.CreateCard(t.listID, name, desc)
 	return err
 }
 
+// Update replaces the description of the card with the given ID.
 func (t *TrelloTarget) Update(id, desc string) error {
 	return t.client.UpdateCard(id, desc)
 }


### PR DESCRIPTION
## Summary
- Add package doc comment and doc comments to all exported symbols in `internal/openspec/` (`RegisterCommands`, `TrelloTarget` / `GitHubTarget` methods).
- Replace `fmt.Sprintf("%d", ...)` with `strconv.Itoa` in `GitHubTarget.FindByName`.
- Normalize octal literals (`0755`/`0644` → `0o755`/`0o644`) in `integration_test.go` for consistency with other tests in the package.

No behavior changes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/openspec/...`
- [x] `make test`
- [x] `make lint` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)