### PR TITLE
docs(readme): add npx skills add install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@
 
 ### Installation
 
+**Just want the skills?** Install the whole catalog into any project with one command — no devpilot CLI required:
+
+```bash
+npx skills add siyuqian/devpilot
+```
+
+This drops the skills into `.claude/skills/` so Claude Code can pick them up immediately. Use the devpilot CLI below if you also want the Gmail / Slack / Trello helpers.
+
 **From release:**
 ```bash
 curl -sSL https://raw.githubusercontent.com/SiyuQian/devpilot/main/install.sh | sh


### PR DESCRIPTION
## Summary
- Add an `npx skills add siyuqian/devpilot` quick-install section at the top of the Installation block, positioned as the fast path for users who only want the skill catalog.
- Keep the existing release / source install paths intact for anyone who also wants the Go CLI (Gmail / Slack / Trello helpers).

## Test plan
- [x] Render README on GitHub and confirm the new block sits cleanly above the release install instructions.
- [x] Verify `npx skills add siyuqian/devpilot` actually pulls the catalog into `.claude/skills/` as advertised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)