### PR TITLE
fix(generate): fall back to single commit when validation empties plan

### DIFF
--- a/internal/generate/commit_plan.go
+++ b/internal/generate/commit_plan.go
@@ -110,6 +110,17 @@ func validatePlan(plan commitPlan, stagedFiles []string) (commitPlan, []string) 
 	}
 	plan.Commits = nonEmpty
 
+	// If validation removed every commit, fall back to a single commit so
+	// downstream consumers (e.g. commitModel.executeCommit) keep their
+	// "plan.Commits is non-empty" invariant. This can happen when every
+	// commit references only unknown files and every staged file is
+	// already in Excluded.
+	if len(plan.Commits) == 0 {
+		fallback := fallbackPlan("", stagedFiles)
+		plan.Commits = fallback.Commits
+		warnings = append(warnings, "plan validation removed all commits; falling back to a single commit")
+	}
+
 	return plan, warnings
 }
 

--- a/internal/generate/commit_plan_test.go
+++ b/internal/generate/commit_plan_test.go
@@ -108,6 +108,79 @@ func TestValidatePlan_MissingFile(t *testing.T) {
 	}
 }
 
+func TestValidatePlan_FallbackOnEmpty(t *testing.T) {
+	cases := []struct {
+		name        string
+		plan        commitPlan
+		staged      []string
+		wantFiles   []string
+		wantMessage string
+	}{
+		{
+			name: "all commit files unknown and only staged file excluded",
+			plan: commitPlan{
+				Commits: []commitEntry{
+					{Message: "feat: ghost", Files: []string{"ghost.go"}},
+				},
+				Excluded: []excludedFile{
+					{File: "real.go", Reason: "Contains secrets"},
+				},
+			},
+			staged:      []string{"real.go"},
+			wantFiles:   []string{"real.go"},
+			wantMessage: "chore: update files",
+		},
+		{
+			name: "multiple commits all reference unknown files and all staged files excluded",
+			plan: commitPlan{
+				Commits: []commitEntry{
+					{Message: "feat: a", Files: []string{"ghost1.go"}},
+					{Message: "feat: b", Files: []string{"ghost2.go"}},
+				},
+				Excluded: []excludedFile{
+					{File: "x.go", Reason: "secret"},
+					{File: "y.go", Reason: "secret"},
+				},
+			},
+			staged:      []string{"x.go", "y.go"},
+			wantFiles:   []string{"x.go", "y.go"},
+			wantMessage: "chore: update files",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			validated, warnings := validatePlan(tc.plan, tc.staged)
+
+			if len(validated.Commits) != 1 {
+				t.Fatalf("expected exactly 1 fallback commit, got %d", len(validated.Commits))
+			}
+			if validated.Commits[0].Message != tc.wantMessage {
+				t.Errorf("expected fallback message %q, got %q", tc.wantMessage, validated.Commits[0].Message)
+			}
+			if len(validated.Commits[0].Files) != len(tc.wantFiles) {
+				t.Fatalf("expected %d files in fallback commit, got %d", len(tc.wantFiles), len(validated.Commits[0].Files))
+			}
+			for i, f := range tc.wantFiles {
+				if validated.Commits[0].Files[i] != f {
+					t.Errorf("file[%d]: expected %q, got %q", i, f, validated.Commits[0].Files[i])
+				}
+			}
+
+			foundFallbackWarning := false
+			for _, w := range warnings {
+				if strings.Contains(w, "falling back") || strings.Contains(w, "fallback") {
+					foundFallbackWarning = true
+					break
+				}
+			}
+			if !foundFallbackWarning {
+				t.Errorf("expected a warning mentioning fallback, got %v", warnings)
+			}
+		})
+	}
+}
+
 func TestTruncateDiff_SmallDiff(t *testing.T) {
 	diff := "diff --git a/file.go b/file.go\n--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new\n"
 	result := truncateDiff(diff)


### PR DESCRIPTION
## Description

**Bug:** `validatePlan` in `internal/generate/commit_plan.go` could return a `commitPlan` with `len(Commits) == 0`. `commitModel.startExecution` (`internal/generate/commit_model.go:233-243`) then called `m.executeCommit(0)`, which evaluates `m.plan.Commits[0]` at `commit_model.go:307` and panicked the TUI.

**Cause:** Reachable scenario in `validatePlan`:

1. Each plan commit's `Files` is filtered to only-staged files (`commit_plan.go:77-88`). If every file in a commit is unknown, that commit's `Files` becomes `nil`.
2. Uncovered staged files are appended to the *last* commit (`:91-102`). If every staged file is in `Excluded`, no missing files exist, so this step adds nothing.
3. The final filter at `:104-111` drops zero-file commits. If every commit was emptied in step 1, the result is `[]`.

The author of `commit_model.executeCommit` was reasonably entitled to assume `Commits` was non-empty — the contract violation is at `validatePlan`'s exit, not at the consumer.

**Fix:** After the existing nonEmpty filter, if `plan.Commits` is empty, repopulate it via the existing `fallbackPlan(\"\", stagedFiles)` helper (which already handles the \"give up and use a single commit\" pattern in `parseCommitPlan`). Append a warning so the user sees the fallback was triggered.

Deliberately *not* changing `executeCommit`. The bug was the contract violation in `validatePlan`; once the contract is restored, defending against an impossible scenario in the consumer would be exactly the kind of \"error handling for scenarios that can't happen\" CLAUDE.md asks against.

## Review Guide

**Start here:** `internal/generate/commit_plan.go:113-122` — the new fallback block at the end of `validatePlan`. Reuses `fallbackPlan` rather than duplicating its body. Single warning message.

Then `internal/generate/commit_plan_test.go` — `TestValidatePlan_FallbackOnEmpty`, table-driven with two cases that both reduce to empty after validation:
- One commit referencing only unknown files, only staged file in `Excluded`.
- Multi-commit variant where all referenced files are unknown and all staged files are excluded.

Both assert exactly one fallback commit, the expected files, and the fallback warning.

Out-of-scope (flagged for follow-up): `commit_plan.go:99` does `last := len(plan.Commits) - 1` without a guard. With the current `parseCommitPlan` always returning ≥1 commit on entry, this is fine, but if `validatePlan` ever became reachable from a different caller with an empty plan input, it would index `[-1]`. A two-line guard would harden it; not in scope here.

## Verification

- [x] `make test` passes (`internal/generate` 0.2s; all packages green)
- [x] `make lint` passes (`0 issues`)
- [ ] Bug no longer reproduces: revert the new block in `validatePlan`, run `go test -run TestValidatePlan_FallbackOnEmpty -timeout 5s ./internal/generate/`. Without the fix the test panics on `validated.Commits[0]` access; with the fix it passes in <1s.
- [x] No regressions: existing `TestValidatePlan_UnknownFile` and `TestValidatePlan_MissingFile` still pass.

## For Reviewers (human)

- [ ] Self-review of the code

Closes #78