### PR TITLE
feat(skills): require per-issue git worktree in resolve-issues

### DIFF
--- a/skills/devpilot-resolve-issues/SKILL.md
+++ b/skills/devpilot-resolve-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devpilot-resolve-issues
-description: Use when the user wants to resolve, fix, work through, or burn down open GitHub issues in a repository — "fix all the issues", "resolve these tickets", "work through the repo-scan issues", "clear the backlog", "fix issue #42", "/resolve-issues", "解决所有issue", "修复这些issue", "处理issue backlog". Runs as a loop over matching issues until none remain. Do NOT use for creating issues (use devpilot-scanning-repos) or for reviewing a PR the user already has open (use devpilot-pr-review).
+description: Use when the user wants to resolve, fix, work through, or burn down open GitHub issues in a repository — "fix all the issues", "resolve these tickets", "work through the repo-scan issues", "clear the backlog", "fix issue #42", "/resolve-issues", "解决所有issue", "修复这些issue", "处理issue backlog". Runs as a loop over matching issues until none remain; each REAL issue is fixed in its own `git worktree` so the main checkout stays untouched. Do NOT use for creating issues (use devpilot-scanning-repos) or for reviewing a PR the user already has open (use devpilot-pr-review).
 ---
 
 # Resolve GitHub Issues (Loop Until Done)
@@ -9,6 +9,7 @@ description: Use when the user wants to resolve, fix, work through, or burn down
 
 | File | When to load |
 |---|---|
+| `references/worktree-management.md` | Step 0 (preflight prune) and Step 5 (per-issue create) and the cleanup path — path scheme, create / remove, failure modes. |
 | `references/verdict-comments.md` | Step 4 — exact comment bodies for the three verdicts. |
 | `references/task-decomposition.md` | Step 6a — split a REAL issue into 1–3 tasks. |
 | `references/subagent-spec.md` | Step 6b — the spec handed to each per-task implementer subagent. |
@@ -18,11 +19,13 @@ description: Use when the user wants to resolve, fix, work through, or burn down
 
 End-to-end loop that takes open GitHub issues from triage to reviewed PR, one at a time, until the filter returns no matches. Each issue ends in exactly one of three states: **closed with reason** (false positive), **escalated with questions** (needs human), or **reviewed PR opened** (real). Nothing else is a valid terminal state.
 
-For a REAL issue, the fix itself follows the `superpowers:subagent-driven-development` pattern: decompose into a small number of tasks, dispatch one implementer subagent per task, run `superpowers:requesting-code-review` after each task. The branch and PR are still per-issue (one PR per issue, always), but the work that lands on that branch is gated task-by-task.
+Every REAL issue is fixed in its **own `git worktree`**, not in the main checkout. The main checkout stays on the default branch, untouched, so the user can keep working in it while the loop runs. The fix branch and all its commits live in a sibling directory at `<repo-root>.worktrees/issue-<N>-<slug>/`. See `references/worktree-management.md` for the lifecycle.
+
+For a REAL issue, the fix itself follows the `superpowers:subagent-driven-development` pattern: decompose into a small number of tasks, dispatch one implementer subagent per task, run `superpowers:requesting-code-review` after each task. The worktree, branch, and PR are still per-issue (one worktree, one branch, one PR per issue, always), but the work that lands on that branch is gated task-by-task.
 
 The per-task code review is the **only** review run by this loop. There is no separate published GitHub review — the per-task gate already covered code quality, architecture, testing, requirements, and production readiness on every commit that landed. The PR is opened ready-for-review for human eyes, with `Closes #N` linking back to the issue.
 
-**Core principle:** No fix without a verdict, no task without a fresh implementer, no task complete without code review. Anything else breaks the loop and accrues silent debt.
+**Core principle:** No fix without a verdict, no fix outside a per-issue worktree, no task without a fresh implementer, no task complete without code review. Anything else breaks the loop and accrues silent debt.
 
 ## When NOT to Use
 
@@ -45,7 +48,7 @@ digraph resolve_loop {
   "Verdict" [shape=diamond];
   "Close wontfix + reason" [shape=box];
   "Comment with blockers" [shape=box];
-  "Branch fix/issue-N-slug" [shape=box];
+  "Create worktree + branch (cd into it)" [shape=box];
   "Decompose into 1-3 tasks (TodoWrite)" [shape=box];
   "Next task?" [shape=diamond];
   "Dispatch implementer subagent (one task)" [shape=box];
@@ -56,10 +59,11 @@ digraph resolve_loop {
   "Review clean?" [shape=diamond];
   "Re-dispatch implementer w/ review feedback" [shape=box];
   "Mark task done" [shape=box];
-  "Final verify locally" [shape=box];
+  "Final verify in worktree" [shape=box];
   "Passed?" [shape=diamond];
-  "Escalate NEEDS-HUMAN" [shape=box];
+  "Push draft + escalate NEEDS-HUMAN" [shape=box];
   "devpilot-pr-creator (Closes #N)" [shape=box];
+  "Remove worktree, return to main checkout" [shape=box];
 
   "Select next issue" -> "None?";
   "None?" -> "Summarize, stop" [label="yes"];
@@ -73,28 +77,29 @@ digraph resolve_loop {
   "Close wontfix + reason" -> "Select next issue";
   "Verdict" -> "Comment with blockers" [label="NEEDS-HUMAN"];
   "Comment with blockers" -> "Select next issue";
-  "Verdict" -> "Branch fix/issue-N-slug" [label="REAL"];
-  "Branch fix/issue-N-slug" -> "Decompose into 1-3 tasks (TodoWrite)";
+  "Verdict" -> "Create worktree + branch (cd into it)" [label="REAL"];
+  "Create worktree + branch (cd into it)" -> "Decompose into 1-3 tasks (TodoWrite)";
   "Decompose into 1-3 tasks (TodoWrite)" -> "Next task?";
   "Next task?" -> "Dispatch implementer subagent (one task)" [label="yes"];
   "Dispatch implementer subagent (one task)" -> "Implementer status?";
   "Implementer status?" -> "Provide context, re-dispatch" [label="NEEDS_CONTEXT"];
   "Provide context, re-dispatch" -> "Dispatch implementer subagent (one task)";
   "Implementer status?" -> "Re-dispatch w/ failure or escalate" [label="BLOCKED / verification failed twice"];
-  "Re-dispatch w/ failure or escalate" -> "Escalate NEEDS-HUMAN";
+  "Re-dispatch w/ failure or escalate" -> "Push draft + escalate NEEDS-HUMAN";
   "Implementer status?" -> "Run per-task code review (superpowers:requesting-code-review)" [label="DONE / DONE_WITH_CONCERNS"];
   "Run per-task code review (superpowers:requesting-code-review)" -> "Review clean?";
   "Review clean?" -> "Re-dispatch implementer w/ review feedback" [label="no, ≤2 rounds"];
   "Re-dispatch implementer w/ review feedback" -> "Run per-task code review (superpowers:requesting-code-review)";
-  "Review clean?" -> "Escalate NEEDS-HUMAN" [label="round 3 still failing"];
+  "Review clean?" -> "Push draft + escalate NEEDS-HUMAN" [label="round 3 still failing"];
   "Review clean?" -> "Mark task done" [label="yes"];
   "Mark task done" -> "Next task?";
-  "Next task?" -> "Final verify locally" [label="no, all done"];
-  "Final verify locally" -> "Passed?";
+  "Next task?" -> "Final verify in worktree" [label="no, all done"];
+  "Final verify in worktree" -> "Passed?";
   "Passed?" -> "devpilot-pr-creator (Closes #N)" [label="yes"];
-  "Passed?" -> "Escalate NEEDS-HUMAN" [label="no"];
-  "Escalate NEEDS-HUMAN" -> "Select next issue";
-  "devpilot-pr-creator (Closes #N)" -> "Select next issue";
+  "Passed?" -> "Push draft + escalate NEEDS-HUMAN" [label="no"];
+  "Push draft + escalate NEEDS-HUMAN" -> "Remove worktree, return to main checkout";
+  "devpilot-pr-creator (Closes #N)" -> "Remove worktree, return to main checkout";
+  "Remove worktree, return to main checkout" -> "Select next issue";
 }
 ```
 
@@ -109,16 +114,22 @@ gh repo view --json nameWithOwner,defaultBranchRef   # identify repo + default b
 gh auth status                                        # must be logged in
 gh api user --jq .login                               # who is "me"?
 git rev-parse --abbrev-ref HEAD                       # starting branch
+git rev-parse --show-toplevel                         # main checkout root — save as $MAIN
 git status --porcelain                                # working tree clean?
+git worktree list                                     # see existing worktrees
+git worktree prune                                    # drop metadata for already-deleted worktree dirs
 ```
 
 **Stop and ask the user if:**
 
-- Working tree has uncommitted changes — commit, stash, or abort. You cannot branch safely otherwise.
+- Working tree has uncommitted changes — commit, stash, or abort. The main checkout must be clean before the loop runs.
 - `gh auth status` is not logged in.
 - The repo has zero matching open issues — confirm the filter before looping on nothing.
+- `git worktree list` shows existing worktrees from a prior run with **unpushed commits**. That is in-progress work, not garbage. See `references/worktree-management.md` → "Step 0 — preflight pruning". Default action: leave it alone, ask the user.
 
 **Establish the filter.** Default: `is:open no:assignee` plus the labels the user cares about (e.g., `repo-scan`, `bug`). If the user said "all issues" but there are >20, confirm the scope before starting. Save the filter — the loop reuses it every iteration.
+
+**Save `$MAIN` (the main checkout root).** Every cleanup step `cd`s back to `$MAIN` to remove the per-issue worktree. The loop's "home" cwd is `$MAIN`; it temporarily moves into a worktree for steps 5–9 of each REAL iteration.
 
 ### 1. Select the next issue
 
@@ -130,7 +141,7 @@ gh issue list \
   --json number,title,body,labels,url,author
 ```
 
-If the result is empty → go to step 11 (summarize & stop).
+If the result is empty → go to step 12 (summarize & stop).
 
 ### 2. Assign to self
 
@@ -161,19 +172,32 @@ Read the full issue body. If the issue was filed by `devpilot-scanning-repos` it
 
 **Do not classify as REAL just to "take a shot."** False positives close in 60 seconds; wrong REAL verdicts spawn implementer subagents that produce useless diffs and poison the PR history.
 
-### 5. Branch for the fix
+### 5. Create the per-issue worktree (and the branch inside it)
+
+**The fix branch lives in its own worktree, never in the main checkout.** This is non-negotiable — see "Hard rules" below and `references/worktree-management.md` for the full rationale and failure-mode handling.
+
+Slug: derive from the issue title — kebab-case, 3–5 ASCII words. Example: issue #42 "Sanitize shell input in cmd/devpilot/run.go" → slug `sanitize-shell-input`, branch `fix/issue-42-sanitize-shell-input`, worktree `<repo-root>.worktrees/issue-42-sanitize-shell-input`.
 
 ```bash
-git switch <default-branch>
-git pull --ff-only
-git switch -c "fix/issue-<num>-<short-slug>"
+# From $MAIN. Refresh default branch, then create worktree + branch in one shot.
+git fetch origin "<default-branch>"
+
+WORKTREE="$MAIN.worktrees/issue-<num>-<slug>"
+BRANCH="fix/issue-<num>-<slug>"
+
+git worktree add -b "$BRANCH" "$WORKTREE" "origin/<default-branch>"
+cd "$WORKTREE"
 ```
 
-Slug: derive from the issue title — kebab-case, 3–5 ASCII words. Example: issue #42 "Sanitize shell input in cmd/devpilot/run.go" → `fix/issue-42-sanitize-shell-input`.
+After `cd "$WORKTREE"`, every subsequent step in this iteration (6 implementers, 6c review, 7 verify, 8 PR, 9 issue comment) runs with `cwd = $WORKTREE`. Subagents you dispatch from here **inherit this cwd**, which is exactly what you want — they see the fix branch's working tree natively, no extra `cd` plumbing required.
+
+**Failure handling** (path already exists, branch already exists, fetch failed): see `references/worktree-management.md` → "Failure modes at create time". Never `--force` past these in the autonomous loop; ask the user instead. A forced create on top of in-progress work is the kind of destructive action that requires explicit confirmation.
 
 ### 6. Fix via per-task implementers + per-task code reviews
 
 This is the heart of the skill. Do NOT fix in the main context. The main context is the orchestrator; coding lives in implementer subagents, gating lives in reviewer subagents.
+
+**Cwd contract for this step:** controller stays at `$WORKTREE`. Each dispatched implementer and reviewer subagent inherits that cwd, so their `git`, file paths, and `make` invocations all naturally apply to the issue's worktree. **Never `cd "$MAIN"` mid-step 6** — that would point your tooling at the default branch's working tree and confuse every subsequent dispatch.
 
 #### 6a. Decompose into tasks
 
@@ -208,7 +232,7 @@ Continue to step 7. Do not skip the final local verify even if every per-task re
 
 ### 7. Final verify — yourself, not any subagent's report
 
-Run the project's verification commands **in the main context** on the fix branch:
+Still at `cwd = $WORKTREE`. Run the project's verification commands **in the main context (controller), in the worktree**, on the fix branch:
 
 ```bash
 make test
@@ -218,24 +242,43 @@ make lint
 Or the project-specific equivalents (`go test ./...`, `pnpm test`, `cargo test`). Trust-but-verify: implementer and reviewer subagents can both misreport — innocently or because a test harness is broken.
 
 - Everything passes → step 8.
-- Anything fails → escalate the issue `NEEDS-HUMAN`: push the branch as a draft, comment on the issue with the failing output and the branch URL, unassign, next issue. The per-task reviews already ate the retry budget; don't burn another round here.
+- Anything fails → escalate the issue `NEEDS-HUMAN`: push the branch as a draft (`git push -u origin "$BRANCH"`), comment on the issue with the failing output and the branch URL, unassign, then proceed to step 10 (worktree cleanup) before the next issue. The per-task reviews already ate the retry budget; don't burn another round here.
 
 ### 8. Create the PR
 
-Invoke `devpilot-pr-creator`. Extra constraints this skill adds on top of that skill:
+Still at `cwd = $WORKTREE`. Invoke `devpilot-pr-creator`. Extra constraints this skill adds on top of that skill:
 
 - The PR body MUST contain `Closes #<issue-num>` on its own line so GitHub auto-closes the issue on merge.
 - The PR title should describe the fix, not repeat the issue number.
 - Base branch = repo default, unless the user specified a different stacking target at preflight.
 - Open the PR ready-for-review (not draft). The per-task code-review gate has already run on every commit; there is no separate published review pass to wait for.
 
+`devpilot-pr-creator` runs `git push -u origin "$BRANCH"` itself; after it returns, the branch is on origin and the worktree's job is done.
+
 ### 9. Post the resolution comment on the issue
 
 Post the **Real → PR opened** comment template from `references/verdict-comments.md` on the issue itself (not only the PR), so subscribers see the resolution trail without having to click into the PR. The issue stays open and assigned to you — `Closes #<num>` in the PR body will close it on merge.
 
-### 10. Return to step 1
+### 10. Cleanup — remove the worktree, return to `$MAIN`
 
-### 11. Final summary
+Reached on three paths: PR opened (step 8 success), final-verify failure escalation (step 7 failure after pushing draft), or mid-fix escalation (BLOCKED / round-3 review / second verification fail, after pushing draft). Never reached on FALSE-POSITIVE / NEEDS-HUMAN — those verdicts never created a worktree.
+
+```bash
+cd "$MAIN"
+git worktree remove "$WORKTREE"     # try plain remove first
+# If it fails on gitignored build artifacts (bin/, node_modules/, target/, etc.):
+#   git -C "$WORKTREE" clean -fdX && git worktree remove "$WORKTREE"
+# --force is the last resort; see references/worktree-management.md → "Cleanup policy".
+git worktree prune
+```
+
+If `git worktree remove` (and `clean -fdX` retry) still fails because of modified or untracked **tracked** files that are NOT on origin, **stop and ask the user.** Don't `--force` past unpushed work — `references/worktree-management.md` → "Cleanup policy" walks the full ladder.
+
+After this step the controller is back at `$MAIN`, the worktree directory is gone, and `git worktree list` no longer shows the issue's entry. Ready for the next iteration.
+
+### 11. Return to step 1
+
+### 12. Final summary
 
 When the loop terminates, print:
 
@@ -281,8 +324,13 @@ The loop ends when **any** of these is true — not before:
 9. **Never open a PR without `Closes #N`.** The issue will stay open forever and the loop will re-pick it.
 10. **Never push to `main` / the default branch.** Always work on `fix/issue-<num>-...`.
 11. **Never fix in the main context.** Implementation lives in implementer subagents; review lives in `superpowers:code-reviewer` subagents. The main context orchestrates only.
+12. **Every REAL issue is fixed in its own `git worktree`, never in the main checkout.** No exceptions: not for "tiny" fixes, not when worktree creation is "annoying", not when "the main checkout is already clean." The main checkout is the user's working environment; the loop never owns it. Worktree create at step 5, cleanup at step 10. See `references/worktree-management.md`.
+13. **One worktree per issue, one branch per worktree, sequential issues.** Reusing a worktree across issues, or creating two worktrees for the same issue, both break the cleanup contract and leak branches. Sequential at the issue level — even though worktrees are physically isolated, this skill processes one issue at a time. Parallelizing across issues is a future change, not a license to skip.
+14. **Never `--force` past a worktree-create or worktree-remove failure in autonomous mode.** Both failure modes (path collision on create, modified/untracked files on remove) usually indicate someone's in-progress work or a real disk problem. Stop and ask the user; `--force` is reserved for cases where you have *verified* (`git status`, `git log origin/$BRANCH..HEAD`) that the work is already on origin.
 
 ## Red flags — STOP and reset
+
+**Meta-rationalization:** almost every entry below is a costume for the same pressure: *"the queue is piling up,"* *"this one is special,"* *"the user is asleep,"* *"it'd be faster."* If your reasoning leans on queue depth, time pressure, or the user's absence to justify deviating from a rule, that's the trap — not the situation. The cost of one rule-violating shortcut is never that one issue; it's that the loop forgets the rule the next time.
 
 | Thought | What's actually happening |
 |---|---|
@@ -301,6 +349,11 @@ The loop ends when **any** of these is true — not before:
 | "The implementer said tests pass, so I don't need to run them at step 7" | Subagents misreport. Run the commands yourself. |
 | "I'll skip `Closes #N` since the PR title mentions the issue" | Title text doesn't autolink. Without the magic word the issue stays open. |
 | "I'll assign and then un-assign later if I don't fix it" | Unassign in the same iteration the verdict demands it (FALSE-POSITIVE / NEEDS-HUMAN). Dangling assignments leak. |
+| "Just one issue this run — I'll skip the worktree dance and branch in the main checkout" | The main checkout is the user's. The loop never owns it. Worktree create is two commands; the cost of skipping is the user's editor / dev server colliding with your fix branch the moment you `cd` away. |
+| "Worktree create failed with 'already exists' — I'll `git worktree remove --force` and retry" | "Already exists" usually means an in-progress branch from a prior run, not garbage. Inspect `git worktree list` and the branch's commits before any `--force`. |
+| "I'll create the worktree but stay in `$MAIN` and pass `-C "$WORKTREE"` to git" | Then every subagent gets the wrong cwd and tries to operate on the main checkout. `cd "$WORKTREE"` once at step 5 and stay there until step 10. |
+| "Cleanup is bookkeeping; I'll batch it at the end of the loop" | A loop that processes 10 issues should never have 10 worktrees alive. Cleanup is per-iteration. Batching cleanup is hoarding state across iterations the loop is not designed to hold. |
+| "`git stash` in the main checkout is the same idea as a worktree" | It is not. Stash leaves HEAD on the fix branch with unrelated work on top — the exact pollution worktrees exist to prevent. |
 
 ## Common mistakes
 
@@ -310,13 +363,16 @@ The loop ends when **any** of these is true — not before:
 - **Marking a task `completed` before the per-task review returned clean.** TodoWrite is the gate; flip it only after the reviewer says so.
 - **Skipping `superpowers:requesting-code-review` for "small" tasks.** There is no "small" exception. The minimum is 1 task + 1 review per REAL issue.
 - **Picking up issues assigned to others.** Even if they look abandoned — leave a comment asking, move on.
-- **Creating a fix branch off a stale default branch.** Always `git pull --ff-only` first.
+- **Creating the worktree off a stale default branch.** Always `git fetch origin <default-branch>` before `git worktree add`.
+- **Forgetting to `cd "$WORKTREE"` after `git worktree add`.** Then every subagent dispatched in step 6 inherits `$MAIN` as cwd, not the worktree, and operates on the wrong tree.
+- **Skipping cleanup at step 10.** The loop is built around per-iteration cleanup. Stale worktrees pile up across iterations and confuse the next preflight.
 - **Letting the loop run over issues the user didn't scope to.** Honor the filter you agreed on in preflight. If new issues appear, they get the next `/resolve-issues` run.
 
 ## Cross-references
 
 - One implementer per task + per-task code review pattern → `superpowers:subagent-driven-development` (this skill is its specialization for the resolve-issues loop).
 - Per-task review subagent dispatch → `superpowers:requesting-code-review`.
+- Worktree path scheme, create / remove commands, preflight pruning, failure modes → `references/worktree-management.md`.
 - Splitting an issue into tasks → `references/task-decomposition.md`.
 - Per-task implementer prompt → `references/subagent-spec.md`.
 - Per-task review invocation and gating → `references/per-task-review.md`.
@@ -338,5 +394,8 @@ A correct run produces:
 8. The loop terminated on empty filter, user interrupt, or the three-strike escalation — not arbitrarily after N issues.
 9. Final summary was printed with per-issue disposition AND per-task stats.
 10. No push to the default branch occurred.
+11. **Every REAL issue ran inside its own `<repo-root>.worktrees/issue-<N>-<slug>` worktree.** No fix branch ever lived in the main checkout.
+12. **Every worktree created during the run was removed before the loop terminated.** `git worktree list` after the loop finishes shows no leftover `issue-*` entries from this run.
+13. The main checkout's HEAD and working tree are unchanged from the loop's starting state (still on the default branch, still clean).
 
 If any is violated, the skill failed — correct before continuing.

--- a/skills/devpilot-resolve-issues/references/per-task-review.md
+++ b/skills/devpilot-resolve-issues/references/per-task-review.md
@@ -17,11 +17,15 @@ The two reviews are complementary, not redundant. Per-task review is the interna
 For each task that just returned DONE, dispatch the code-reviewer following `superpowers:requesting-code-review`:
 
 ```bash
-# In the controller, between implementer DONE and TodoWrite completed:
+# In the controller, between implementer DONE and TodoWrite completed.
+# Cwd at this point is $WORKTREE — the issue's git worktree. git resolves HEAD
+# against the worktree's branch (fix/issue-<num>-<slug>), not the main checkout.
 
 BASE_SHA=$(git rev-parse HEAD~"$commits_in_this_task")  # commits the implementer made
 HEAD_SHA=$(git rev-parse HEAD)
 ```
+
+The reviewer subagent inherits `$WORKTREE` as cwd, so its `git diff $BASE_SHA..$HEAD_SHA`, file reads, and any `make` invocations apply to this issue's tree — not to the main checkout. Do **not** `cd "$MAIN"` before invoking the reviewer; the SHAs above only resolve correctly inside the worktree.
 
 Dispatch the reviewer with the template fields from `superpowers:requesting-code-review`:
 

--- a/skills/devpilot-resolve-issues/references/subagent-spec.md
+++ b/skills/devpilot-resolve-issues/references/subagent-spec.md
@@ -11,6 +11,12 @@ Fill every bracketed placeholder before dispatching. A spec with unfilled bracke
 
 You are an implementer subagent. The main agent has triaged issue #<num> as **real** and decomposed the fix into <N> task(s); this dispatch covers task <i> only. Your job is to land task <i> on the current branch (`fix/issue-<num>-<slug>`), verify it, and return a status to the main agent.
 
+## Working tree
+
+You are running inside a per-issue git worktree. Your initial cwd (`pwd`) is the worktree root, and `git rev-parse --abbrev-ref HEAD` is `fix/issue-<num>-<slug>`. **Stay there.** Do not `cd` outside the worktree, do not run `git worktree add`/`remove`/`prune`, do not `git switch`/`checkout` to another branch, do not touch the parent main checkout. The controller owns worktree lifecycle; you own commits on this branch.
+
+If `pwd` does not match the expected worktree path or HEAD does not match `fix/issue-<num>-<slug>`, return `BLOCKED` immediately with the mismatch — do not try to "fix" the cwd or switch branches yourself.
+
 ## Why this task exists
 
 Verdict: REAL.
@@ -59,6 +65,7 @@ These are the criteria the per-task code reviewer will check against. They must 
 - **Honor repo conventions.** Read `CLAUDE.md` / `AGENTS.md` / language style skills if they exist. In particular for Go: `devpilot-google-go-style` rules apply.
 - **Commit your work on the branch before returning.** Granular commits are fine. The per-task code reviewer reads the SHA range you produced.
 - **Do not push, do not open a PR, do not comment on the issue.** That's the main agent's job after all tasks land.
+- **Do not move out of the worktree.** No `cd "$MAIN"`, no `git worktree …`, no `git switch <other-branch>`. The controller created this worktree at step 5 of `SKILL.md` and will remove it at step 10; you operate strictly inside it.
 
 ## Return summary format
 
@@ -99,8 +106,9 @@ If you returned NEEDS_CONTEXT or BLOCKED, leave the branch in whatever state you
 
 ## Rules for the main agent filling this template
 
+- **Dispatch from inside the issue's worktree.** The controller's cwd at step 6 of `SKILL.md` is `$WORKTREE`; the implementer subagent inherits that cwd, so its `pwd` and `git` calls naturally land on the right tree and branch. Do not dispatch from `$MAIN`.
 - **One task per dispatch.** Even if two tasks look "small enough to combine", separate dispatches keep the per-task review surface small. The skill is built around one implementer + one reviewer per task.
-- **Never run implementers in parallel on the same issue's branch.** They'd race on the working tree and produce a merge mess inside a single PR. Sequential only.
+- **Never run implementers in parallel on the same issue's branch.** They'd race on the working tree and produce a merge mess inside a single PR. Sequential only — even though each issue has its own worktree, multiple implementers in the same worktree still race.
 - **Do not omit the Evidence block.** Even if the main agent already reasoned about it — the subagent needs the verbatim quote, every dispatch.
 - **Concrete acceptance criteria, not aspirations.** "Tests pass" is not a criterion; "`make test` exits 0" is. "Handles the edge case" is not a criterion; "`TestFooFn_EmptyInput` passes" is.
 - **Name specific files.** Subagents that are told "figure out which files to read" waste a full context window exploring. Hand them the starting points from your investigation in step 3.

--- a/skills/devpilot-resolve-issues/references/worktree-management.md
+++ b/skills/devpilot-resolve-issues/references/worktree-management.md
@@ -1,0 +1,158 @@
+# Worktree Management
+
+Every REAL issue gets its own `git worktree`. The main checkout never sees the fix branch — that is the whole point. This file is the operational reference: path scheme, create / remove commands, preflight pruning, failure modes.
+
+**Scope:** This file is loaded at step 0 (preflight pruning) and step 5 (per-issue create) of `SKILL.md`, and again on the cleanup path after step 8 / on escalation. It is not loaded by implementer or reviewer subagents — they inherit cwd from the controller and don't run worktree commands themselves.
+
+## Path scheme
+
+```
+<repo-root>.worktrees/issue-<num>-<slug>/
+```
+
+Concretely, if the main checkout is `/Users/me/Works/foo` and the issue is `#42` with slug `sanitize-shell-input`:
+
+```
+/Users/me/Works/foo                                  <- main checkout (default branch, never the fix branch)
+/Users/me/Works/foo.worktrees/issue-42-sanitize-shell-input  <- the per-issue worktree
+```
+
+Why this layout:
+
+- **Sibling of repo, hidden by `.worktrees` suffix.** Discoverable when listing the parent directory; clearly transient by name.
+- **One parent dir per repo.** `rm -rf <repo>.worktrees` (or `git worktree prune`) cleans every dangling worktree for that repo at once.
+- **No collision with other repos.** The dir name embeds the repo name, so multiple repos under the same parent each get their own bucket.
+
+`<slug>` is the same kebab-case slug used for the branch name (3–5 ASCII words, derived from the issue title). The branch in the worktree is `fix/issue-<num>-<slug>` — same naming you would have used pre-worktree.
+
+**Do not put the worktree inside the main checkout.** `<repo-root>/.worktrees/issue-N` looks tidier but breaks: the main checkout's tooling (linters, test runners, IDEs, file watchers) will recurse into it and confuse itself, and `git status` from the main checkout will surface it as untracked. Sibling-only.
+
+## Step 0 — preflight pruning
+
+Run once per loop, before selecting the first issue. Three things, in order:
+
+```bash
+# 1. Confirm git is new enough to support worktrees (it always is on supported platforms).
+git worktree --help >/dev/null 2>&1 || { echo "git worktree unavailable"; exit 1; }
+
+# 2. Prune metadata for worktrees whose directory was deleted out from under git.
+git worktree prune
+
+# 3. List remaining worktrees and decide what to do with stragglers.
+git worktree list
+```
+
+If `git worktree list` shows worktrees from a prior `/resolve-issues` run that did NOT clean up:
+
+- **Their branch is already pushed and the PR is open / merged** — safe to remove. `git worktree remove <path>` (add `--force` only if uncommitted changes exist; investigate first).
+- **Their branch has unpushed commits** — STOP. Ask the user. This is somebody's in-progress work; the safe default is leave it alone and pick a different issue, not blow it away.
+
+Never remove a worktree without first inspecting its branch. The whole point of worktrees is that they keep work isolated, so a stale worktree is more often "in-progress work nobody has come back to" than "leftover garbage."
+
+## Step 5 — create the worktree for one issue
+
+Pre-conditions you should have already established:
+
+- Verdict on `#<num>` is REAL (steps 3–4 of `SKILL.md`).
+- Default branch name is in `$DEFAULT_BRANCH` (from preflight).
+- Slug is in `$SLUG` (kebab-case, 3–5 words).
+
+```bash
+# Refresh the default branch ref so the worktree branches off the latest commit.
+git fetch origin "$DEFAULT_BRANCH"
+
+WORKTREE_PATH="$(git rev-parse --show-toplevel).worktrees/issue-${NUM}-${SLUG}"
+BRANCH="fix/issue-${NUM}-${SLUG}"
+
+# Create the worktree on a fresh branch off origin/<default>.
+git worktree add -b "$BRANCH" "$WORKTREE_PATH" "origin/${DEFAULT_BRANCH}"
+
+# Move the controller into the worktree. Subagents dispatched from here will inherit this cwd.
+cd "$WORKTREE_PATH"
+```
+
+After this point, every subsequent step (6 implementers, 6c review, 7 verify, 8 PR creation, 9 issue comment) runs with `cwd = $WORKTREE_PATH`. The main checkout is untouched until cleanup.
+
+### Failure modes at create time
+
+| Failure | What to do |
+|---|---|
+| `fatal: '<path>' already exists` | A previous run for this issue did not clean up. Run `git worktree list` to confirm; if the branch is unpushed, treat as in-progress (ask the user). If the branch matches `fix/issue-<num>-<slug>` and has been pushed, remove it (`git worktree remove "$WORKTREE_PATH"`) and retry. |
+| `fatal: '<branch>' is already checked out at '<other-path>'` | The branch is live in another worktree. Same diagnosis: somebody (you in a prior run, or another agent) is mid-fix. Stop and ask. |
+| `<branch>` already exists locally | Either reuse it (`git worktree add "$WORKTREE_PATH" "$BRANCH"` — no `-b`) if it was a clean prior attempt, or rename your slug. Default to renaming. |
+| `error: invalid reference: origin/<default>` | `git fetch origin` first; then retry. If the fetch fails, that's a network / auth issue, escalate to the user before continuing the loop. |
+| Disk full / parent dir not writable | Stop the loop. The user has to fix the filesystem before any issue can be processed. |
+
+Never `--force` your way past these. A forced worktree create on top of in-progress work is exactly the kind of "hard-to-reverse" action that belongs in a confirmation prompt, not in an autonomous loop.
+
+## Cleanup — after PR creation, after escalation, or after FALSE-POSITIVE retry-with-worktree
+
+The controller is currently at `cwd = $WORKTREE_PATH`. Get back to the main checkout and remove the worktree:
+
+```bash
+MAIN="$(git rev-parse --path-format=absolute --git-common-dir)"
+MAIN="$(dirname "$MAIN")"   # .git/common-dir → repo root of the main checkout
+cd "$MAIN"
+
+git worktree remove "$WORKTREE_PATH"
+```
+
+**Cleanup policy — try in this order:**
+
+1. **Plain remove first:**
+
+   ```bash
+   git worktree remove "$WORKTREE_PATH"
+   ```
+
+   Often fails on Go / Node / Rust repos with "contains modified or untracked files" because `bin/` or `node_modules/` or `target/` got built inside the worktree.
+
+2. **If plain remove failed because of *gitignored* artifacts** (build outputs, dep caches): drop the ignored files first, then re-run the plain remove. This avoids `--force` entirely and is the preferred path:
+
+   ```bash
+   git -C "$WORKTREE_PATH" clean -fdX     # -X = ignored files only; -fd = force, dirs
+   git worktree remove "$WORKTREE_PATH"   # should succeed now
+   ```
+
+3. **`--force` is the last resort, only when both of these are true:**
+   - You have **verified** with `git status` and `git log origin/$BRANCH..HEAD` that all real work is on origin (or that you're intentionally discarding it).
+   - `clean -fdX` didn't help — i.e., the dirty files aren't gitignored, they're untracked but not ignored.
+
+   Then: `git worktree remove --force "$WORKTREE_PATH"`. Reach for this only after step 2 didn't work.
+
+**Common cases:**
+
+- After `devpilot-pr-creator` succeeded → the branch is on origin → step 2 (`clean -fdX` + plain remove) handles ~all build-artifact cases. Skip straight to `--force` only if `clean -fdX` left modified-but-not-ignored files behind, which suggests something tracked got modified — investigate before forcing.
+- After escalation pushed a draft branch → same: try step 2 first.
+- Implementer crashed mid-task and the worktree has uncommitted changes to **tracked** files → STOP. Do not `--force`. Ask the user. Those changes are not on origin.
+
+After remove, run `git worktree prune` once more to clean the metadata side and confirm nothing is left:
+
+```bash
+git worktree prune
+git worktree list   # should not show the issue worktree anymore
+```
+
+### Cleanup branches
+
+Cleanup is required at exactly three points in the loop:
+
+1. **PR opened cleanly (step 8 success)** — branch is pushed, PR is up; remove the worktree, the branch lives on origin.
+2. **Escalation mid-fix (BLOCKED, round-3 review, second verification fail)** — push the branch as a draft (`git push -u origin "$BRANCH"`), comment on the issue with the branch URL, *then* remove the worktree. The escalation is documented on the issue; the work-so-far is preserved on origin.
+3. **Final verify failed at step 7** — same as escalation: push as draft, comment, then remove.
+
+You never reach cleanup on the FALSE-POSITIVE or NEEDS-HUMAN paths because **no worktree was ever created** for those — the verdict happens at step 4, before step 5.
+
+## Why this matters (and what it forbids)
+
+- **The main checkout is sacred.** While the loop runs, the user's `cd` into the repo still shows the default branch with no surprise edits. They can keep working — open editors, run dev servers — without colliding with the loop.
+- **Multiple issues in flight is now physically possible.** Each issue lives at a separate path on disk, on a separate branch, with separate `make` build outputs. The current `SKILL.md` still keeps issues sequential, but the constraint that previously *forced* sequence (one branch checked out at a time) is gone — when we relax sequencing in the future, the worktree layout is what makes it safe.
+- **One implementer per task on a given branch is still required.** Worktrees buy you isolation between *issues*, not between tasks of the same issue. Two implementers in the same worktree race on the same working tree.
+
+## Anti-shortcuts
+
+- **"Just branch in the main checkout for this one — worktree feels like overhead."** Worktree creation is two commands and ~50ms. The "overhead" is the user being able to keep working in the main checkout. Skip it once and the loop forgets it forever.
+- **"`git stash` before switching branches is the same thing."** It is not. Stash leaves the main checkout's HEAD pointing at the fix branch with an unrelated stash on top — exactly the polluted state worktrees exist to avoid.
+- **"I'll create the worktree but stay in the main checkout's cwd and pass paths."** Then every shell invocation needs `-C "$WORKTREE_PATH"`, every subagent gets a different cwd than git expects, and the implementer trips on its own paths. `cd` into the worktree once at step 5 and stay there until cleanup.
+- **"`git worktree remove --force` is fine, the work is on origin."** Only if you actually pushed it. Verify with `git status` and `git log origin/<branch>..HEAD` first; "I think I pushed" is not verified.
+- **"Cleanup can wait until the end of the loop, batch it."** No. Each iteration cleans up its own worktree. A loop that processes 10 issues should never have 10 worktrees alive simultaneously — that is unprocessed cleanup, not parallelism.

--- a/skills/index.json
+++ b/skills/index.json
@@ -114,12 +114,13 @@
     },
     {
       "name": "devpilot-resolve-issues",
-      "description": "End-to-end loop that works through open GitHub issues one at a time: triage, self-assign, investigate code, render a REAL / FALSE-POSITIVE / NEEDS-HUMAN verdict, and for REAL issues decompose the fix into 1–3 tasks dispatched as one implementer subagent per task with superpowers:requesting-code-review gating each task, then open a PR with Closes #N. Runs until the issue filter is empty.",
+      "description": "End-to-end loop that works through open GitHub issues one at a time: triage, self-assign, investigate code, render a REAL / FALSE-POSITIVE / NEEDS-HUMAN verdict, and for REAL issues fix in a per-issue git worktree — decompose into 1–3 tasks dispatched as one implementer subagent per task with superpowers:requesting-code-review gating each task, then open a PR with Closes #N. Runs until the issue filter is empty.",
       "files": [
         "references/per-task-review.md",
         "references/subagent-spec.md",
         "references/task-decomposition.md",
         "references/verdict-comments.md",
+        "references/worktree-management.md",
         "SKILL.md"
       ]
     },


### PR DESCRIPTION
## Summary

Locks the `devpilot-resolve-issues` skill to fix every REAL issue inside its **own `git worktree`**, never in the main checkout. The user's main checkout stays on the default branch and untouched while the loop runs, so editors, dev servers, and `git status` in the user's terminal aren't in the loop's blast radius.

### Changes

- **New `references/worktree-management.md`** (158 lines) — operational reference. Path scheme `<repo-root>.worktrees/issue-<num>-<slug>/` (sibling of repo, never nested). Covers step 0 preflight pruning, step 5 create, the failure-modes table at create time, and the cleanup ladder (plain remove → `clean -fdX` for gitignored artifacts → `--force` only after verifying work is on origin).
- **`SKILL.md` rewritten across all phases:**
  - Preflight saves `$MAIN`, runs `git worktree list` / `prune`, stops on stragglers with unpushed commits.
  - Old "Step 5 — branch for the fix" replaced by "create the worktree (and the branch inside it)"; controller `cd`s into the worktree and stays there through steps 6–9.
  - New **step 10 cleanup** removes the worktree on every reachable terminal path (PR opened, mid-fix escalation after draft push, final-verify failure after draft push). FALSE-POSITIVE / NEEDS-HUMAN never reach cleanup because no worktree was ever created.
  - Final verify (step 7) and PR creation (step 8) annotated with the `cwd = $WORKTREE` contract.
  - Three new hard rules (#12 worktree mandatory, #13 one-worktree-one-issue, #14 no `--force` in autonomous mode), a new "Meta-rationalization" preamble in red flags + four queue-pressure red-flag rows, three new common-mistake bullets, three new acceptance-criteria items.
  - Mermaid graph swaps `Branch fix/issue-N-slug` for `Create worktree + branch (cd into it)` and adds `Remove worktree, return to main checkout` before the loop edge.
- **`references/subagent-spec.md`** — implementer prompt grows a "Working tree" section: subagent inherits the worktree as cwd, must not `cd` out, must not run `git worktree …`, must not switch branches; if `pwd`/HEAD don't match expected, return `BLOCKED` instead of self-healing. The "Never run implementers in parallel" rule restated for the same-worktree case.
- **`references/per-task-review.md`** — cwd contract for the per-task reviewer dispatch: SHAs only resolve correctly inside `$WORKTREE`; controller must not `cd "$MAIN"` before invoking the reviewer.
- **`skills/index.json`** — registers `references/worktree-management.md` and updates the `devpilot-resolve-issues` description to mention the per-issue worktree.

### Why

Pre-change, the loop branched in the main checkout and dragged the user's working environment along on every fix. Worktrees give physical isolation per issue: one branch per directory, no `git switch` in the user's checkout, and `git worktree list` is a single-shot inventory of in-flight loop state. The path scheme also unlocks future cross-issue parallelism without changing the controller — the constraint that previously forced sequencing (one branch checked out at a time) is gone.

## Review Guide

**Start here:** `skills/devpilot-resolve-issues/references/worktree-management.md` (new file). It is the spec the rest of the diff implements.

Then `skills/devpilot-resolve-issues/SKILL.md`, in diff order:
1. Frontmatter description + Overview — surfaces the per-worktree contract.
2. Mermaid graph — visual diff of the new flow with cleanup before "Select next issue".
3. Step 0 preflight — added `$MAIN` capture and `git worktree prune` / `list`.
4. Step 5 — the heart of the change. Pay attention to the "Failure handling" pointer at the end: it's the lever that prevents `--force` shortcuts.
5. Steps 7 / 8 / 9 — annotated with `cwd = $WORKTREE` to make the contract explicit.
6. New step 10 cleanup, plus 11/12 renumbering.
7. Hard rules 12–14, "Meta-rationalization" preamble, the four new red-flag rows, and acceptance criteria 11–13.

Subagent reference files (`subagent-spec.md`, `per-task-review.md`) are short — read for cwd-contract consistency with `SKILL.md` step 6.

`skills/index.json` adds one entry to the `files` array and updates the description string. No structural change.

**Things to watch for:**
- Anywhere `SKILL.md` says `cwd = $WORKTREE` but a subagent reference still implies main-checkout cwd.
- The cleanup ladder must never recommend `--force` without first verifying with `git status` + `git log origin/$BRANCH..HEAD`. The "Cleanup policy" section in `worktree-management.md` enforces this — sanity-check the wording.
- Path scheme is `<repo-root>.worktrees/...` (sibling, **not** nested `.worktrees/` inside the repo) — confirm both `worktree-management.md` and `SKILL.md` agree.

## Verification

- [x] `skills/index.json` parses as valid JSON (`python3 -c "import json; json.load(open('skills/index.json'))"`) and lists `references/worktree-management.md` under `devpilot-resolve-issues`.
- [x] No code changes (`*.go`, `Makefile`, build config untouched), so `make test` / `make lint` are unchanged from main.
- [ ] Manual end-to-end: run `/resolve-issues` against a low-risk REAL issue. Confirm (1) a worktree appears at `<repo-root>.worktrees/issue-<N>-<slug>/`, (2) the main checkout's HEAD does not move and `git status` stays clean, (3) step 10 removes the worktree before the loop iterates.

## For Reviewers (human)

- [ ] Self-review of the diff