### PR TITLE
feat(scanning-repos): redesign labels, add large-repo scaffolding

### DIFF
--- a/skills/devpilot-scanning-repos/SKILL.md
+++ b/skills/devpilot-scanning-repos/SKILL.md
@@ -34,17 +34,23 @@ A whole-repo sweep that dispatches **three parallel specialist sub-agents**, sco
 ## Workflow
 
 1. **Resolve target.** Accept `owner/repo`, a clone URL, or "this repo" (use `gh repo view --json nameWithOwner`). Verify with `gh repo view`.
-2. **Ensure labels exist.** Create (idempotently) the labels this skill uses: `repo-scan`, `scan:security`, `scan:edge-case`, `scan:coverage`, `severity:high`, `severity:medium`, `severity:low`. See `references/labels.md` for the `gh label create` incantations.
+2. **Ensure labels exist.** Create (idempotently) the full label taxonomy: `scan/<category>` × 3, all `sec/*` / `edge/*` / `cov/*` subcategories, `severity/<level>` × 3, `confidence/75`, `confidence/100`. `area/*` labels are created lazily at filing time (one per first-path-segment encountered). See `references/labels.md` for the exact `gh label create` block — paste it verbatim.
+2.5. **Build a shared file manifest.** The orchestrator does ONE walk and hands a sampled file list to all three scanners. Scanners MUST NOT re-walk — they may only read paths in the manifest. See "Scaling for large repos" below for the algorithm. The manifest is a plain text file written to `/tmp/devpilot-scan-manifest.txt`, one repo-relative path per line. Default cap: **800 files**. Override with `--full` (raises to 2000) or `--scope <dir>` (manifest = `find <dir>` capped at 800).
 3. **Dispatch scanners in parallel.** In ONE message, launch three sub-agents using the prompts in `agents/`:
    - `agents/security-scanner.md`
    - `agents/edge-case-hunter.md`
    - `agents/coverage-auditor.md`
-   Each returns a list of `Finding` objects (see format below). Scanners are told to emit everything they notice — including low-severity — because filtering happens in step 4, not in the scanner.
-3.5. **Validate scanner output.** Pipe each scanner's JSON array through `python3 scripts/check-findings.py`. It exits non-zero and prints the offending object if any finding is missing a required field, uses an invalid `category`/`severity` enum, or has an empty `evidence` block. Fix (or ask the scanner to re-emit) before scoring.
-4. **Score every finding.** For each finding, dispatch a lightweight scoring sub-agent using the rubric in `references/scoring.md`. Scores are 0, 25, 50, 75, or 100 — the same scale used by the official `/code-review:code-review` command, adapted for repo-wide scans.
+   Pass the manifest path to each scanner. Each returns a list of `Finding` objects (see format below). Scanners are told to emit everything they notice — including low-severity — because filtering happens in step 4, not in the scanner.
+3.5. **Validate scanner output.** Pipe each scanner's JSON array through `python3 scripts/check-findings.py --manifest /tmp/devpilot-scan-manifest.txt`. The `--manifest` flag is mandatory — it makes the script reject any finding whose `file` is not on the manifest, enforcing the contract from step 2.5. The script also rejects missing required fields, invalid `category`/`subcategory`/`severity` enums, and empty `evidence`. Fix (or ask the scanner to re-emit) before scoring.
+4. **Score every finding, in batches.** Group findings by category and dispatch ONE scoring sub-agent per batch of up to **25 findings** (not one per finding — the per-finding fan-out doesn't scale past ~50). The scoring agent returns a JSON array of `{index, score, reason}` aligned with the input order. See `references/scoring.md` for the rubric and the batched prompt.
 5. **Filter.** Drop every finding with score `< 75`. If zero survive, stop — report "no high-confidence issues found" to the user and do not create issues.
-6. **Deduplicate against existing issues.** Before filing, run `gh issue list --label repo-scan --state all --limit 200 --json title,body,number` and skip findings whose normalized title already matches an open or recently-closed scan issue.
-7. **File issues.** One `gh issue create` per surviving finding, using the template in `references/issue-template.md`. Labels: always `repo-scan` + one `scan:*` category + one `severity:*`.
+6. **Deduplicate against existing issues.** Before filing, query existing scan issues. Use a search that covers BOTH the new taxonomy and the legacy `repo-scan` label (so re-runs against repos scanned under the old label set still dedupe correctly):
+   ```bash
+   gh issue list --search 'label:scan/security,scan/edge-case,scan/coverage,repo-scan in:title' \
+     --state all --limit 1000 --json title,number,state
+   ```
+   Normalize titles by lower-casing, stripping the `[scan/<category>]` / `[repo-scan:<category>]` prefix, and collapsing whitespace before comparing. Skip findings whose normalized title matches an existing issue. If `--limit 1000` returns exactly 1000, paginate with `--search "... created:<<date-of-oldest>"` until empty.
+7. **File issues.** One `gh issue create` per surviving finding, using the template in `references/issue-template.md`. Labels: always exactly five — `scan/<category>` + matching subcategory + `severity/<level>` + `confidence/<score>` + auto-derived `area/<top-level-dir>`. Create the `area/*` label idempotently right before the issue.
 8. **Summarize.** Print a compact table to the user: `[category] [severity] title → #issue-number`.
 
 ## Finding format
@@ -54,6 +60,7 @@ Every scanner returns a JSON array of objects with exactly these fields:
 ```json
 {
   "category": "security | edge-case | coverage",
+  "subcategory": "sec/injection | sec/authn-authz | sec/secrets | sec/crypto | sec/path-traversal | sec/ssrf-csrf | sec/deserialization | sec/tls-misconfig | edge/nil-deref | edge/bounds-overflow | edge/error-swallowed | edge/concurrency | edge/resource-leak | edge/input-validation | cov/no-test-file | cov/error-paths | cov/integration-seam | cov/stale-test",
   "title": "<≤80 chars, imperative — e.g. 'Sanitize shell input in cmd/devpilot/run.go'>",
   "severity": "high | medium | low",
   "file": "<path relative to repo root>",
@@ -63,6 +70,8 @@ Every scanner returns a JSON array of objects with exactly these fields:
   "suggested_fix": "<1–3 sentences; null if scanner can't confidently propose one>"
 }
 ```
+
+`subcategory` must match `category` (`sec/*` for security, `edge/*` for edge-case, `cov/*` for coverage). See `references/labels.md` for the fixed enum — scanners do NOT invent new subcategory values. If a finding doesn't fit any subcategory, the scanner picks the closest fit OR drops the finding.
 
 `evidence` is mandatory. A finding without quotable code is speculation — drop it at the scanner level.
 
@@ -106,14 +115,56 @@ See each agent prompt for category-specific false-positive classes.
 A correct run of this skill produces:
 
 1. Exactly three scanner sub-agent dispatches, in parallel.
-2. Every filed issue has `repo-scan` + one `scan:*` + one `severity:*` label.
+2. Every filed issue has exactly five labels: `scan/<category>`, a matching `sec/*`|`edge/*`|`cov/*` subcategory, `severity/<level>`, `confidence/<score>` (75 or 100), and an auto-derived `area/<top-level-dir>`.
 3. No issue is filed whose scoring-agent score is below 75.
-4. No duplicate of an existing open `repo-scan` issue.
+4. No duplicate of an existing open scan issue (under either the new `scan/*` labels or the legacy `repo-scan` label).
 5. No finding cites business-logic correctness as the sole reason.
 6. Every filed issue body quotes ≥2 lines of actual code with a `<file>#L<start>-L<end>` link.
 7. If zero findings survive scoring, no issues are filed and the user is told so explicitly.
 
 If any of these is violated, the skill failed — stop and correct before continuing.
+
+## Scaling for large repos
+
+A real-world stress test on `kubernetes/kubernetes` (16,942 source files, ~268k tokens just for the path list) surfaced three failure modes the workflow MUST defend against. This section is the contract — it is not optional.
+
+### Failure modes (measured, not theoretical)
+
+1. **Path-list explosion.** The full file list of a large monorepo can consume more tokens than a sub-agent's entire window, *before* a single file is read. Each scanner re-walking the tree triplicates the cost.
+2. **Hardcoded directory allowlist misses.** The naive fallback `cmd/, internal/, api/, handlers/, controllers/, auth/, crypto/, utils/` matched **3% of code** on kubernetes (which has none of `internal/`, `api/`, `handlers/`, `controllers/`, `auth/`, `crypto/`, `utils/` at the top level). Hardcoded allowlists cannot be the fallback.
+3. **Sink-grep volume swamps verify.** `exec.Command` alone returns 252 hits, `math/rand` 214, `InsecureSkipVerify` 93 — totalling 647 hits across just 6 patterns. A scanner told to "read the surrounding function" for each will either skip verification (and emit raw greps) or stop after a tiny fraction.
+
+### The manifest algorithm (step 2.5)
+
+The orchestrator builds the manifest BEFORE dispatching scanners:
+
+1. **Inventory.** Run `find . -type f \( -name '*.go' -o -name '*.py' -o -name '*.js' -o -name '*.ts' -o -name '*.rb' -o -name '*.java' -o -name '*.rs' \) -not -path './vendor/*' -not -path './node_modules/*' -not -path '*/gen/*' -not -path '*/.git/*' | wc -l`. Call this `N`.
+2. **If `N` ≤ 800**, the manifest is the full list — no sampling needed.
+3. **If `N` > 800**, sample down to 800 with this priority order (concatenate, dedupe, truncate at 800):
+   1. **Hot-path churn.** Files changed in the last 90 days, ranked by commit count: `git log --since=90.days.ago --name-only --pretty=format: -- '*.go' '*.py' '*.js' '*.ts' '*.rb' '*.java' '*.rs' | sort | uniq -c | sort -rn | awk '$2 != "" {print $2}'`. Take the top 400.
+   2. **Top-level high-signal dirs by file count.** Dynamically discover (do NOT use the hardcoded allowlist): `find . -mindepth 1 -maxdepth 1 -type d -not -name '.*' -not -name 'vendor' -not -name 'node_modules' -not -name 'test' -not -name 'tests' -not -name 'docs' -not -name 'examples'`, count source files in each, take the top 4 dirs by count, sample evenly from them up to 300 files. This is the part that fixes the kubernetes-allowlist mismatch — a repo with `pkg/` and `staging/` at the top will have those picked, not ignored.
+   3. **Security-sensitive name patterns** as a final fill: any path containing `auth`, `crypto`, `secret`, `cred`, `token`, `password`, `cert`, `tls`, `oauth`, `session`, `jwt`, `signin`, `login`. Take up to 100.
+4. **Write `/tmp/devpilot-scan-manifest.txt`**, one path per line. Print to the user: total `N`, manifest size, and the top 5 dirs represented (so they can sanity-check that the sampling caught the right slice).
+5. **`--full` mode** raises the cap to 2000 but still goes through the same priority sampling. Above 2000, refuse and ask the user to scope.
+6. **`--scope <dir>` mode** skips churn ranking — manifest is `find <dir>` capped at 800.
+
+### Sink-grep budget (per scanner)
+
+Each scanner runs its dangerous-sink greps ONLY against files in the manifest, not the whole tree:
+
+```bash
+grep -nE 'exec\.Command|InsecureSkipVerify|...' $(cat /tmp/devpilot-scan-manifest.txt)
+```
+
+Cap per pattern: **40 hits**. If a pattern returns more, take the top 40 by file (prefer files that also appear in the churn list — recently-modified hits beat ancient ones). The remainder is logged as "skipped: N additional `<pattern>` hits not verified" in the scanner's output, so the user sees coverage gaps explicitly rather than silently.
+
+### Scoring batching (step 4)
+
+Group findings by category, send up to **25 findings per scoring sub-agent** dispatch in one message. For 200 findings across three categories that's ~9 scoring dispatches, not 200. The scoring agent's batched prompt lives in `references/scoring.md`.
+
+### Dedupe pagination (step 6)
+
+`gh issue list --limit 200` silently truncates — confirmed against kubernetes/kubernetes. Always use `--limit 1000`, check whether exactly 1000 returned, and paginate with `created:<<<date>` until the page is short. See step 6.
 
 ## Common mistakes
 

--- a/skills/devpilot-scanning-repos/agents/coverage-auditor.md
+++ b/skills/devpilot-scanning-repos/agents/coverage-auditor.md
@@ -24,6 +24,8 @@ Flag:
 
 ## How to scan
 
+You will receive a path to a manifest file (default `/tmp/devpilot-scan-manifest.txt`). The manifest enumerates production files the orchestrator chose to scan. You may read test files for any production file in the manifest (those won't be in the manifest themselves), but findings can only target manifest paths.
+
 1. Build a map of production files to candidate test files:
    - Go: `foo.go` → `foo_test.go` in the same package.
    - JS/TS: `foo.ts` → `foo.test.ts` / `foo.spec.ts` nearby or under `__tests__/`.
@@ -40,6 +42,7 @@ Return ONLY a JSON array:
 [
   {
     "category": "coverage",
+    "subcategory": "cov/no-test-file",
     "title": "No tests for authentication middleware in internal/auth/middleware.go",
     "severity": "high",
     "file": "internal/auth/middleware.go",
@@ -58,3 +61,16 @@ Return ONLY a JSON array:
 - `severity: low` — stale or incomplete test file; code works today but is drifting.
 
 Be over-inclusive. The scoring pass filters.
+
+**Context-pressure trailer.** If the manifest is larger than you can audit, append `{"_meta": {"manifest_size": <M>, "files_scanned": <N>, "stopped_reason": "context_budget"}}` as the last element of the JSON array.
+
+## Subcategory enum (mandatory)
+
+Every finding MUST set `subcategory` to one of:
+
+- `cov/no-test-file` — exported file has no companion `*_test.*` anywhere in the repo
+- `cov/error-paths` — happy path tested, error branches have no assertions
+- `cov/integration-seam` — boundary between two packages (auth+handler, etc.) has no test
+- `cov/stale-test` — production file churned recently (`git log --since=90.days.ago`), test file did not
+
+Pick the closest fit. Do NOT invent new subcategories. If nothing fits, drop the finding.

--- a/skills/devpilot-scanning-repos/agents/edge-case-hunter.md
+++ b/skills/devpilot-scanning-repos/agents/edge-case-hunter.md
@@ -42,8 +42,10 @@ You are dispatched by the `devpilot-scanning-repos` skill to find edge cases —
 
 ## How to scan
 
-1. Walk the production source tree. Skip test files, generated files, and vendor directories.
-2. In each file, read every non-trivial function. Ask for each parameter:
+You will receive a path to a manifest file (default `/tmp/devpilot-scan-manifest.txt`). It is the EXCLUSIVE set of files you may read. Do NOT run a fresh `find` or open files outside the manifest. If a finding's file isn't in the manifest, drop it.
+
+1. Read `/tmp/devpilot-scan-manifest.txt`. Filter out `*_test.*`, files under `gen/`, and obvious generated files (header line `// Code generated`).
+2. In each remaining file, read every non-trivial function. Ask for each parameter:
    - What if this is nil / zero / empty / negative / huge / unicode / malformed?
    - Is that case handled, or does it crash / return silently-wrong data?
 3. For each error return: is the error path as correct as the happy path? Look for the pattern `if err != nil { return ... }` where the `...` discards context or returns a partial result.
@@ -58,6 +60,7 @@ Return ONLY a JSON array (no prose) of findings using the repo-scan Finding sche
 [
   {
     "category": "edge-case",
+    "subcategory": "edge/nil-deref",
     "title": "Nil map dereferenced on empty config in internal/project/config.go",
     "severity": "medium",
     "file": "internal/project/config.go",
@@ -76,3 +79,18 @@ Return ONLY a JSON array (no prose) of findings using the repo-scan Finding sche
 - `severity: low` — hardening opportunity; would surprise a reader but needs effort to hit.
 
 Be over-inclusive — filtering happens downstream.
+
+**Context-pressure trailer.** If you can't read every manifest file before exhausting context, append `{"_meta": {"manifest_size": <M>, "files_scanned": <N>, "stopped_reason": "context_budget"}}` as the last element of the JSON array. Never silently truncate.
+
+## Subcategory enum (mandatory)
+
+Every finding MUST set `subcategory` to one of:
+
+- `edge/nil-deref` — nil pointer / nil map / nil interface deref, empty-slice index
+- `edge/bounds-overflow` — off-by-one, integer over/underflow, slice index out of range
+- `edge/error-swallowed` — discarded errors, returned-zero-value-on-error, ignored close errors on writes
+- `edge/concurrency` — data race, deadlock, leaked goroutine, double-close, captured loop var, missing context propagation
+- `edge/resource-leak` — unclosed file / response.Body / DB row / ticker / mutex on error path
+- `edge/input-validation` — unbounded external input flowing into index, length, or `make([]T, n)`
+
+Pick the closest fit. Do NOT invent new subcategories. If nothing fits, drop the finding.

--- a/skills/devpilot-scanning-repos/agents/security-scanner.md
+++ b/skills/devpilot-scanning-repos/agents/security-scanner.md
@@ -26,10 +26,19 @@ Look for, in decreasing priority:
 
 ## How to scan
 
-1. Start with a breadth-first file walk: `find . -type f -name '*.go' -o -name '*.py' -o -name '*.js' -o -name '*.ts' -o -name '*.rb' -o -name '*.java' -o -name '*.rs'` (adjust to the repo). Cap at a reasonable file count; if the repo is huge, focus on `cmd/`, `internal/`, `api/`, `handlers/`, `controllers/`, `auth/`, `crypto/`, `utils/`.
-2. For each high-signal directory, grep for dangerous sinks: `exec.Command`, `os/exec`, `fmt.Sprintf.*SELECT`, `subprocess.run.*shell=True`, `eval(`, `InsecureSkipVerify`, `math/rand`, `yaml.load(`, `pickle.loads`, `http.Get(.*r\\.`.
-3. When a sink is found, **read the surrounding function** to confirm user-controlled input reaches it. A sink with a hardcoded literal is not a finding.
-4. Record the finding in the required format (below).
+You will receive a path to a manifest file (default `/tmp/devpilot-scan-manifest.txt`). It contains one repo-relative path per line and is the EXCLUSIVE set of files you may scan. Do NOT run a fresh `find`. Do NOT open files outside the manifest. If a finding's file isn't in the manifest, drop the finding.
+
+1. **Load the manifest.** `cat /tmp/devpilot-scan-manifest.txt | wc -l` — sanity-check it's non-empty. Read its contents.
+2. **Run the dangerous-sink greps against ONLY the manifest:**
+   ```bash
+   xargs -a /tmp/devpilot-scan-manifest.txt grep -nE \
+     'exec\.Command|os/exec|fmt\.Sprintf.*SELECT|subprocess\.run.*shell=True|eval\(|InsecureSkipVerify|math/rand|yaml\.load\(|pickle\.loads|http\.Get\(.*r\.'
+   ```
+   Per-pattern cap: **40 hits**. If a pattern exceeds 40, prefer hits in files that also appear in the recent-churn list (the orchestrator can provide it via `git log --since=90.days.ago --name-only --pretty=format:`); ancient hits sort lower. Log skipped hits explicitly in your output as `skipped: N additional <pattern> hits not verified` — never silently drop them.
+3. When a sink is in the verify set, **read the surrounding function** to confirm user-controlled input reaches it. A sink with a hardcoded literal is not a finding.
+4. Record the finding in the required format (below). Set `subcategory` from the enum at the bottom of this prompt.
+
+**Hard rules under context pressure:** if your context budget runs out before all manifest files are scanned, stop and emit what you have. As the LAST element of the JSON array, append a single meta object so the orchestrator can see coverage: `{"_meta": {"manifest_size": <M>, "files_scanned": <N>, "patterns_capped": ["exec.Command", ...], "stopped_reason": "context_budget"}}`. The validator skips objects with a `_meta` key. Never silently truncate.
 
 ## Output format
 
@@ -39,6 +48,7 @@ Return ONLY a JSON array. No prose.
 [
   {
     "category": "security",
+    "subcategory": "sec/injection",
     "title": "Shell command built from unvalidated HTTP input in internal/runner/exec.go",
     "severity": "high",
     "file": "internal/runner/exec.go",
@@ -49,6 +59,21 @@ Return ONLY a JSON array. No prose.
   }
 ]
 ```
+
+## Subcategory enum (mandatory, no invention)
+
+Every finding MUST set `subcategory` to one of:
+
+- `sec/injection` — SQL / shell / template / NoSQL / LDAP injection
+- `sec/authn-authz` — missing auth, bypassable role checks, broken session
+- `sec/secrets` — hardcoded keys / tokens / credentials in code or history
+- `sec/crypto` — weak hash, bad RNG, ECB, static IV, JWT alg=none
+- `sec/path-traversal` — `../` injection, zip-slip, archive escape
+- `sec/ssrf-csrf` — SSRF, permissive CORS on private data, missing CSRF
+- `sec/deserialization` — pickle/unsafe yaml/gob from untrusted sources
+- `sec/tls-misconfig` — `InsecureSkipVerify`, plaintext-where-TLS-expected, weak ciphers
+
+If a finding doesn't fit any of these, pick the closest fit OR drop the finding. Do NOT invent a new subcategory.
 
 ## Calibration
 

--- a/skills/devpilot-scanning-repos/evals/evals.json
+++ b/skills/devpilot-scanning-repos/evals/evals.json
@@ -8,11 +8,15 @@
       "files": [],
       "assertions": [
         {"name": "exactly_three_scanner_dispatches", "description": "Main agent dispatches security-scanner, edge-case-hunter, and coverage-auditor exactly once each, in parallel (one message)"},
-        {"name": "labels_provisioned_first", "description": "gh label create is invoked for all seven required labels before any gh issue create call"},
+        {"name": "labels_provisioned_first", "description": "gh label create is invoked for the full taxonomy (3 categories + 18 subcategories + 3 severities + 2 confidences) before any gh issue create call; area/* labels are created lazily at filing time"},
+        {"name": "manifest_built_before_dispatch", "description": "Step 2.5 produces /tmp/devpilot-scan-manifest.txt before scanners are dispatched, capped at 800 paths (or 2000 with --full)"},
+        {"name": "scanners_consume_manifest", "description": "Each of the three scanners is given the manifest path and does not run a fresh `find` of the whole tree"},
+        {"name": "scoring_is_batched", "description": "Scoring uses batches of up to 25 findings per scoring sub-agent dispatch, not one dispatch per finding"},
+        {"name": "dedupe_paginates", "description": "Step 6 uses --limit 1000 and paginates with created:< when the page is full; never relies on --limit 200"},
         {"name": "findings_validated", "description": "Each scanner's JSON output is piped through scripts/check-findings.py before scoring"},
         {"name": "scoring_pass_separate_from_scanner", "description": "Scoring happens in a distinct sub-agent dispatch, not inside the scanner"},
         {"name": "threshold_75_applied", "description": "No finding with score < 75 is filed as an issue"},
-        {"name": "three_labels_per_issue", "description": "Every filed issue has exactly: repo-scan, one scan:<category>, one severity:<level>"},
+        {"name": "three_labels_per_issue", "description": "Every filed issue has exactly five labels: scan/<category>, one matching sec/*|edge/*|cov/* subcategory, severity/<level>, confidence/<score>, and one auto-derived area/<top-level-dir>"},
         {"name": "evidence_block_in_body", "description": "Every filed issue body includes a quoted code block of ≥2 lines and a <file>#L<a>-L<b> link"},
         {"name": "dedupe_against_existing", "description": "gh issue list --label repo-scan is run before any gh issue create, and matching-title issues are skipped"}
       ]
@@ -25,7 +29,7 @@
       "assertions": [
         {"name": "correct_target_resolved", "description": "Skill uses 'SiyuQian/devpilot' as the target, not the current working directory"},
         {"name": "no_local_git_ops", "description": "Skill does not run `git clone` — it reads files via gh or dispatches scanners that use the target repo context"},
-        {"name": "three_labels_per_issue", "description": "Every filed issue still has exactly three labels"}
+        {"name": "three_labels_per_issue", "description": "Every filed issue still has exactly five labels per the new contract"}
       ]
     },
     {
@@ -58,7 +62,7 @@
       "files": [],
       "assertions": [
         {"name": "only_security_scanner_dispatched", "description": "edge-case-hunter and coverage-auditor are not invoked"},
-        {"name": "all_filed_issues_are_security", "description": "Every filed issue has the scan:security label"},
+        {"name": "all_filed_issues_are_security", "description": "Every filed issue has the scan/security label"},
         {"name": "user_confirmed_scope_reduction", "description": "If the user's request is ambiguous about whether to also run the others, the skill confirms before reducing scope"}
       ]
     },
@@ -110,8 +114,8 @@
       "expected_output": "Skill runs normal pipeline but the dedupe step (step 6) compares against existing repo-scan-labeled issues (both open and closed) and skips any finding whose normalized title matches.",
       "files": [],
       "assertions": [
-        {"name": "dedupe_queries_existing_issues", "description": "gh issue list --label repo-scan --state all is invoked before filing"},
-        {"name": "dedupe_considers_closed_issues", "description": "Findings matching a closed repo-scan issue are skipped too (not just open)"},
+        {"name": "dedupe_queries_existing_issues", "description": "gh issue list with a search covering label:scan/security,scan/edge-case,scan/coverage,repo-scan and state=all is invoked before filing (legacy repo-scan label included for backward-compat dedupe)"},
+        {"name": "dedupe_considers_closed_issues", "description": "Findings matching a closed scan-filed issue are skipped too (not just open), under either the new scan/* labels or the legacy repo-scan label"},
         {"name": "dedupe_decisions_logged", "description": "Skipped-duplicates count is reported in the summary"}
       ]
     },
@@ -123,7 +127,7 @@
       "assertions": [
         {"name": "only_coverage_auditor_dispatched", "description": "security-scanner and edge-case-hunter are not invoked"},
         {"name": "no_findings_on_trivial_files", "description": "No filed issue targets a generated file, a type-only file, or a file with only constants"},
-        {"name": "all_filed_issues_are_coverage", "description": "Every filed issue has the scan:coverage label"}
+        {"name": "all_filed_issues_are_coverage", "description": "Every filed issue has the scan/coverage label"}
       ]
     },
     {

--- a/skills/devpilot-scanning-repos/references/issue-template.md
+++ b/skills/devpilot-scanning-repos/references/issue-template.md
@@ -5,16 +5,24 @@ Exactly one `gh issue create` per surviving finding. Use this body verbatim, fil
 ## `gh` invocation
 
 ```bash
+# Derive area label from the first path segment of the finding's file
+area_label="area/$(echo "<finding-file>" | cut -d/ -f1 | tr '/' '-')"
+gh label create "$area_label" --color FEF2C0 --description "Auto-derived from finding file path" || true
+
 gh issue create \
-  --title "[repo-scan:<category>] <title>" \
-  --label "repo-scan,scan:<category>,severity:<severity>" \
+  --title "[scan/<category>] <title>" \
+  --label "scan/<category>,<subcategory>,severity/<severity>,confidence/<score>,$area_label" \
   --body "$(cat <<'EOF'
 <see body template below>
 EOF
 )"
 ```
 
-`<category>` ∈ `security`, `edge-case`, `coverage`. `<severity>` ∈ `high`, `medium`, `low`. The title prefix makes these trivially filterable in the issue list and in notifications.
+- `<category>` ∈ `security`, `edge-case`, `coverage`.
+- `<subcategory>` is one of `sec/*`, `edge/*`, `cov/*` matching the category — see `references/labels.md` for the full enum. The scanner emits the subcategory in its finding (see Finding schema); the orchestrator does NOT pick freely.
+- `<severity>` ∈ `high`, `medium`, `low`.
+- `<score>` ∈ `75`, `100` (output of the scoring pass; sub-75 findings are already filtered).
+- The title prefix `[scan/<category>]` keeps issues trivially filterable in notifications even when labels aren't visible.
 
 ## Body template
 
@@ -43,10 +51,11 @@ https://github.com/<owner>/<repo>/blob/<full-sha>/<path>#L<start>-L<end>
 
 ## Metadata
 
-- Category: `<category>`
+- Category: `<category>` / `<subcategory>`
 - Severity: `<severity>`
+- Area: `<area/...>`
 - Scanner: `<security-scanner | edge-case-hunter | coverage-auditor>`
-- Scored: `<score>/100`
+- Scored: `<score>/100` (`confidence/<score>`)
 
 ---
 
@@ -57,6 +66,6 @@ https://github.com/<owner>/<repo>/blob/<full-sha>/<path>#L<start>-L<end>
 
 - **Use `git rev-parse HEAD` for the SHA in the link** so the link survives future commits. Insert it literally into the body; do not use `$(...)` shell substitution inside the heredoc.
 - **Never** include the full scanner output or the full scoring justification in the body. The template is the contract with the maintainer; extra content degrades scannability.
-- **Labels are mandatory** — always three of them: `repo-scan`, `scan:<category>`, `severity:<severity>`.
+- **Labels are mandatory** — always exactly five: `scan/<category>`, one matching subcategory (`sec/*` | `edge/*` | `cov/*`), `severity/<level>`, `confidence/<score>`, and one auto-derived `area/<top-level-dir>`. See `references/labels.md`.
 - **One issue per finding.** Do NOT batch findings into a single issue, even for the same file.
 - **Do not auto-assign** the issue. Let the maintainer triage.

--- a/skills/devpilot-scanning-repos/references/labels.md
+++ b/skills/devpilot-scanning-repos/references/labels.md
@@ -2,20 +2,89 @@
 
 Run once per repository before the first scan. Safe to re-run — `gh label create` returns a non-zero exit when a label already exists, so guard with `|| true`.
 
+Every label carries information. There is no redundant root label: `scan/<category>` already uniquely identifies issues filed by this skill.
+
+## Required labels
+
 ```bash
-gh label create repo-scan        --color FBCA04 --description "Filed by devpilot-scanning-repos"       || true
-gh label create scan:security    --color B60205 --description "Security category"                 || true
-gh label create scan:edge-case   --color D93F0B --description "Edge-case / robustness category"   || true
-gh label create scan:coverage    --color 0E8A16 --description "Testing-coverage category"         || true
-gh label create severity:high    --color B60205 --description "High-severity scan finding"        || true
-gh label create severity:medium  --color FBCA04 --description "Medium-severity scan finding"      || true
-gh label create severity:low     --color C5DEF5 --description "Low-severity scan finding"         || true
+# --- categories (one per issue) ---
+gh label create scan/security    --color B60205 --description "Filed by devpilot-scanning-repos: security category"      || true
+gh label create scan/edge-case   --color D93F0B --description "Filed by devpilot-scanning-repos: edge-case / robustness" || true
+gh label create scan/coverage    --color 0E8A16 --description "Filed by devpilot-scanning-repos: test-coverage gap"      || true
+
+# --- security subcategories (exactly one when category=scan/security) ---
+gh label create sec/injection         --color B60205 --description "SQL / shell / template / NoSQL injection"     || true
+gh label create sec/authn-authz       --color B60205 --description "Auth bypass, missing checks, role tampering"  || true
+gh label create sec/secrets           --color B60205 --description "Hardcoded keys, tokens, credentials"          || true
+gh label create sec/crypto            --color B60205 --description "Weak hashes, bad RNG, TLS verify disabled"    || true
+gh label create sec/path-traversal    --color B60205 --description "Zip-slip, ../ in user paths, archive escape"  || true
+gh label create sec/ssrf-csrf         --color B60205 --description "SSRF, CORS misconfig, missing CSRF"           || true
+gh label create sec/deserialization   --color B60205 --description "pickle, unsafe yaml, gob from untrusted"      || true
+gh label create sec/tls-misconfig     --color B60205 --description "Cert verify off, weak ciphers, plaintext"     || true
+
+# --- edge-case subcategories (exactly one when category=scan/edge-case) ---
+gh label create edge/nil-deref         --color D93F0B --description "Nil pointer / map / slice deref"             || true
+gh label create edge/bounds-overflow   --color D93F0B --description "Off-by-one, integer over/underflow"          || true
+gh label create edge/error-swallowed   --color D93F0B --description "Discarded errors, returned-nil-on-error"     || true
+gh label create edge/concurrency       --color D93F0B --description "Race, deadlock, leaked goroutine, double-close" || true
+gh label create edge/resource-leak     --color D93F0B --description "Unclosed file/conn/row/ticker on error path" || true
+gh label create edge/input-validation  --color D93F0B --description "Unbounded user input → index/alloc/length"   || true
+
+# --- coverage subcategories (exactly one when category=scan/coverage) ---
+gh label create cov/no-test-file       --color 0E8A16 --description "Exported surface with no test file at all"   || true
+gh label create cov/error-paths        --color 0E8A16 --description "Happy path tested, error branches not"        || true
+gh label create cov/integration-seam   --color 0E8A16 --description "Untested boundary between two packages"       || true
+gh label create cov/stale-test         --color 0E8A16 --description "Production churn, test file stagnant"         || true
+
+# --- severity (one per issue; switched : → / for namespace consistency) ---
+gh label create severity/high     --color CC0000 --description "High-severity scan finding"   || true   # darker than scan/security on purpose
+gh label create severity/medium   --color FBCA04 --description "Medium-severity scan finding" || true
+gh label create severity/low      --color C5DEF5 --description "Low-severity scan finding"    || true
+
+# --- confidence (one per issue, from the scoring pass) ---
+gh label create confidence/75     --color BFD4F2 --description "Scoring agent gave 75/100 — real, meaningful, verified"     || true
+gh label create confidence/100    --color 0052CC --description "Scoring agent gave 100/100 — certain, load-bearing, frequent" || true
 ```
+
+## `area/<top-level-dir>` (auto-created on demand)
+
+Derived from each finding's `file` path: take the first path segment, replace `/` with `-`. Example: a finding on `internal/auth/middleware.go` gets `area/internal-auth`.
+
+The orchestrator MUST create the area label idempotently right before filing the issue:
+
+```bash
+area_label="area/$(echo "<finding-file>" | cut -d/ -f1 | tr '/' '-')"
+gh label create "$area_label" --color FEF2C0 --description "Auto-derived from finding file path" || true
+```
+
+This lets the file's CODEOWNER filter `is:open label:area/internal-auth` and see only their slice.
+
+## Per-issue label contract
+
+Every filed issue MUST have exactly **five** labels:
+
+1. One `scan/<category>` — `security` | `edge-case` | `coverage`
+2. One subcategory matching the category — `sec/*` | `edge/*` | `cov/*`
+3. One `severity/<level>` — `high` | `medium` | `low`
+4. One `confidence/<score>` — `75` | `100` (matches the scoring-pass output)
+5. One `area/<top-level-dir>` — auto-derived from `file`
+
+If a scanner returns a finding whose subcategory doesn't fit any of the labels above, the orchestrator drops it and logs the mismatch — do not invent new subcategory labels at filing time. The fixed taxonomy is the contract.
 
 ## Rationale
 
-- `repo-scan` is the root label — filter to this to see the full scan backlog.
-- `scan:<category>` lets the maintainer route the work (security → security team, coverage → the file's owner, etc.).
-- `severity:<severity>` maps cleanly to the 3-tier triage bucket most teams already use.
+- **`repo-scan` was deleted** because every scan-filed issue already carries `scan/*`. A label every issue has filters nothing.
+- **Subcategories are mandatory**, not optional, so triage queries like `label:sec/injection` actually return a meaningful slice instead of every security issue lumped together.
+- **`area/*` labels** route work to the file's owner without the orchestrator needing CODEOWNERS context — the maintainer already knows their dir.
+- **`confidence/*`** lets reviewers process the `100` bucket first; mixed lists slow triage.
+- **Color collision fixed**: `scan/security` keeps `#B60205`, `severity/high` is now `#CC0000` — distinguishable in the UI.
 
-Do not add more labels. A longer taxonomy slows triage more than it helps.
+## Migration from the old taxonomy
+
+If you previously ran the skill and have issues labeled `repo-scan`, `scan:security`, etc., do NOT mass-relabel. Run:
+
+```bash
+gh issue list --label repo-scan --state all --limit 1000 --json number,labels
+```
+
+and let the dedupe step (SKILL.md step 6) treat them as historical — old issues stay on the old labels, new issues use the new ones. The dedupe normalizer matches on title, not labels, so this is safe.

--- a/skills/devpilot-scanning-repos/references/scoring.md
+++ b/skills/devpilot-scanning-repos/references/scoring.md
@@ -1,10 +1,18 @@
 # Scoring rubric
 
-After each scanner returns its findings, dispatch ONE lightweight sub-agent per finding with this prompt. The agent returns a single number in `{0, 25, 50, 75, 100}` plus a one-line justification.
+Findings are scored in **batches of up to 25** per sub-agent dispatch. The per-finding fan-out (one dispatch per finding) does not scale past ~50 findings — empirically observed on large-repo runs where scanners returned 200+ findings. Group by category, send one batch per dispatch.
 
 Keep the scoring agent isolated from the scanner agents — it must evaluate each finding on its own merits, not be anchored by the scanner's framing.
 
-## Scoring-agent prompt (paste verbatim)
+## Batched scoring prompt (paste verbatim)
+
+> You are scoring a batch of code-scan findings for confidence. The input is a JSON array of `Finding` objects. Return ONLY a JSON array of `{"index": <int>, "score": <int>, "reason": "<one sentence>"}` aligned with the input order. Use the scale below.
+>
+> For each finding: read the cited file at `line_range`, evaluate against the rubric, assign a score in `{0, 25, 50, 75, 100}`. Do NOT skip findings; if you can't read a file, score it 25 with reason "could not verify".
+
+(Per-finding rubric is identical to the single-finding version below.)
+
+## Single-finding prompt (legacy — for spot rescoring)
 
 > You are evaluating a single code-scan finding for confidence. Read the finding, read the file cited in `file` around `line_range`, and assign a score using this scale. Return ONLY `{"score": <int>, "reason": "<one sentence>"}`.
 >

--- a/skills/devpilot-scanning-repos/scripts/check-findings.py
+++ b/skills/devpilot-scanning-repos/scripts/check-findings.py
@@ -4,10 +4,15 @@
 Usage:
     cat findings.json | python3 scripts/check-findings.py
     python3 scripts/check-findings.py findings.json
+    python3 scripts/check-findings.py findings.json --manifest /tmp/devpilot-scan-manifest.txt
 
 Exits 0 if every finding is well-formed, non-zero otherwise. On failure, prints
 the index of the bad finding, the field that's wrong, and the offending object.
 The agent should re-emit (or drop) the failing finding before scoring.
+
+When `--manifest <path>` is provided, also rejects findings whose `file` is not
+in the manifest — enforces the SKILL.md step 2.5 contract that scanners may
+only emit findings on manifest paths.
 """
 
 from __future__ import annotations
@@ -18,6 +23,7 @@ from typing import Any
 
 REQUIRED_FIELDS = (
     "category",
+    "subcategory",
     "title",
     "severity",
     "file",
@@ -28,10 +34,23 @@ REQUIRED_FIELDS = (
 )
 VALID_CATEGORIES = {"security", "edge-case", "coverage"}
 VALID_SEVERITIES = {"high", "medium", "low"}
+VALID_SUBCATEGORIES = {
+    "security": {
+        "sec/injection", "sec/authn-authz", "sec/secrets", "sec/crypto",
+        "sec/path-traversal", "sec/ssrf-csrf", "sec/deserialization", "sec/tls-misconfig",
+    },
+    "edge-case": {
+        "edge/nil-deref", "edge/bounds-overflow", "edge/error-swallowed",
+        "edge/concurrency", "edge/resource-leak", "edge/input-validation",
+    },
+    "coverage": {
+        "cov/no-test-file", "cov/error-paths", "cov/integration-seam", "cov/stale-test",
+    },
+}
 MAX_TITLE_LEN = 80
 
 
-def check(finding: Any, idx: int) -> list[str]:
+def check(finding: Any, idx: int, manifest: set[str] | None = None) -> list[str]:
     errs: list[str] = []
     if not isinstance(finding, dict):
         return [f"[{idx}] not a JSON object"]
@@ -48,6 +67,12 @@ def check(finding: Any, idx: int) -> list[str]:
     if sev is not None and sev not in VALID_SEVERITIES:
         errs.append(f"[{idx}] severity='{sev}' not in {sorted(VALID_SEVERITIES)}")
 
+    sub = finding.get("subcategory")
+    if cat in VALID_SUBCATEGORIES:
+        allowed = VALID_SUBCATEGORIES[cat]
+        if sub is not None and sub not in allowed:
+            errs.append(f"[{idx}] subcategory='{sub}' not valid for category='{cat}'; allowed: {sorted(allowed)}")
+
     title = finding.get("title")
     if isinstance(title, str):
         if not title.strip():
@@ -62,6 +87,10 @@ def check(finding: Any, idx: int) -> list[str]:
     file_ = finding.get("file")
     if isinstance(file_, str) and file_.startswith("/"):
         errs.append(f"[{idx}] file must be repo-relative, got absolute path '{file_}'")
+    if manifest is not None and isinstance(file_, str):
+        normalized = file_.lstrip("./")
+        if normalized not in manifest and file_ not in manifest:
+            errs.append(f"[{idx}] file '{file_}' is not in the scan manifest — scanners may only emit findings on manifest paths (SKILL.md step 2.5)")
 
     lr = finding.get("line_range")
     if isinstance(lr, str) and not lr.startswith("L"):
@@ -75,8 +104,21 @@ def check(finding: Any, idx: int) -> list[str]:
 
 
 def main() -> int:
-    if len(sys.argv) > 1 and sys.argv[1] != "-":
-        with open(sys.argv[1], encoding="utf-8") as fh:
+    args = sys.argv[1:]
+    manifest: set[str] | None = None
+    if "--manifest" in args:
+        i = args.index("--manifest")
+        try:
+            manifest_path = args[i + 1]
+        except IndexError:
+            print("ERROR: --manifest requires a path argument", file=sys.stderr)
+            return 2
+        with open(manifest_path, encoding="utf-8") as fh:
+            manifest = {line.strip().lstrip("./") for line in fh if line.strip()}
+        del args[i : i + 2]
+
+    if args and args[0] != "-":
+        with open(args[0], encoding="utf-8") as fh:
             raw = fh.read()
     else:
         raw = sys.stdin.read()
@@ -92,8 +134,13 @@ def main() -> int:
         return 2
 
     all_errs: list[str] = []
+    real_count = 0
     for i, f in enumerate(findings):
-        all_errs.extend(check(f, i))
+        # Skip the optional trailing _meta object scanners append under context pressure.
+        if isinstance(f, dict) and "_meta" in f and len(f) == 1:
+            continue
+        real_count += 1
+        all_errs.extend(check(f, i, manifest))
 
     if all_errs:
         print("INVALID findings:", file=sys.stderr)
@@ -102,7 +149,7 @@ def main() -> int:
         print(f"\n{len(all_errs)} error(s) across {len(findings)} finding(s)", file=sys.stderr)
         return 1
 
-    print(f"OK: {len(findings)} finding(s) validated")
+    print(f"OK: {real_count} finding(s) validated")
     return 0
 
 


### PR DESCRIPTION
## Summary

Stress-tested `devpilot-scanning-repos` against `kubernetes/kubernetes` (16,942 source files, ~268k tokens just for the path list) and tightened two failure classes: **uninformative labels** and **unbounded scanning on large repos**.

## What changed

### Labels — every label now carries information

Dropped `repo-scan` (every scan issue had it, so it filtered nothing). New 5-label contract per filed issue:

| Label | Cardinality | Notes |
|---|---|---|
| `scan/<category>` | 3 | `security` \| `edge-case` \| `coverage` — uniquely identifies scan-filed issues |
| subcategory | 18 total | `sec/*` ×8, `edge/*` ×6, `cov/*` ×4 — closed set, validator-enforced |
| `severity/<level>` | 3 | `:` → `/` for namespace consistency |
| `confidence/<score>` | 2 | `75` \| `100` — from the scoring pass |
| `area/<top-level-dir>` | dynamic | auto-derived from finding's file path so CODEOWNERs can filter |

Fixes the `scan/security` vs `severity/high` color collision (`#B60205` vs `#CC0000`).

### Large-repo scaffolding — driven by real measurements

- **New SKILL.md step 2.5: shared file manifest.** Main agent does ONE walk and writes `/tmp/devpilot-scan-manifest.txt` (cap 800; `--full` raises to 2000). Sampling priority: 90-day churn → dynamic top-level dirs by file count → security-sensitive name patterns. Replaces the hardcoded `cmd/, internal/, api/, ...` allowlist that matched only **3% of code** on k8s.
- **Scanners may only read manifest paths.** `check-findings.py --manifest` rejects findings on non-manifest files — enforced, not just documented.
- **Per-pattern grep cap: 40 hits.** With explicit `skipped: N additional <pattern> hits` logging so coverage gaps are visible. Previously `exec.Command` alone returned 252 hits, which silently overflowed scanner context.
- **Scoring batched** (≤25 findings per sub-agent dispatch) instead of one dispatch per finding — the per-finding fan-out doesn't scale past ~50 findings.
- **Dedupe paginates** with `--limit 1000` + `created:<<<date>`. The previous `--limit 200` was confirmed to silently truncate against k8s.
- **`_meta` trailer** lets scanners signal context exhaustion; validator skips it, orchestrator sees coverage explicitly.

### Backward compatibility

Dedupe search still includes `label:repo-scan` so re-runs against repos scanned under the old label set still dedupe correctly. Old issues stay on their old labels — no mass-relabel.

## Review Guide

Start with **`SKILL.md`** — that's the contract. Then:

1. **`references/labels.md`** — the new taxonomy and `gh label create` block.
2. **`SKILL.md` "Scaling for large repos"** section — manifest algorithm with the actual k8s numbers that motivated it.
3. **`scripts/check-findings.py`** — short; the `--manifest` mode is the new enforcement teeth.
4. **`agents/security-scanner.md`** — manifest discipline + grep cap + meta trailer; the other two scanners follow the same pattern more briefly.
5. **`references/issue-template.md` + `evals/evals.json`** — wiring updates to match the 5-label contract.

Things to watch for:
- The `_meta` trailer object in scanner output: validator skips it (`scripts/check-findings.py:118`); make sure that's the right trade-off vs forcing a stricter envelope.
- Sampling priorities for the manifest are a judgment call — the order is churn → dynamic dirs → security-name patterns. If you'd prioritize differently for your team, this is the place.
- Migration: existing `repo-scan` issues are NOT relabeled. The dedupe code reads both label sets.

## Test plan

- [x] `python3 -m py_compile scripts/check-findings.py`
- [x] `python3 -c 'import json; json.load(open("evals/evals.json"))'`
- [x] Validator smoke test: subcategory enum mismatch → exit 1 with field error
- [x] Validator smoke test: `--manifest` flag rejects out-of-manifest finding paths
- [x] Validator smoke test: `_meta` trailer is skipped, real-finding count reported
- [ ] (human) Re-run the skill against a small real repo (e.g. `SiyuQian/devpilot` itself) end-to-end, confirm 5-label contract holds
- [ ] (human) Run against a large repo with `--full` to confirm the 2000-cap path

🤖 Generated with [Claude Code](https://claude.com/claude-code)