### PR TITLE
style(taskrunner): align with Google Go style guide

### DIFF
--- a/internal/taskrunner/git.go
+++ b/internal/taskrunner/git.go
@@ -22,16 +22,18 @@ func (g *GitOps) run(args ...string) (string, error) {
 	cmd.Dir = g.dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("git %s: %s %w", strings.Join(args, " "), string(out), err)
+		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), string(out), err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
 
+// CreateBranch creates or resets a branch with the given name and checks it out.
 func (g *GitOps) CreateBranch(name string) error {
 	_, err := g.run("checkout", "-B", name)
 	return err
 }
 
+// CheckoutMain checks out the main branch, falling back to master.
 func (g *GitOps) CheckoutMain() error {
 	if _, err := g.run("checkout", "main"); err != nil {
 		_, err = g.run("checkout", "master")
@@ -40,11 +42,13 @@ func (g *GitOps) CheckoutMain() error {
 	return nil
 }
 
+// Pull fast-forwards the current branch from its upstream.
 func (g *GitOps) Pull() error {
 	_, err := g.run("pull", "--ff-only")
 	return err
 }
 
+// BranchName builds a task branch name from a card ID and card name.
 func (g *GitOps) BranchName(cardID, cardName string) string {
 	slug := Slugify(cardName)
 	if len(slug) > 40 {
@@ -57,27 +61,30 @@ func (g *GitOps) BranchName(cardID, cardName string) string {
 	return fmt.Sprintf("task/%s-%s", cardID, slug)
 }
 
+// Push pushes the given branch to origin and sets upstream tracking.
 func (g *GitOps) Push(branch string) error {
 	_, err := g.run("push", "-u", "origin", branch)
 	return err
 }
 
+// CreatePR creates a GitHub pull request via the gh CLI and returns its URL.
 func (g *GitOps) CreatePR(title, body string) (string, error) {
 	cmd := exec.Command("gh", "pr", "create", "--title", title, "--body", body)
 	cmd.Dir = g.dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("gh pr create: %s %w", string(out), err)
+		return "", fmt.Errorf("gh pr create: %s: %w", string(out), err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
 
+// MergePR enables auto-merge (squash) on the current branch's pull request.
 func (g *GitOps) MergePR() error {
 	cmd := exec.Command("gh", "pr", "merge", "--squash", "--auto")
 	cmd.Dir = g.dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("gh pr merge: %s %w", string(out), err)
+		return fmt.Errorf("gh pr merge: %s: %w", string(out), err)
 	}
 	return nil
 }

--- a/internal/taskrunner/github_source.go
+++ b/internal/taskrunner/github_source.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -23,6 +24,7 @@ func NewGitHubSource() *GitHubSource {
 	return &GitHubSource{}
 }
 
+// Init detects the current repository via the gh CLI and returns its slug.
 func (s *GitHubSource) Init() (SourceInfo, error) {
 	out, err := exec.Command("gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner").Output()
 	if err != nil {
@@ -45,6 +47,7 @@ type ghIssue struct {
 	CreatedAt time.Time `json:"createdAt"`
 }
 
+// FetchReady returns ready tasks by querying open devpilot-labeled issues.
 func (s *GitHubSource) FetchReady() ([]Task, error) {
 	// "sort:created-asc" asks the GitHub API to return issues oldest-first.
 	// Combined with the stable priority sort in SortByPriority, this gives a
@@ -75,7 +78,7 @@ func issuesToReadyTasks(issues []ghIssue) []Task {
 			continue
 		}
 		tasks = append(tasks, Task{
-			ID:          fmt.Sprintf("%d", issue.Number),
+			ID:          strconv.Itoa(issue.Number),
 			Name:        issue.Title,
 			Description: issue.Body,
 			URL:         issue.URL,
@@ -86,6 +89,7 @@ func issuesToReadyTasks(issues []ghIssue) []Task {
 	return tasks
 }
 
+// MarkInProgress adds the in-progress label to the given issue.
 func (s *GitHubSource) MarkInProgress(id string) error {
 	_, err := exec.Command("gh", "issue", "edit", id, "--add-label", ghLabelInProgress).Output()
 	if err != nil {
@@ -94,6 +98,7 @@ func (s *GitHubSource) MarkInProgress(id string) error {
 	return nil
 }
 
+// MarkDone closes the given issue and adds a completion comment.
 func (s *GitHubSource) MarkDone(id, comment string) error {
 	_, err := exec.Command("gh", "issue", "close", id).Output()
 	if err != nil {
@@ -102,6 +107,7 @@ func (s *GitHubSource) MarkDone(id, comment string) error {
 	return s.addComment(id, comment)
 }
 
+// MarkFailed replaces the in-progress label with failed and adds a comment.
 func (s *GitHubSource) MarkFailed(id, comment string) error {
 	_, err := exec.Command("gh", "issue", "edit", id,
 		"--remove-label", ghLabelInProgress,

--- a/internal/taskrunner/reviewer.go
+++ b/internal/taskrunner/reviewer.go
@@ -21,10 +21,12 @@ func NewReviewer(execOpts ...executor.ExecutorOption) *Reviewer {
 	return &Reviewer{opts: opts}
 }
 
+// Review runs an automated code review against the given PR URL.
 func (rv *Reviewer) Review(ctx context.Context, prURL string) (*executor.ExecuteResult, error) {
 	return review.Review(ctx, prURL, rv.opts...)
 }
 
+// Fix runs an automated fix attempt against the given PR URL.
 func (rv *Reviewer) Fix(ctx context.Context, prURL string) (*executor.ExecuteResult, error) {
 	return review.Fix(ctx, prURL, rv.opts...)
 }

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -94,6 +94,7 @@ func (r *Runner) init() error {
 	return nil
 }
 
+// Run starts the polling loop and processes ready tasks until ctx is cancelled.
 func (r *Runner) Run(ctx context.Context) error {
 	if err := r.init(); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Add doc comments on exported methods in `git.go`, `github_source.go`, `reviewer.go`, and `Runner.Run`
- Fix error-wrapping separator in git/gh error messages (`%s %w` -> `%s: %w`)
- Replace `fmt.Sprintf(\"%d\", n)` with `strconv.Itoa` in `github_source.go`

No behavior changes — surgical style adjustments only.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/taskrunner/...`
- [x] `make test`
- [x] `make lint`

Generated with Claude Code