### PR TITLE
style(generate): align with Google Go style guide

### DIFF
--- a/internal/generate/claude.go
+++ b/internal/generate/claude.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-// Generate calls `claude --print` with the given prompt and optional model.
-func Generate(ctx context.Context, prompt, model string) (string, error) {
+// run calls `claude --print` with the given prompt and optional model.
+func run(ctx context.Context, prompt, model string) (string, error) {
 	args := buildArgs(model)
 	args = append(args, prompt)
 
@@ -41,8 +41,8 @@ func buildReadmeArgs(model string) []string {
 	return args
 }
 
-// GenerateWithTools calls `claude -p` with tools enabled for autonomous exploration.
-func GenerateWithTools(ctx context.Context, prompt, model string) (string, error) {
+// runWithTools calls `claude -p` with tools enabled for autonomous exploration.
+func runWithTools(ctx context.Context, prompt, model string) (string, error) {
 	args := buildReadmeArgs(model)
 	args = append(args, prompt)
 

--- a/internal/generate/commands.go
+++ b/internal/generate/commands.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// RegisterCommands attaches the `commit` and `readme` subcommands to parent.
 func RegisterCommands(parent *cobra.Command) {
 	commitCmd.Flags().StringP("message", "m", "", "Additional context for AI")
 	commitCmd.Flags().String("model", "", "Override Claude model")
@@ -44,7 +45,7 @@ var commitCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 
-		if err := RunCommit(ctx, model, msg, dryRun); err != nil {
+		if err := runCommit(ctx, model, msg, dryRun); err != nil {
 			fmt.Fprintln(os.Stderr, "Error:", err)
 			os.Exit(1)
 		}
@@ -63,7 +64,7 @@ var readmeCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
-		if err := RunReadme(ctx, model, dryRun); err != nil {
+		if err := runReadme(ctx, model, dryRun); err != nil {
 			fmt.Fprintln(os.Stderr, "Error:", err)
 			os.Exit(1)
 		}

--- a/internal/generate/commit.go
+++ b/internal/generate/commit.go
@@ -120,16 +120,16 @@ func gitOutput(args ...string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// RunCommit launches the Bubble Tea commit workflow.
-func RunCommit(ctx context.Context, model, userContext string, dryRun bool) error {
-	m := NewCommitModel(ctx, model, userContext, dryRun)
+// runCommit launches the Bubble Tea commit workflow.
+func runCommit(ctx context.Context, model, userContext string, dryRun bool) error {
+	m := newCommitModel(ctx, model, userContext, dryRun)
 	p := tea.NewProgram(m)
 	finalModel, err := p.Run()
 	if err != nil {
 		return err
 	}
 
-	fm := finalModel.(CommitModel)
+	fm := finalModel.(commitModel)
 	if fm.err != nil {
 		if errors.Is(fm.err, errAborted) || errors.Is(fm.err, errNoChanges) {
 			return nil

--- a/internal/generate/commit_model.go
+++ b/internal/generate/commit_model.go
@@ -25,8 +25,8 @@ const (
 	phaseDone         = "done"
 )
 
-// CommitModel is the Bubble Tea model for the commit workflow.
-type CommitModel struct {
+// commitModel is the Bubble Tea model for the commit workflow.
+type commitModel struct {
 	// Config
 	model   string
 	context string
@@ -35,7 +35,7 @@ type CommitModel struct {
 
 	// State
 	phase    string
-	plan     CommitPlan
+	plan     commitPlan
 	warnings []string
 	err      error
 
@@ -70,7 +70,7 @@ type stagingDoneMsg struct {
 }
 
 type analysisDoneMsg struct {
-	plan     CommitPlan
+	plan     commitPlan
 	warnings []string
 	err      error
 }
@@ -82,26 +82,26 @@ type commitExecMsg struct {
 }
 
 type editDoneMsg struct {
-	plan CommitPlan
+	plan commitPlan
 	err  error
 }
 
-func (m CommitModel) finishWithError(err error) (tea.Model, tea.Cmd) {
+func (m commitModel) finishWithError(err error) (tea.Model, tea.Cmd) {
 	m.phase = phaseDone
 	m.err = err
 	return m, tea.Quit
 }
 
-func (m CommitModel) isMultiCommit() bool {
+func (m commitModel) isMultiCommit() bool {
 	return len(m.plan.Commits) > 1 || len(m.plan.Excluded) > 0
 }
 
-// NewCommitModel creates a new CommitModel.
-func NewCommitModel(ctx context.Context, model, userContext string, dryRun bool) CommitModel {
+// newCommitModel creates a new commitModel.
+func newCommitModel(ctx context.Context, model, userContext string, dryRun bool) commitModel {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 
-	return CommitModel{
+	return commitModel{
 		model:   model,
 		context: userContext,
 		dryRun:  dryRun,
@@ -111,11 +111,11 @@ func NewCommitModel(ctx context.Context, model, userContext string, dryRun bool)
 	}
 }
 
-func (m CommitModel) Init() tea.Cmd {
+func (m commitModel) Init() tea.Cmd {
 	return tea.Batch(m.spinner.Tick, m.stageAndCollectDiff())
 }
 
-func (m CommitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m commitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		return m.handleKey(msg)
@@ -138,7 +138,7 @@ func (m CommitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m CommitModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m commitModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+c":
 		return m, tea.Quit
@@ -165,7 +165,7 @@ func (m CommitModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m CommitModel) handleStagingDone(msg stagingDoneMsg) (tea.Model, tea.Cmd) {
+func (m commitModel) handleStagingDone(msg stagingDoneMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		return m.finishWithError(msg.err)
 	}
@@ -183,7 +183,7 @@ func (m CommitModel) handleStagingDone(msg stagingDoneMsg) (tea.Model, tea.Cmd) 
 	return m, m.analyzeChanges()
 }
 
-func (m CommitModel) handleAnalysisDone(msg analysisDoneMsg) (tea.Model, tea.Cmd) {
+func (m commitModel) handleAnalysisDone(msg analysisDoneMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		return m.finishWithError(msg.err)
 	}
@@ -200,7 +200,7 @@ func (m CommitModel) handleAnalysisDone(msg analysisDoneMsg) (tea.Model, tea.Cmd
 	return m, nil
 }
 
-func (m CommitModel) handleCommitExec(msg commitExecMsg) (tea.Model, tea.Cmd) {
+func (m commitModel) handleCommitExec(msg commitExecMsg) (tea.Model, tea.Cmd) {
 	result := commitResult{hash: msg.hash, message: m.plan.Commits[msg.index].Message}
 	if msg.err != nil {
 		result.err = msg.err
@@ -219,7 +219,7 @@ func (m CommitModel) handleCommitExec(msg commitExecMsg) (tea.Model, tea.Cmd) {
 	return m, m.executeCommit(m.currentCommit)
 }
 
-func (m CommitModel) handleEditDone(msg editDoneMsg) (tea.Model, tea.Cmd) {
+func (m commitModel) handleEditDone(msg editDoneMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		// Stay in plan phase, show error
 		m.warnings = append(m.warnings, fmt.Sprintf("edit error: %v", msg.err))
@@ -230,7 +230,7 @@ func (m CommitModel) handleEditDone(msg editDoneMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m CommitModel) startExecution() (tea.Model, tea.Cmd) {
+func (m commitModel) startExecution() (tea.Model, tea.Cmd) {
 	m.phase = phaseExecuting
 	m.currentCommit = 0
 	m.completedCommits = nil
@@ -244,7 +244,7 @@ func (m CommitModel) startExecution() (tea.Model, tea.Cmd) {
 
 // Async commands
 
-func (m CommitModel) stageAndCollectDiff() tea.Cmd {
+func (m commitModel) stageAndCollectDiff() tea.Cmd {
 	return func() tea.Msg {
 		// Stage all changes
 		if out, err := exec.Command("git", "add", ".").CombinedOutput(); err != nil {
@@ -284,14 +284,14 @@ func (m CommitModel) stageAndCollectDiff() tea.Cmd {
 	}
 }
 
-func (m CommitModel) analyzeChanges() tea.Cmd {
+func (m commitModel) analyzeChanges() tea.Cmd {
 	return func() tea.Msg {
 		prompt, err := buildCommitPrompt(m.nameStatus, m.diffStat, m.diffContent, m.context)
 		if err != nil {
 			return analysisDoneMsg{err: fmt.Errorf("build prompt: %w", err)}
 		}
 
-		output, err := Generate(m.genCtx, prompt, m.model)
+		output, err := run(m.genCtx, prompt, m.model)
 		if err != nil {
 			return analysisDoneMsg{err: err}
 		}
@@ -303,7 +303,7 @@ func (m CommitModel) analyzeChanges() tea.Cmd {
 	}
 }
 
-func (m CommitModel) executeCommit(index int) tea.Cmd {
+func (m commitModel) executeCommit(index int) tea.Cmd {
 	commit := m.plan.Commits[index]
 	return func() tea.Msg {
 		// Reset staging area
@@ -331,7 +331,7 @@ func (m CommitModel) executeCommit(index int) tea.Cmd {
 	}
 }
 
-func (m CommitModel) unstageExcluded() tea.Cmd {
+func (m commitModel) unstageExcluded() tea.Cmd {
 	excluded := m.plan.Excluded
 	return func() tea.Msg {
 		var files []string
@@ -344,7 +344,7 @@ func (m CommitModel) unstageExcluded() tea.Cmd {
 	}
 }
 
-func (m CommitModel) openEditor() tea.Cmd {
+func (m commitModel) openEditor() tea.Cmd {
 	return func() tea.Msg {
 		edited, err := editPlanInTerminal(m.plan)
 		if err != nil {

--- a/internal/generate/commit_plan.go
+++ b/internal/generate/commit_plan.go
@@ -8,30 +8,30 @@ import (
 	"strings"
 )
 
-// CommitEntry represents a single commit in the plan.
-type CommitEntry struct {
+// commitEntry represents a single commit in the plan.
+type commitEntry struct {
 	Message string   `json:"message"`
 	Files   []string `json:"files"`
 }
 
-// ExcludedFile represents a file excluded from committing.
-type ExcludedFile struct {
+// excludedFile represents a file excluded from committing.
+type excludedFile struct {
 	File   string `json:"file"`
 	Reason string `json:"reason"`
 }
 
-// CommitPlan represents the full commit plan returned by Claude.
-type CommitPlan struct {
-	Commits  []CommitEntry  `json:"commits"`
-	Excluded []ExcludedFile `json:"excluded"`
+// commitPlan represents the full commit plan returned by Claude.
+type commitPlan struct {
+	Commits  []commitEntry  `json:"commits"`
+	Excluded []excludedFile `json:"excluded"`
 }
 
-// parseCommitPlan parses JSON output from Claude into a CommitPlan.
+// parseCommitPlan parses JSON output from Claude into a commitPlan.
 // On parse failure, falls back to a single commit with all files.
-func parseCommitPlan(output string, stagedFiles []string) CommitPlan {
+func parseCommitPlan(output string, stagedFiles []string) commitPlan {
 	output = cleanOutput(output)
 
-	var plan CommitPlan
+	var plan commitPlan
 	if err := json.Unmarshal([]byte(output), &plan); err != nil {
 		return fallbackPlan(output, stagedFiles)
 	}
@@ -44,13 +44,13 @@ func parseCommitPlan(output string, stagedFiles []string) CommitPlan {
 }
 
 // fallbackPlan creates a single-commit plan using raw output as message.
-func fallbackPlan(rawMessage string, stagedFiles []string) CommitPlan {
+func fallbackPlan(rawMessage string, stagedFiles []string) commitPlan {
 	msg := strings.TrimSpace(rawMessage)
 	if msg == "" {
 		msg = "chore: update files"
 	}
-	return CommitPlan{
-		Commits: []CommitEntry{
+	return commitPlan{
+		Commits: []commitEntry{
 			{Message: msg, Files: stagedFiles},
 		},
 	}
@@ -59,7 +59,7 @@ func fallbackPlan(rawMessage string, stagedFiles []string) CommitPlan {
 // validatePlan checks that all plan files exist in staged changes and
 // all staged files appear in exactly one commit or excluded.
 // Returns warnings and a corrected plan.
-func validatePlan(plan CommitPlan, stagedFiles []string) (CommitPlan, []string) {
+func validatePlan(plan commitPlan, stagedFiles []string) (commitPlan, []string) {
 	staged := make(map[string]bool, len(stagedFiles))
 	for _, f := range stagedFiles {
 		staged[f] = true
@@ -102,7 +102,7 @@ func validatePlan(plan CommitPlan, stagedFiles []string) (CommitPlan, []string) 
 	}
 
 	// Remove empty commits
-	var nonEmpty []CommitEntry
+	var nonEmpty []commitEntry
 	for _, c := range plan.Commits {
 		if len(c.Files) > 0 {
 			nonEmpty = append(nonEmpty, c)
@@ -113,8 +113,8 @@ func validatePlan(plan CommitPlan, stagedFiles []string) (CommitPlan, []string) 
 	return plan, warnings
 }
 
-// serializePlanToMarkdown converts a CommitPlan to an editable markdown format.
-func serializePlanToMarkdown(plan CommitPlan) string {
+// serializePlanToMarkdown converts a commitPlan to an editable markdown format.
+func serializePlanToMarkdown(plan commitPlan) string {
 	var sb strings.Builder
 	for i, c := range plan.Commits {
 		fmt.Fprintf(&sb, "## Commit %d\n\n", i+1)
@@ -134,9 +134,9 @@ func serializePlanToMarkdown(plan CommitPlan) string {
 	return sb.String()
 }
 
-// parsePlanFromMarkdown parses the markdown format back into a CommitPlan.
-func parsePlanFromMarkdown(text string) (CommitPlan, error) {
-	var plan CommitPlan
+// parsePlanFromMarkdown parses the markdown format back into a commitPlan.
+func parsePlanFromMarkdown(text string) (commitPlan, error) {
+	var plan commitPlan
 	sections := strings.Split(text, "## ")
 
 	for _, section := range sections {
@@ -156,9 +156,9 @@ func parsePlanFromMarkdown(text string) (CommitPlan, error) {
 				if idx := strings.LastIndex(line, " ("); idx > 0 {
 					file := line[:idx]
 					reason := strings.TrimSuffix(line[idx+2:], ")")
-					plan.Excluded = append(plan.Excluded, ExcludedFile{File: file, Reason: reason})
+					plan.Excluded = append(plan.Excluded, excludedFile{File: file, Reason: reason})
 				} else {
-					plan.Excluded = append(plan.Excluded, ExcludedFile{File: line, Reason: "excluded by user"})
+					plan.Excluded = append(plan.Excluded, excludedFile{File: line, Reason: "excluded by user"})
 				}
 			}
 			continue
@@ -169,7 +169,7 @@ func parsePlanFromMarkdown(text string) (CommitPlan, error) {
 		}
 
 		lines := strings.Split(section, "\n")
-		var commit CommitEntry
+		var commit commitEntry
 		inFiles := false
 		for _, line := range lines[1:] {
 			line = strings.TrimSpace(line)
@@ -194,7 +194,7 @@ func parsePlanFromMarkdown(text string) (CommitPlan, error) {
 }
 
 // editPlanInTerminal opens $EDITOR with the plan in markdown format.
-func editPlanInTerminal(plan CommitPlan) (CommitPlan, error) {
+func editPlanInTerminal(plan commitPlan) (commitPlan, error) {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		editor = "vi"

--- a/internal/generate/commit_plan_test.go
+++ b/internal/generate/commit_plan_test.go
@@ -69,8 +69,8 @@ func TestParseCommitPlan_MarkdownFences(t *testing.T) {
 }
 
 func TestValidatePlan_UnknownFile(t *testing.T) {
-	plan := CommitPlan{
-		Commits: []CommitEntry{
+	plan := commitPlan{
+		Commits: []commitEntry{
 			{Message: "feat: x", Files: []string{"real.go", "ghost.go"}},
 		},
 	}
@@ -86,8 +86,8 @@ func TestValidatePlan_UnknownFile(t *testing.T) {
 }
 
 func TestValidatePlan_MissingFile(t *testing.T) {
-	plan := CommitPlan{
-		Commits: []CommitEntry{
+	plan := commitPlan{
+		Commits: []commitEntry{
 			{Message: "feat: x", Files: []string{"a.go"}},
 		},
 	}
@@ -146,12 +146,12 @@ func TestTruncateDiff_Empty(t *testing.T) {
 }
 
 func TestSerializeAndParsePlanRoundtrip(t *testing.T) {
-	plan := CommitPlan{
-		Commits: []CommitEntry{
+	plan := commitPlan{
+		Commits: []commitEntry{
 			{Message: "feat: add auth", Files: []string{"auth.go", "auth_test.go"}},
 			{Message: "fix: typo in docs", Files: []string{"README.md"}},
 		},
-		Excluded: []ExcludedFile{
+		Excluded: []excludedFile{
 			{File: ".env", Reason: "Contains secrets"},
 		},
 	}

--- a/internal/generate/commit_view.go
+++ b/internal/generate/commit_view.go
@@ -30,7 +30,7 @@ var (
 )
 
 // View renders the current state of the commit TUI.
-func (m CommitModel) View() string {
+func (m commitModel) View() string {
 	switch m.phase {
 	case phaseStagingFiles:
 		return m.viewStaging()
@@ -46,15 +46,15 @@ func (m CommitModel) View() string {
 	return ""
 }
 
-func (m CommitModel) viewStaging() string {
+func (m commitModel) viewStaging() string {
 	return m.spinner.View() + " Staging changes...\n"
 }
 
-func (m CommitModel) viewAnalyzing() string {
+func (m commitModel) viewAnalyzing() string {
 	return m.spinner.View() + " Analyzing changes...\n"
 }
 
-func (m CommitModel) viewPlan() string {
+func (m commitModel) viewPlan() string {
 	var sb strings.Builder
 	statusMap := parseNameStatus(m.nameStatus)
 
@@ -100,7 +100,7 @@ func (m CommitModel) viewPlan() string {
 	return sb.String()
 }
 
-func (m CommitModel) viewExecuting() string {
+func (m commitModel) viewExecuting() string {
 	var sb strings.Builder
 	sb.WriteString(commitTitleStyle.Render("Committing...") + "\n\n")
 
@@ -126,7 +126,7 @@ func (m CommitModel) viewExecuting() string {
 	return sb.String()
 }
 
-func (m CommitModel) viewDone() string {
+func (m commitModel) viewDone() string {
 	var sb strings.Builder
 
 	if m.err != nil {

--- a/internal/generate/embed.go
+++ b/internal/generate/embed.go
@@ -1,3 +1,6 @@
+// Package generate implements the `devpilot commit` and `devpilot readme`
+// commands, which shell out to `claude --print` to author commit messages
+// and README files.
 package generate
 
 import "embed"

--- a/internal/generate/readme.go
+++ b/internal/generate/readme.go
@@ -24,8 +24,8 @@ func buildReadmePrompt(existingReadme string) (string, error) {
 	return buf.String(), err
 }
 
-// RunReadme generates a README by letting Claude explore the project with tools.
-func RunReadme(ctx context.Context, model string, dryRun bool) error {
+// runReadme generates a README by letting Claude explore the project with tools.
+func runReadme(ctx context.Context, model string, dryRun bool) error {
 	dir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -42,7 +42,7 @@ func RunReadme(ctx context.Context, model string, dryRun bool) error {
 	}
 
 	fmt.Println("Generating README (exploring project)...")
-	content, err := GenerateWithTools(ctx, prompt, model)
+	content, err := runWithTools(ctx, prompt, model)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func RunReadme(ctx context.Context, model string, dryRun bool) error {
 		return nil
 	}
 
-	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content+"\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content+"\n"), 0o644); err != nil {
 		return err
 	}
 	fmt.Println("Saved to README.md")


### PR DESCRIPTION
## Summary
- Add package doc comment on `internal/generate`.
- Drop `Generate` stuttering: unexport internal-only symbols (`Generate`/`GenerateWithTools` -> `run`/`runWithTools`, `RunCommit`/`RunReadme` -> `runCommit`/`runReadme`, `CommitModel`/`NewCommitModel`/`CommitPlan`/`CommitEntry`/`ExcludedFile` -> lowercase equivalents). Only `RegisterCommands` stays exported (used by `cmd/devpilot`) and now has a doc comment.
- Use `0o644` octal literal style in `readme.go`.

No behavior changes. Bubble Tea patterns in `commit_model.go` / `commit_view.go` preserved (interface methods `Init`/`Update`/`View` remain exported).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/generate/...`
- [x] `make test`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)