### PR TITLE
fix(skillmgr): reject traversal and separators in skill install paths

### DIFF
--- a/internal/skillmgr/install.go
+++ b/internal/skillmgr/install.go
@@ -4,16 +4,30 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // InstallSkill writes skill files into <baseDir>/<skillName>/.
 // baseDir is the absolute path to the skills directory (e.g., ".claude/skills" or "~/.claude/skills").
 // Existing files are silently overwritten.
+//
+// Both skillName and each SkillFile.Path can originate from the remote
+// skills/index.json, so the caller cannot assume they are trusted. Every
+// input is validated to prevent a malicious catalog from writing outside
+// skillDir via absolute paths or "../" segments.
 func InstallSkill(baseDir, skillName string, files []SkillFile) error {
+	if err := validateSkillName(skillName); err != nil {
+		return err
+	}
+
 	skillDir := filepath.Join(baseDir, skillName)
+	cleanSkillDir := filepath.Clean(skillDir)
 
 	for _, f := range files {
-		target := filepath.Join(skillDir, filepath.FromSlash(f.Path))
+		target, err := resolveSkillFilePath(cleanSkillDir, f.Path)
+		if err != nil {
+			return err
+		}
 		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 			return fmt.Errorf("creating directory for %s: %w", f.Path, err)
 		}
@@ -22,4 +36,44 @@ func InstallSkill(baseDir, skillName string, files []SkillFile) error {
 		}
 	}
 	return nil
+}
+
+func validateSkillName(skillName string) error {
+	if skillName == "" {
+		return fmt.Errorf("invalid skillName %q: must not be empty", skillName)
+	}
+	if skillName == "." || skillName == ".." {
+		return fmt.Errorf("invalid skillName %q: must not be %q", skillName, skillName)
+	}
+	if strings.ContainsRune(skillName, '/') || strings.ContainsRune(skillName, '\\') ||
+		strings.ContainsRune(skillName, filepath.Separator) {
+		return fmt.Errorf("invalid skillName %q: must not contain path separators", skillName)
+	}
+	if filepath.IsAbs(skillName) {
+		return fmt.Errorf("invalid skillName %q: must not be an absolute path", skillName)
+	}
+	return nil
+}
+
+func resolveSkillFilePath(cleanSkillDir, filePath string) (string, error) {
+	if filePath == "" {
+		return "", fmt.Errorf("invalid file path %q: must not be empty", filePath)
+	}
+	// filepath.Join silently strips a leading separator, so "/etc/passwd"
+	// would land under skillDir as "etc/passwd". Reject absolutes first.
+	converted := filepath.FromSlash(filePath)
+	if filepath.IsAbs(filePath) || filepath.IsAbs(converted) || strings.HasPrefix(filePath, "/") {
+		return "", fmt.Errorf("invalid file path %q: must not be absolute", filePath)
+	}
+	target := filepath.Join(cleanSkillDir, converted)
+	cleaned := filepath.Clean(target)
+	// The "+ Separator" prefix check prevents "/a/skilldir-evil" from
+	// matching "/a/skilldir" as a descendant.
+	if cleaned != cleanSkillDir && !strings.HasPrefix(cleaned, cleanSkillDir+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid file path %q: escapes skill directory", filePath)
+	}
+	if cleaned == cleanSkillDir {
+		return "", fmt.Errorf("invalid file path %q: resolves to skill directory itself", filePath)
+	}
+	return target, nil
 }

--- a/internal/skillmgr/install_test.go
+++ b/internal/skillmgr/install_test.go
@@ -1,0 +1,219 @@
+package skillmgr
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestInstallSkillPaths covers path-traversal and input-validation behavior
+// of InstallSkill. Happy paths verify expected files land inside skillDir;
+// rejection paths verify a descriptive error is returned AND the filesystem
+// under baseDir contains no files outside skillDir.
+func TestInstallSkillPaths(t *testing.T) {
+	type wantFile struct {
+		relPath string // path under baseDir (forward slashes)
+		content string
+	}
+
+	cases := []struct {
+		name       string
+		skillName  string
+		files      []SkillFile
+		wantErr    bool
+		wantErrHas string // substring the error must contain (when wantErr)
+		wantFiles  []wantFile
+		skipOnWin  bool // skip on Windows when test depends on unix path semantics
+		onlyOnWin  bool
+	}{
+		{
+			name:      "happy path single file",
+			skillName: "pm",
+			files: []SkillFile{
+				{Path: "SKILL.md", Content: []byte("top")},
+			},
+			wantFiles: []wantFile{
+				{relPath: "pm/SKILL.md", content: "top"},
+			},
+		},
+		{
+			name:      "happy path nested file",
+			skillName: "pm",
+			files: []SkillFile{
+				{Path: "SKILL.md", Content: []byte("top")},
+				{Path: "subdir/SKILL.md", Content: []byte("nested")},
+			},
+			wantFiles: []wantFile{
+				{relPath: "pm/SKILL.md", content: "top"},
+				{relPath: "pm/subdir/SKILL.md", content: "nested"},
+			},
+		},
+		{
+			name:       "empty skill name",
+			skillName:  "",
+			files:      []SkillFile{{Path: "SKILL.md", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "skillName",
+		},
+		{
+			name:       "dot skill name",
+			skillName:  ".",
+			files:      []SkillFile{{Path: "SKILL.md", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "skillName",
+		},
+		{
+			name:       "dotdot skill name",
+			skillName:  "..",
+			files:      []SkillFile{{Path: "SKILL.md", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "skillName",
+		},
+		{
+			name:       "skill name with forward slash",
+			skillName:  "foo/bar",
+			files:      []SkillFile{{Path: "SKILL.md", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "skillName",
+		},
+		{
+			name:       "skill name with parent traversal",
+			skillName:  "../evil",
+			files:      []SkillFile{{Path: "SKILL.md", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "skillName",
+		},
+		{
+			name:       "skill name with backslash",
+			skillName:  `foo\bar`,
+			files:      []SkillFile{{Path: "SKILL.md", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "skillName",
+		},
+		{
+			name:       "absolute skill name",
+			skillName:  "/etc/passwd",
+			files:      []SkillFile{{Path: "SKILL.md", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "skillName",
+			skipOnWin:  true,
+		},
+		{
+			name:       "file path with parent traversal prefix",
+			skillName:  "pm",
+			files:      []SkillFile{{Path: "../escape.md", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "file path",
+		},
+		{
+			name:       "file path with nested traversal that escapes after clean",
+			skillName:  "pm",
+			files:      []SkillFile{{Path: "foo/../../bar", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "file path",
+		},
+		{
+			name:       "absolute file path",
+			skillName:  "pm",
+			files:      []SkillFile{{Path: "/etc/passwd", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "file path",
+			skipOnWin:  true,
+		},
+		{
+			name:       "empty file path",
+			skillName:  "pm",
+			files:      []SkillFile{{Path: "", Content: []byte("x")}},
+			wantErr:    true,
+			wantErrHas: "file path",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipOnWin && runtime.GOOS == "windows" {
+				t.Skip("unix-specific path semantics")
+			}
+			if tc.onlyOnWin && runtime.GOOS != "windows" {
+				t.Skip("windows-specific path semantics")
+			}
+
+			baseDir := t.TempDir()
+			err := InstallSkill(baseDir, tc.skillName, tc.files)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("InstallSkill: expected error, got nil")
+				}
+				if tc.wantErrHas != "" && !strings.Contains(err.Error(), tc.wantErrHas) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrHas)
+				}
+				assertNoFilesOutsideSkillDir(t, baseDir, tc.skillName)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("InstallSkill: %v", err)
+			}
+			for _, wf := range tc.wantFiles {
+				parts := strings.Split(wf.relPath, "/")
+				full := filepath.Join(append([]string{baseDir}, parts...)...)
+				data, rerr := os.ReadFile(full)
+				if rerr != nil {
+					t.Fatalf("reading %s: %v", full, rerr)
+				}
+				if string(data) != wf.content {
+					t.Errorf("%s = %q, want %q", wf.relPath, string(data), wf.content)
+				}
+			}
+			assertOnlyFilesUnder(t, baseDir, filepath.Join(baseDir, tc.skillName))
+		})
+	}
+}
+
+// assertNoFilesOutsideSkillDir walks baseDir and fails if any regular file
+// exists outside filepath.Join(baseDir, skillName). The skillDir itself may
+// or may not exist (rejection paths typically don't create it).
+func assertNoFilesOutsideSkillDir(t *testing.T, baseDir, skillName string) {
+	t.Helper()
+	skillDir := filepath.Clean(filepath.Join(baseDir, skillName))
+	_ = filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		cleaned := filepath.Clean(path)
+		if cleaned == skillDir || strings.HasPrefix(cleaned, skillDir+string(os.PathSeparator)) {
+			return nil
+		}
+		t.Errorf("unexpected file written outside skillDir: %s", path)
+		return nil
+	})
+}
+
+// assertOnlyFilesUnder walks baseDir and fails if any regular file exists
+// outside skillDir. Used on happy paths to confirm no accidental escape.
+func assertOnlyFilesUnder(t *testing.T, baseDir, skillDir string) {
+	t.Helper()
+	skillDir = filepath.Clean(skillDir)
+	_ = filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		cleaned := filepath.Clean(path)
+		if cleaned == skillDir || strings.HasPrefix(cleaned, skillDir+string(os.PathSeparator)) {
+			return nil
+		}
+		t.Errorf("file written outside skillDir: %s", path)
+		return nil
+	})
+}

--- a/internal/skillmgr/install_test.go
+++ b/internal/skillmgr/install_test.go
@@ -133,7 +133,6 @@ func TestInstallSkillPaths(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.skipOnWin && runtime.GOOS == "windows" {
 				t.Skip("unix-specific path semantics")


### PR DESCRIPTION
## Description

**Bug:** `InstallSkill` trusted `skillName` and `SkillFile.Path` without validation, even though both originate from a remote `skills/index.json` fetched from GitHub. A compromised (or forked) catalog entry could use `..` segments, absolute paths, or path separators inside `skillName` to make `InstallSkill` write files anywhere the invoking user can write — including `~/.claude/settings.json` or `~/.ssh/authorized_keys` when running `devpilot skill add --all --level user`.

**Cause:** `install.go` computed `target := filepath.Join(skillDir, filepath.FromSlash(f.Path))` and wrote directly to it. `filepath.Join` silently strips a leading separator (so `"/etc/passwd"` maps under `skillDir`) but does nothing about `..` segments that escape after `Clean`. `skillName` was never inspected at all.

**Fix:** Two new helpers in `internal/skillmgr/install.go`:
- `validateSkillName` rejects empty, `.`, `..`, any path separator (`/`, `\`, or `filepath.Separator`), and absolute paths.
- `resolveSkillFilePath` rejects empty, absolute (checked both before and after `FromSlash` to catch Windows drive-letter absolutes and unix-style absolutes respectively), and any target that — after `filepath.Clean` — is not equal to `cleanSkillDir` or under `cleanSkillDir + string(os.PathSeparator)`. The `+ Separator` prefix check prevents a sibling like `skilldir-evil` from matching `skilldir` as a descendant.

Every error names which input was invalid (`skillName` vs `file path`) and includes the offending value so CLI users can diagnose catalog issues.

## Review Guide

**Start here:** `internal/skillmgr/install.go` — the new `validateSkillName` and `resolveSkillFilePath` helpers plus the call sites inside `InstallSkill`.

Then `internal/skillmgr/install_test.go` — 13 table-driven cases covering two happy paths (single and nested file) and every rejection class: empty / `.` / `..` / forward-slash / backslash / absolute `skillName`, plus `../` prefix, nested `foo/../../bar` escape, absolute, and empty `SkillFile.Path`. Rejection cases walk `baseDir` via `filepath.WalkDir` and fail if any file landed outside `skillDir`, so this is a true traversal test — not just an error-message assertion.

Non-obvious calls:
- `InstallSkill`'s signature is unchanged; both existing callers (`runSingleInstall` and `installCatalogEntry` in `commands.go`) get the new validation for free.
- The absolute-path check runs on both `filePath` and `filepath.FromSlash(filePath)`. This is redundant on unix but necessary on Windows — see the inline comment.

Out-of-scope (flag for follow-up, not fixed here to keep the PR to one issue): `ParseIndex` in `index.go` filters only non-empty `Name`; a second layer of rejection there would produce nicer errors for `skill add --all` instead of the current per-entry `FAIL` with the raw wrapped error. Defensive duplication, not a functional gap.

## Verification

- [x] `make test` passes (`internal/skillmgr` 2.5s; all other packages green)
- [x] `make lint` passes (`0 issues`)
- [ ] Bug no longer reproduces: craft a local `index.json` with a malicious entry (e.g. `{"name":"../evil","files":["SKILL.md"]}` or `{"name":"pm","files":["../../etc/passwd"]}`), point `rawBaseURL` at a local httptest server, run `devpilot skill add pm`, and confirm the command errors out with a message naming the offending input and no file is written outside the expected skill directory.
- [x] No regressions in related functionality (existing `TestInstallSkill*` in `github_test.go` still pass)

## For Reviewers (human)

- [ ] Self-review of the code

Closes #74