### PR TITLE
feat(scanning-repos): reuse existing repo labels, switch to {type}:{value} naming

### DIFF
--- a/skills/devpilot-scanning-repos/SKILL.md
+++ b/skills/devpilot-scanning-repos/SKILL.md
@@ -34,7 +34,14 @@ A whole-repo sweep that dispatches **three parallel specialist sub-agents**, sco
 ## Workflow
 
 1. **Resolve target.** Accept `owner/repo`, a clone URL, or "this repo" (use `gh repo view --json nameWithOwner`). Verify with `gh repo view`.
-2. **Ensure labels exist.** Create (idempotently) the full label taxonomy: `scan/<category>` × 3, all `sec/*` / `edge/*` / `cov/*` subcategories, `severity/<level>` × 3, `confidence/75`, `confidence/100`. `area/*` labels are created lazily at filing time (one per first-path-segment encountered). See `references/labels.md` for the exact `gh label create` block — paste it verbatim.
+2. **Reconcile labels — reuse what the repo already has, only create what's missing.** Do NOT blindly paste a `gh label create` block. The procedure:
+   1. **Snapshot existing labels:** `gh label list --limit 200 --json name,description > /tmp/devpilot-existing-labels.json`. If the count returned equals the limit, raise `--limit` and re-run until the result is shorter than the limit.
+   2. **For each label the skill needs** (the full taxonomy lives in `references/labels.md`): check whether the repo already has a *suitable* label for the same purpose. "Suitable" means same semantic intent, not just same name. A repo label `security` or `type:security` covers `scan:security`; `bug` does NOT cover `edge:nil-deref` (too generic). The match rule: the existing label's name OR description clearly maps onto the canonical purpose listed in `references/labels.md`. When in doubt, do NOT reuse — false reuse poisons triage queries.
+   3. **Build a name-mapping table** for this run: `canonical_name → label_to_apply` (either the canonical `type:value` name, or the suitable existing repo label). The orchestrator uses this mapping when filing issues in step 7.
+   4. **Only create the labels that have no suitable existing match.** Use the canonical `type:value` form. See `references/labels.md` for the exact `gh label create` invocation per label (colors and descriptions). Skip any label already mapped to an existing repo label.
+   5. **Print the reconciliation summary** to the user before continuing: `N reused, M created, list of each` — so they can spot a wrong reuse before issues get filed.
+
+   `area:*` labels follow the same rule but are reconciled lazily at filing time (step 7): for each finding, check the snapshot for an existing area-ish label covering the same top-level dir before creating `area:<dir>`.
 2.5. **Build a shared file manifest.** The orchestrator does ONE walk and hands a sampled file list to all three scanners. Scanners MUST NOT re-walk — they may only read paths in the manifest. See "Scaling for large repos" below for the algorithm. The manifest is a plain text file written to `/tmp/devpilot-scan-manifest.txt`, one repo-relative path per line. Default cap: **800 files**. Override with `--full` (raises to 2000) or `--scope <dir>` (manifest = `find <dir>` capped at 800).
 3. **Dispatch scanners in parallel.** In ONE message, launch three sub-agents using the prompts in `agents/`:
    - `agents/security-scanner.md`
@@ -46,11 +53,11 @@ A whole-repo sweep that dispatches **three parallel specialist sub-agents**, sco
 5. **Filter.** Drop every finding with score `< 75`. If zero survive, stop — report "no high-confidence issues found" to the user and do not create issues.
 6. **Deduplicate against existing issues.** Before filing, query existing scan issues. Use a search that covers BOTH the new taxonomy and the legacy `repo-scan` label (so re-runs against repos scanned under the old label set still dedupe correctly):
    ```bash
-   gh issue list --search 'label:scan/security,scan/edge-case,scan/coverage,repo-scan in:title' \
+   gh issue list --search 'label:scan:security,scan:edge-case,scan:coverage,repo-scan in:title' \
      --state all --limit 1000 --json title,number,state
    ```
-   Normalize titles by lower-casing, stripping the `[scan/<category>]` / `[repo-scan:<category>]` prefix, and collapsing whitespace before comparing. Skip findings whose normalized title matches an existing issue. If `--limit 1000` returns exactly 1000, paginate with `--search "... created:<<date-of-oldest>"` until empty.
-7. **File issues.** One `gh issue create` per surviving finding, using the template in `references/issue-template.md`. Labels: always exactly five — `scan/<category>` + matching subcategory + `severity/<level>` + `confidence/<score>` + auto-derived `area/<top-level-dir>`. Create the `area/*` label idempotently right before the issue.
+   Normalize titles by lower-casing, stripping the `[scan:<category>]` / `[repo-scan:<category>]` prefix, and collapsing whitespace before comparing. Skip findings whose normalized title matches an existing issue. If `--limit 1000` returns exactly 1000, paginate with `--search "... created:<<date-of-oldest>"` until empty.
+7. **File issues.** One `gh issue create` per surviving finding, using the template in `references/issue-template.md`. Labels: always exactly five — apply the labels from the step-2 mapping table for `scan:<category>`, the matching subcategory, `severity:<level>`, `confidence:<score>`, plus an `area:<top-level-dir>` resolved lazily here. For the area label: first check `/tmp/devpilot-existing-labels.json` for a suitable existing label (e.g. repo already has `area-cmd` or `cmd` covering the dir) and reuse it; only run `gh label create area:<dir>` when no suitable repo label exists.
 8. **Summarize.** Print a compact table to the user: `[category] [severity] title → #issue-number`.
 
 ## Finding format
@@ -60,7 +67,7 @@ Every scanner returns a JSON array of objects with exactly these fields:
 ```json
 {
   "category": "security | edge-case | coverage",
-  "subcategory": "sec/injection | sec/authn-authz | sec/secrets | sec/crypto | sec/path-traversal | sec/ssrf-csrf | sec/deserialization | sec/tls-misconfig | edge/nil-deref | edge/bounds-overflow | edge/error-swallowed | edge/concurrency | edge/resource-leak | edge/input-validation | cov/no-test-file | cov/error-paths | cov/integration-seam | cov/stale-test",
+  "subcategory": "sec:injection | sec:authn-authz | sec:secrets | sec:crypto | sec:path-traversal | sec:ssrf-csrf | sec:deserialization | sec:tls-misconfig | edge:nil-deref | edge:bounds-overflow | edge:error-swallowed | edge:concurrency | edge:resource-leak | edge:input-validation | cov:no-test-file | cov:error-paths | cov:integration-seam | cov:stale-test",
   "title": "<≤80 chars, imperative — e.g. 'Sanitize shell input in cmd/devpilot/run.go'>",
   "severity": "high | medium | low",
   "file": "<path relative to repo root>",
@@ -71,7 +78,7 @@ Every scanner returns a JSON array of objects with exactly these fields:
 }
 ```
 
-`subcategory` must match `category` (`sec/*` for security, `edge/*` for edge-case, `cov/*` for coverage). See `references/labels.md` for the fixed enum — scanners do NOT invent new subcategory values. If a finding doesn't fit any subcategory, the scanner picks the closest fit OR drops the finding.
+`subcategory` must match `category` (`sec:*` for security, `edge:*` for edge-case, `cov:*` for coverage). See `references/labels.md` for the fixed enum — scanners do NOT invent new subcategory values. If a finding doesn't fit any subcategory, the scanner picks the closest fit OR drops the finding.
 
 `evidence` is mandatory. A finding without quotable code is speculation — drop it at the scanner level.
 
@@ -115,9 +122,9 @@ See each agent prompt for category-specific false-positive classes.
 A correct run of this skill produces:
 
 1. Exactly three scanner sub-agent dispatches, in parallel.
-2. Every filed issue has exactly five labels: `scan/<category>`, a matching `sec/*`|`edge/*`|`cov/*` subcategory, `severity/<level>`, `confidence/<score>` (75 or 100), and an auto-derived `area/<top-level-dir>`.
+2. Every filed issue has exactly five labels: `scan:<category>`, a matching `sec:*`|`edge:*`|`cov:*` subcategory, `severity:<level>`, `confidence:<score>` (75 or 100), and an auto-derived `area:<top-level-dir>`.
 3. No issue is filed whose scoring-agent score is below 75.
-4. No duplicate of an existing open scan issue (under either the new `scan/*` labels or the legacy `repo-scan` label).
+4. No duplicate of an existing open scan issue (under either the new `scan:*` labels or the legacy `repo-scan` label).
 5. No finding cites business-logic correctness as the sole reason.
 6. Every filed issue body quotes ≥2 lines of actual code with a `<file>#L<start>-L<end>` link.
 7. If zero findings survive scoring, no issues are filed and the user is told so explicitly.
@@ -171,7 +178,9 @@ Group findings by category, send up to **25 findings per scoring sub-agent** dis
 - **Letting scanners filter their own output.** They should over-report. The scoring pass does the filtering. Merging the two loses calibration.
 - **Using the scanner agent to also create the issue.** Don't — the scanner has too much context. File issues from the main agent after scoring.
 - **Dropping the evidence block in the issue body.** Without it the human has to re-derive the finding. File a crap issue once and nobody trusts the skill.
-- **Creating labels inside the issue-creation loop.** Race-y and noisy. Do it once upfront (step 2).
+- **Mass-creating the full taxonomy upfront without checking the repo.** The skill MUST snapshot existing labels (step 2) and reuse any suitable ones. Blindly creating `scan:security` when the repo already has `security` doubles the label space and fragments triage queries.
+- **"Suitable" stretched too far.** Reusing `bug` for every `edge:*` finding loses the per-subcategory triage signal. When the existing label is too generic, create the canonical one.
+- **Creating subcategory or severity labels inside the issue-creation loop.** Reconcile in step 2, file in step 7. Only `area:*` is resolved lazily, and even then it goes through the same suitable-existing-label check.
 - **Asking scanners to rank severity *and* confidence.** Confidence is the scoring pass's job; scanners assign severity only.
 - **Forgetting the dedupe step.** Re-running the skill must be idempotent or the user will stop running it.
 

--- a/skills/devpilot-scanning-repos/agents/coverage-auditor.md
+++ b/skills/devpilot-scanning-repos/agents/coverage-auditor.md
@@ -42,7 +42,7 @@ Return ONLY a JSON array:
 [
   {
     "category": "coverage",
-    "subcategory": "cov/no-test-file",
+    "subcategory": "cov:no-test-file",
     "title": "No tests for authentication middleware in internal/auth/middleware.go",
     "severity": "high",
     "file": "internal/auth/middleware.go",
@@ -68,9 +68,9 @@ Be over-inclusive. The scoring pass filters.
 
 Every finding MUST set `subcategory` to one of:
 
-- `cov/no-test-file` — exported file has no companion `*_test.*` anywhere in the repo
-- `cov/error-paths` — happy path tested, error branches have no assertions
-- `cov/integration-seam` — boundary between two packages (auth+handler, etc.) has no test
-- `cov/stale-test` — production file churned recently (`git log --since=90.days.ago`), test file did not
+- `cov:no-test-file` — exported file has no companion `*_test.*` anywhere in the repo
+- `cov:error-paths` — happy path tested, error branches have no assertions
+- `cov:integration-seam` — boundary between two packages (auth+handler, etc.) has no test
+- `cov:stale-test` — production file churned recently (`git log --since=90.days.ago`), test file did not
 
 Pick the closest fit. Do NOT invent new subcategories. If nothing fits, drop the finding.

--- a/skills/devpilot-scanning-repos/agents/edge-case-hunter.md
+++ b/skills/devpilot-scanning-repos/agents/edge-case-hunter.md
@@ -60,7 +60,7 @@ Return ONLY a JSON array (no prose) of findings using the repo-scan Finding sche
 [
   {
     "category": "edge-case",
-    "subcategory": "edge/nil-deref",
+    "subcategory": "edge:nil-deref",
     "title": "Nil map dereferenced on empty config in internal/project/config.go",
     "severity": "medium",
     "file": "internal/project/config.go",
@@ -86,11 +86,11 @@ Be over-inclusive — filtering happens downstream.
 
 Every finding MUST set `subcategory` to one of:
 
-- `edge/nil-deref` — nil pointer / nil map / nil interface deref, empty-slice index
-- `edge/bounds-overflow` — off-by-one, integer over/underflow, slice index out of range
-- `edge/error-swallowed` — discarded errors, returned-zero-value-on-error, ignored close errors on writes
-- `edge/concurrency` — data race, deadlock, leaked goroutine, double-close, captured loop var, missing context propagation
-- `edge/resource-leak` — unclosed file / response.Body / DB row / ticker / mutex on error path
-- `edge/input-validation` — unbounded external input flowing into index, length, or `make([]T, n)`
+- `edge:nil-deref` — nil pointer / nil map / nil interface deref, empty-slice index
+- `edge:bounds-overflow` — off-by-one, integer over/underflow, slice index out of range
+- `edge:error-swallowed` — discarded errors, returned-zero-value-on-error, ignored close errors on writes
+- `edge:concurrency` — data race, deadlock, leaked goroutine, double-close, captured loop var, missing context propagation
+- `edge:resource-leak` — unclosed file / response.Body / DB row / ticker / mutex on error path
+- `edge:input-validation` — unbounded external input flowing into index, length, or `make([]T, n)`
 
 Pick the closest fit. Do NOT invent new subcategories. If nothing fits, drop the finding.

--- a/skills/devpilot-scanning-repos/agents/security-scanner.md
+++ b/skills/devpilot-scanning-repos/agents/security-scanner.md
@@ -48,7 +48,7 @@ Return ONLY a JSON array. No prose.
 [
   {
     "category": "security",
-    "subcategory": "sec/injection",
+    "subcategory": "sec:injection",
     "title": "Shell command built from unvalidated HTTP input in internal/runner/exec.go",
     "severity": "high",
     "file": "internal/runner/exec.go",
@@ -64,14 +64,14 @@ Return ONLY a JSON array. No prose.
 
 Every finding MUST set `subcategory` to one of:
 
-- `sec/injection` — SQL / shell / template / NoSQL / LDAP injection
-- `sec/authn-authz` — missing auth, bypassable role checks, broken session
-- `sec/secrets` — hardcoded keys / tokens / credentials in code or history
-- `sec/crypto` — weak hash, bad RNG, ECB, static IV, JWT alg=none
-- `sec/path-traversal` — `../` injection, zip-slip, archive escape
-- `sec/ssrf-csrf` — SSRF, permissive CORS on private data, missing CSRF
-- `sec/deserialization` — pickle/unsafe yaml/gob from untrusted sources
-- `sec/tls-misconfig` — `InsecureSkipVerify`, plaintext-where-TLS-expected, weak ciphers
+- `sec:injection` — SQL / shell / template / NoSQL / LDAP injection
+- `sec:authn-authz` — missing auth, bypassable role checks, broken session
+- `sec:secrets` — hardcoded keys / tokens / credentials in code or history
+- `sec:crypto` — weak hash, bad RNG, ECB, static IV, JWT alg=none
+- `sec:path-traversal` — `../` injection, zip-slip, archive escape
+- `sec:ssrf-csrf` — SSRF, permissive CORS on private data, missing CSRF
+- `sec:deserialization` — pickle/unsafe yaml/gob from untrusted sources
+- `sec:tls-misconfig` — `InsecureSkipVerify`, plaintext-where-TLS-expected, weak ciphers
 
 If a finding doesn't fit any of these, pick the closest fit OR drop the finding. Do NOT invent a new subcategory.
 

--- a/skills/devpilot-scanning-repos/evals/evals.json
+++ b/skills/devpilot-scanning-repos/evals/evals.json
@@ -8,7 +8,7 @@
       "files": [],
       "assertions": [
         {"name": "exactly_three_scanner_dispatches", "description": "Main agent dispatches security-scanner, edge-case-hunter, and coverage-auditor exactly once each, in parallel (one message)"},
-        {"name": "labels_provisioned_first", "description": "gh label create is invoked for the full taxonomy (3 categories + 18 subcategories + 3 severities + 2 confidences) before any gh issue create call; area/* labels are created lazily at filing time"},
+        {"name": "labels_provisioned_first", "description": "gh label create is invoked for the full taxonomy (3 categories + 18 subcategories + 3 severities + 2 confidences) before any gh issue create call; area:* labels are created lazily at filing time"},
         {"name": "manifest_built_before_dispatch", "description": "Step 2.5 produces /tmp/devpilot-scan-manifest.txt before scanners are dispatched, capped at 800 paths (or 2000 with --full)"},
         {"name": "scanners_consume_manifest", "description": "Each of the three scanners is given the manifest path and does not run a fresh `find` of the whole tree"},
         {"name": "scoring_is_batched", "description": "Scoring uses batches of up to 25 findings per scoring sub-agent dispatch, not one dispatch per finding"},
@@ -16,7 +16,7 @@
         {"name": "findings_validated", "description": "Each scanner's JSON output is piped through scripts/check-findings.py before scoring"},
         {"name": "scoring_pass_separate_from_scanner", "description": "Scoring happens in a distinct sub-agent dispatch, not inside the scanner"},
         {"name": "threshold_75_applied", "description": "No finding with score < 75 is filed as an issue"},
-        {"name": "three_labels_per_issue", "description": "Every filed issue has exactly five labels: scan/<category>, one matching sec/*|edge/*|cov/* subcategory, severity/<level>, confidence/<score>, and one auto-derived area/<top-level-dir>"},
+        {"name": "three_labels_per_issue", "description": "Every filed issue has exactly five labels: scan:<category>, one matching sec:*|edge:*|cov:* subcategory, severity:<level>, confidence:<score>, and one auto-derived area:<top-level-dir>"},
         {"name": "evidence_block_in_body", "description": "Every filed issue body includes a quoted code block of ≥2 lines and a <file>#L<a>-L<b> link"},
         {"name": "dedupe_against_existing", "description": "gh issue list --label repo-scan is run before any gh issue create, and matching-title issues are skipped"}
       ]
@@ -62,7 +62,7 @@
       "files": [],
       "assertions": [
         {"name": "only_security_scanner_dispatched", "description": "edge-case-hunter and coverage-auditor are not invoked"},
-        {"name": "all_filed_issues_are_security", "description": "Every filed issue has the scan/security label"},
+        {"name": "all_filed_issues_are_security", "description": "Every filed issue has the scan:security label"},
         {"name": "user_confirmed_scope_reduction", "description": "If the user's request is ambiguous about whether to also run the others, the skill confirms before reducing scope"}
       ]
     },
@@ -114,8 +114,8 @@
       "expected_output": "Skill runs normal pipeline but the dedupe step (step 6) compares against existing repo-scan-labeled issues (both open and closed) and skips any finding whose normalized title matches.",
       "files": [],
       "assertions": [
-        {"name": "dedupe_queries_existing_issues", "description": "gh issue list with a search covering label:scan/security,scan/edge-case,scan/coverage,repo-scan and state=all is invoked before filing (legacy repo-scan label included for backward-compat dedupe)"},
-        {"name": "dedupe_considers_closed_issues", "description": "Findings matching a closed scan-filed issue are skipped too (not just open), under either the new scan/* labels or the legacy repo-scan label"},
+        {"name": "dedupe_queries_existing_issues", "description": "gh issue list with a search covering label:scan:security,scan:edge-case,scan:coverage,repo-scan and state=all is invoked before filing (legacy repo-scan label included for backward-compat dedupe)"},
+        {"name": "dedupe_considers_closed_issues", "description": "Findings matching a closed scan-filed issue are skipped too (not just open), under either the new scan:* labels or the legacy repo-scan label"},
         {"name": "dedupe_decisions_logged", "description": "Skipped-duplicates count is reported in the summary"}
       ]
     },
@@ -127,7 +127,7 @@
       "assertions": [
         {"name": "only_coverage_auditor_dispatched", "description": "security-scanner and edge-case-hunter are not invoked"},
         {"name": "no_findings_on_trivial_files", "description": "No filed issue targets a generated file, a type-only file, or a file with only constants"},
-        {"name": "all_filed_issues_are_coverage", "description": "Every filed issue has the scan/coverage label"}
+        {"name": "all_filed_issues_are_coverage", "description": "Every filed issue has the scan:coverage label"}
       ]
     },
     {

--- a/skills/devpilot-scanning-repos/references/issue-template.md
+++ b/skills/devpilot-scanning-repos/references/issue-template.md
@@ -5,24 +5,29 @@ Exactly one `gh issue create` per surviving finding. Use this body verbatim, fil
 ## `gh` invocation
 
 ```bash
-# Derive area label from the first path segment of the finding's file
-area_label="area/$(echo "<finding-file>" | cut -d/ -f1 | tr '/' '-')"
-gh label create "$area_label" --color FEF2C0 --description "Auto-derived from finding file path" || true
+# Resolve the five labels via the step-2 mapping table (canonical → label_to_apply).
+# For area: first check /tmp/devpilot-existing-labels.json for a suitable existing
+# area-ish label covering the finding's top-level dir. Reuse if suitable; otherwise:
+area_dir=$(echo "<finding-file>" | cut -d/ -f1)
+area_label="area:$area_dir"   # or the reused suitable existing label
+# Only run create when no suitable repo label was found:
+gh label create "$area_label" --color FEF2C0 --description "Auto-derived from finding file path"
 
 gh issue create \
-  --title "[scan/<category>] <title>" \
-  --label "scan/<category>,<subcategory>,severity/<severity>,confidence/<score>,$area_label" \
+  --title "[scan:<category>] <title>" \
+  --label "<category_label>,<subcategory_label>,<severity_label>,<confidence_label>,$area_label" \
   --body "$(cat <<'EOF'
 <see body template below>
 EOF
 )"
 ```
 
-- `<category>` ∈ `security`, `edge-case`, `coverage`.
-- `<subcategory>` is one of `sec/*`, `edge/*`, `cov/*` matching the category — see `references/labels.md` for the full enum. The scanner emits the subcategory in its finding (see Finding schema); the orchestrator does NOT pick freely.
+- `<category_label>` etc. come from the step-2 mapping table — they are the *resolved* labels, which may be the canonical `{type}:{value}` form or a suitable existing repo label the orchestrator chose to reuse.
+- `<category>` in the title prefix is always the canonical category value (`security` | `edge-case` | `coverage`), regardless of which label was reused. This keeps title-based dedupe (SKILL.md step 6) and notification filters stable across runs.
+- Canonical `<subcategory>` is one of `sec:*`, `edge:*`, `cov:*` matching the category — see `references/labels.md` for the full enum. The scanner emits the canonical subcategory; the orchestrator does NOT pick freely.
 - `<severity>` ∈ `high`, `medium`, `low`.
 - `<score>` ∈ `75`, `100` (output of the scoring pass; sub-75 findings are already filtered).
-- The title prefix `[scan/<category>]` keeps issues trivially filterable in notifications even when labels aren't visible.
+- The title prefix `[scan:<category>]` keeps issues trivially filterable in notifications even when labels aren't visible.
 
 ## Body template
 
@@ -53,9 +58,9 @@ https://github.com/<owner>/<repo>/blob/<full-sha>/<path>#L<start>-L<end>
 
 - Category: `<category>` / `<subcategory>`
 - Severity: `<severity>`
-- Area: `<area/...>`
+- Area: `<area:...>`
 - Scanner: `<security-scanner | edge-case-hunter | coverage-auditor>`
-- Scored: `<score>/100` (`confidence/<score>`)
+- Scored: `<score>/100` (`confidence:<score>`)
 
 ---
 
@@ -66,6 +71,6 @@ https://github.com/<owner>/<repo>/blob/<full-sha>/<path>#L<start>-L<end>
 
 - **Use `git rev-parse HEAD` for the SHA in the link** so the link survives future commits. Insert it literally into the body; do not use `$(...)` shell substitution inside the heredoc.
 - **Never** include the full scanner output or the full scoring justification in the body. The template is the contract with the maintainer; extra content degrades scannability.
-- **Labels are mandatory** — always exactly five: `scan/<category>`, one matching subcategory (`sec/*` | `edge/*` | `cov/*`), `severity/<level>`, `confidence/<score>`, and one auto-derived `area/<top-level-dir>`. See `references/labels.md`.
+- **Labels are mandatory** — always exactly five, applied via the step-2 mapping table: a category, a matching subcategory, a severity, a confidence, and an auto-derived area. Canonical names are `scan:<category>`, `sec:*` | `edge:*` | `cov:*`, `severity:<level>`, `confidence:<score>`, `area:<top-level-dir>` — but the resolved label may be a suitable existing repo label instead. See `references/labels.md`.
 - **One issue per finding.** Do NOT batch findings into a single issue, even for the same file.
 - **Do not auto-assign** the issue. Let the maintainer triage.

--- a/skills/devpilot-scanning-repos/references/labels.md
+++ b/skills/devpilot-scanning-repos/references/labels.md
@@ -1,90 +1,107 @@
 # Labels
 
-Run once per repository before the first scan. Safe to re-run — `gh label create` returns a non-zero exit when a label already exists, so guard with `|| true`.
+The skill defines a canonical taxonomy below. **Every label name uses `{type}:{value}` (colon, not slash).** Before creating any of these labels, the orchestrator MUST first snapshot the repo's existing labels and reuse any suitable ones — see SKILL.md step 2. Only create the canonical label when the repo has no semantically equivalent label.
 
-Every label carries information. There is no redundant root label: `scan/<category>` already uniquely identifies issues filed by this skill.
+## Reconciliation procedure (summary; full version in SKILL.md step 2)
 
-## Required labels
+1. `gh label list --limit 200 --json name,description > /tmp/devpilot-existing-labels.json` (raise `--limit` if it returns full).
+2. For each canonical label below, look in the snapshot for a label whose **name OR description** clearly maps to the same purpose. If found, reuse it. If not, create the canonical `{type}:{value}` label with the `gh label create` line below.
+3. When uncertain, do NOT reuse — false reuse poisons triage queries (`label:scan:security` returning unrelated `security` issues is worse than two parallel labels).
+
+## Canonical taxonomy and create commands
+
+Each line is the **fallback** used when no suitable repo label exists. Run only the lines whose canonical label is missing from the repo and has no suitable existing equivalent.
 
 ```bash
 # --- categories (one per issue) ---
-gh label create scan/security    --color B60205 --description "Filed by devpilot-scanning-repos: security category"      || true
-gh label create scan/edge-case   --color D93F0B --description "Filed by devpilot-scanning-repos: edge-case / robustness" || true
-gh label create scan/coverage    --color 0E8A16 --description "Filed by devpilot-scanning-repos: test-coverage gap"      || true
+gh label create scan:security    --color B60205 --description "Filed by devpilot-scanning-repos: security category"
+gh label create scan:edge-case   --color D93F0B --description "Filed by devpilot-scanning-repos: edge-case / robustness"
+gh label create scan:coverage    --color 0E8A16 --description "Filed by devpilot-scanning-repos: test-coverage gap"
 
-# --- security subcategories (exactly one when category=scan/security) ---
-gh label create sec/injection         --color B60205 --description "SQL / shell / template / NoSQL injection"     || true
-gh label create sec/authn-authz       --color B60205 --description "Auth bypass, missing checks, role tampering"  || true
-gh label create sec/secrets           --color B60205 --description "Hardcoded keys, tokens, credentials"          || true
-gh label create sec/crypto            --color B60205 --description "Weak hashes, bad RNG, TLS verify disabled"    || true
-gh label create sec/path-traversal    --color B60205 --description "Zip-slip, ../ in user paths, archive escape"  || true
-gh label create sec/ssrf-csrf         --color B60205 --description "SSRF, CORS misconfig, missing CSRF"           || true
-gh label create sec/deserialization   --color B60205 --description "pickle, unsafe yaml, gob from untrusted"      || true
-gh label create sec/tls-misconfig     --color B60205 --description "Cert verify off, weak ciphers, plaintext"     || true
+# --- security subcategories (exactly one when category=scan:security) ---
+gh label create sec:injection         --color B60205 --description "SQL / shell / template / NoSQL injection"
+gh label create sec:authn-authz       --color B60205 --description "Auth bypass, missing checks, role tampering"
+gh label create sec:secrets           --color B60205 --description "Hardcoded keys, tokens, credentials"
+gh label create sec:crypto            --color B60205 --description "Weak hashes, bad RNG, TLS verify disabled"
+gh label create sec:path-traversal    --color B60205 --description "Zip-slip, ../ in user paths, archive escape"
+gh label create sec:ssrf-csrf         --color B60205 --description "SSRF, CORS misconfig, missing CSRF"
+gh label create sec:deserialization   --color B60205 --description "pickle, unsafe yaml, gob from untrusted"
+gh label create sec:tls-misconfig     --color B60205 --description "Cert verify off, weak ciphers, plaintext"
 
-# --- edge-case subcategories (exactly one when category=scan/edge-case) ---
-gh label create edge/nil-deref         --color D93F0B --description "Nil pointer / map / slice deref"             || true
-gh label create edge/bounds-overflow   --color D93F0B --description "Off-by-one, integer over/underflow"          || true
-gh label create edge/error-swallowed   --color D93F0B --description "Discarded errors, returned-nil-on-error"     || true
-gh label create edge/concurrency       --color D93F0B --description "Race, deadlock, leaked goroutine, double-close" || true
-gh label create edge/resource-leak     --color D93F0B --description "Unclosed file/conn/row/ticker on error path" || true
-gh label create edge/input-validation  --color D93F0B --description "Unbounded user input → index/alloc/length"   || true
+# --- edge-case subcategories (exactly one when category=scan:edge-case) ---
+gh label create edge:nil-deref         --color D93F0B --description "Nil pointer / map / slice deref"
+gh label create edge:bounds-overflow   --color D93F0B --description "Off-by-one, integer over/underflow"
+gh label create edge:error-swallowed   --color D93F0B --description "Discarded errors, returned-nil-on-error"
+gh label create edge:concurrency       --color D93F0B --description "Race, deadlock, leaked goroutine, double-close"
+gh label create edge:resource-leak     --color D93F0B --description "Unclosed file/conn/row/ticker on error path"
+gh label create edge:input-validation  --color D93F0B --description "Unbounded user input → index/alloc/length"
 
-# --- coverage subcategories (exactly one when category=scan/coverage) ---
-gh label create cov/no-test-file       --color 0E8A16 --description "Exported surface with no test file at all"   || true
-gh label create cov/error-paths        --color 0E8A16 --description "Happy path tested, error branches not"        || true
-gh label create cov/integration-seam   --color 0E8A16 --description "Untested boundary between two packages"       || true
-gh label create cov/stale-test         --color 0E8A16 --description "Production churn, test file stagnant"         || true
+# --- coverage subcategories (exactly one when category=scan:coverage) ---
+gh label create cov:no-test-file       --color 0E8A16 --description "Exported surface with no test file at all"
+gh label create cov:error-paths        --color 0E8A16 --description "Happy path tested, error branches not"
+gh label create cov:integration-seam   --color 0E8A16 --description "Untested boundary between two packages"
+gh label create cov:stale-test         --color 0E8A16 --description "Production churn, test file stagnant"
 
-# --- severity (one per issue; switched : → / for namespace consistency) ---
-gh label create severity/high     --color CC0000 --description "High-severity scan finding"   || true   # darker than scan/security on purpose
-gh label create severity/medium   --color FBCA04 --description "Medium-severity scan finding" || true
-gh label create severity/low      --color C5DEF5 --description "Low-severity scan finding"    || true
+# --- severity (one per issue) ---
+gh label create severity:high     --color CC0000 --description "High-severity scan finding"
+gh label create severity:medium   --color FBCA04 --description "Medium-severity scan finding"
+gh label create severity:low      --color C5DEF5 --description "Low-severity scan finding"
 
 # --- confidence (one per issue, from the scoring pass) ---
-gh label create confidence/75     --color BFD4F2 --description "Scoring agent gave 75/100 — real, meaningful, verified"     || true
-gh label create confidence/100    --color 0052CC --description "Scoring agent gave 100/100 — certain, load-bearing, frequent" || true
+gh label create confidence:75     --color BFD4F2 --description "Scoring agent gave 75/100 — real, meaningful, verified"
+gh label create confidence:100    --color 0052CC --description "Scoring agent gave 100/100 — certain, load-bearing, frequent"
 ```
 
-## `area/<top-level-dir>` (auto-created on demand)
+Note: no `|| true` guards. The reconciliation step has already proven the label is missing — a failure here is a real signal, not noise to swallow.
 
-Derived from each finding's `file` path: take the first path segment, replace `/` with `-`. Example: a finding on `internal/auth/middleware.go` gets `area/internal-auth`.
+## Suitable-match guidance
 
-The orchestrator MUST create the area label idempotently right before filing the issue:
+The orchestrator should treat these as suitable reuses (examples — not exhaustive):
+
+| Canonical | Suitable existing label (examples) | Not suitable |
+|---|---|---|
+| `scan:security` | `security`, `type:security`, `kind/security` | `bug` (too broad) |
+| `scan:coverage` | `testing`, `tests`, `coverage` | `enhancement` |
+| `severity:high` | `priority:high`, `p0`, `severity-1`, `critical` | `urgent` (priority ≠ severity) |
+| `severity:low` | `priority:low`, `p3`, `nice-to-have` | `wontfix` |
+| `confidence:75` / `confidence:100` | (almost never present) | anything ranking-shaped — confidence is internal to the scoring pass |
+| `sec:injection` | `vulnerability:injection`, `security:injection` | `security` (loses subcategory signal) |
+| `area:cmd` | `cmd`, `component:cmd`, `area-cmd` | `module` (too generic) |
+
+Rule of thumb: **subcategory labels (`sec:*`, `edge:*`, `cov:*`) and `confidence:*` rarely have a suitable equivalent — almost always create.** Top-level category, severity, and area labels are the ones most worth reusing.
+
+## `area:{top-level-dir}` (resolved lazily at filing time)
+
+Derived from each finding's `file` path: take the first path segment. Example: `internal/auth/middleware.go` → canonical label `area:internal`.
+
+At filing time, the orchestrator checks `/tmp/devpilot-existing-labels.json` for a suitable area-ish label (e.g. the repo already has `internal` or `area-internal`). If suitable, reuse it. Otherwise:
 
 ```bash
-area_label="area/$(echo "<finding-file>" | cut -d/ -f1 | tr '/' '-')"
-gh label create "$area_label" --color FEF2C0 --description "Auto-derived from finding file path" || true
+area_label="area:$(echo "<finding-file>" | cut -d/ -f1)"
+gh label create "$area_label" --color FEF2C0 --description "Auto-derived from finding file path"
 ```
 
-This lets the file's CODEOWNER filter `is:open label:area/internal-auth` and see only their slice.
+This lets a CODEOWNER filter `is:open label:area:internal` (or whichever label was reused) and see only their slice.
 
 ## Per-issue label contract
 
-Every filed issue MUST have exactly **five** labels:
+Every filed issue MUST have exactly **five** labels (using whichever name the step-2 mapping resolved to — canonical or reused):
 
-1. One `scan/<category>` — `security` | `edge-case` | `coverage`
-2. One subcategory matching the category — `sec/*` | `edge/*` | `cov/*`
-3. One `severity/<level>` — `high` | `medium` | `low`
-4. One `confidence/<score>` — `75` | `100` (matches the scoring-pass output)
-5. One `area/<top-level-dir>` — auto-derived from `file`
+1. One category — canonical: `scan:security` | `scan:edge-case` | `scan:coverage`
+2. One subcategory matching the category — canonical: `sec:*` | `edge:*` | `cov:*`
+3. One severity — canonical: `severity:high` | `severity:medium` | `severity:low`
+4. One confidence — canonical: `confidence:75` | `confidence:100`
+5. One area — canonical: `area:{top-level-dir}`
 
-If a scanner returns a finding whose subcategory doesn't fit any of the labels above, the orchestrator drops it and logs the mismatch — do not invent new subcategory labels at filing time. The fixed taxonomy is the contract.
+If a scanner returns a finding whose subcategory doesn't match the fixed enum, the orchestrator drops it and logs the mismatch — do not invent new subcategory values at filing time. The fixed taxonomy is the contract; reuse only swaps the *label that carries* the canonical meaning, not the meaning itself.
 
 ## Rationale
 
-- **`repo-scan` was deleted** because every scan-filed issue already carries `scan/*`. A label every issue has filters nothing.
-- **Subcategories are mandatory**, not optional, so triage queries like `label:sec/injection` actually return a meaningful slice instead of every security issue lumped together.
-- **`area/*` labels** route work to the file's owner without the orchestrator needing CODEOWNERS context — the maintainer already knows their dir.
-- **`confidence/*`** lets reviewers process the `100` bucket first; mixed lists slow triage.
-- **Color collision fixed**: `scan/security` keeps `#B60205`, `severity/high` is now `#CC0000` — distinguishable in the UI.
+- **`{type}:{value}` everywhere** matches GitHub's increasingly common convention and reads as a key/value pair (`type:security`, `severity:high`) rather than a path.
+- **Reuse before create** keeps the repo's label space clean. A repo that already has `security` and `priority:high` does not need `scan:security` and `severity:high` cluttering the sidebar — but the canonical names are still the fallback when nothing suitable exists.
+- **Subcategories are mandatory**, not optional, so triage queries like `label:sec:injection` actually return a meaningful slice instead of every security issue lumped together.
+- **`confidence:*`** lets reviewers process the `100` bucket first; mixed lists slow triage.
 
 ## Migration from the old taxonomy
 
-If you previously ran the skill and have issues labeled `repo-scan`, `scan:security`, etc., do NOT mass-relabel. Run:
-
-```bash
-gh issue list --label repo-scan --state all --limit 1000 --json number,labels
-```
-
-and let the dedupe step (SKILL.md step 6) treat them as historical — old issues stay on the old labels, new issues use the new ones. The dedupe normalizer matches on title, not labels, so this is safe.
+If you previously ran the skill and have issues labeled `repo-scan`, `scan/security`, etc., do NOT mass-relabel. The dedupe step (SKILL.md step 6) matches on title, not labels — old issues stay on the old labels, new issues use the new colon-form (or whatever the reconciliation resolved to).

--- a/skills/devpilot-scanning-repos/scripts/check-findings.py
+++ b/skills/devpilot-scanning-repos/scripts/check-findings.py
@@ -36,15 +36,15 @@ VALID_CATEGORIES = {"security", "edge-case", "coverage"}
 VALID_SEVERITIES = {"high", "medium", "low"}
 VALID_SUBCATEGORIES = {
     "security": {
-        "sec/injection", "sec/authn-authz", "sec/secrets", "sec/crypto",
-        "sec/path-traversal", "sec/ssrf-csrf", "sec/deserialization", "sec/tls-misconfig",
+        "sec:injection", "sec:authn-authz", "sec:secrets", "sec:crypto",
+        "sec:path-traversal", "sec:ssrf-csrf", "sec:deserialization", "sec:tls-misconfig",
     },
     "edge-case": {
-        "edge/nil-deref", "edge/bounds-overflow", "edge/error-swallowed",
-        "edge/concurrency", "edge/resource-leak", "edge/input-validation",
+        "edge:nil-deref", "edge:bounds-overflow", "edge:error-swallowed",
+        "edge:concurrency", "edge:resource-leak", "edge:input-validation",
     },
     "coverage": {
-        "cov/no-test-file", "cov/error-paths", "cov/integration-seam", "cov/stale-test",
+        "cov:no-test-file", "cov:error-paths", "cov:integration-seam", "cov:stale-test",
     },
 }
 MAX_TITLE_LEN = 80


### PR DESCRIPTION
## Summary

Two behavioral changes to the \`devpilot-scanning-repos\` skill:

1. **Reuse before create.** Step 2 of the workflow now snapshots the repo's existing labels (\`gh label list\`), maps each canonical label against existing ones by name + description, and only creates the labels that have no semantically suitable equivalent. The \`area:*\` labels follow the same rule lazily at filing time. Reconciliation summary is printed before any issue is filed so the user can spot a wrong reuse.
2. **\`{type}:{value}\` naming.** All canonical label names switched from slash-form (\`scan/security\`, \`severity/high\`, \`area/internal\`) to colon-form (\`scan:security\`, \`severity:high\`, \`area:internal\`) across SKILL.md, references, agent prompts, the validator script, and evals.

## Files changed

- \`SKILL.md\` — step 2 rewritten; step 7 uses the mapping; common-mistakes updated to flag both blind upfront creation and over-stretched reuse.
- \`references/labels.md\` — replaced "paste verbatim" \`gh label create\` block with a reconciliation procedure + canonical fallback table; added suitable-match guidance (e.g. \`severity:high\` ⇔ \`priority:high\`/\`p0\`/\`critical\`).
- \`references/issue-template.md\` — \`gh issue create\` now uses placeholders for *resolved* labels from the mapping table; title prefix stays canonical so dedupe is stable across runs.
- \`agents/*.md\`, \`scripts/check-findings.py\`, \`evals/evals.json\` — bulk subcategory rename (\`sec/injection\` → \`sec:injection\` etc.).

Legacy \`repo-scan\` references are preserved for backward-compat dedupe in step 6.

## Review Guide

Start with **\`skills/devpilot-scanning-repos/SKILL.md\`** step 2 — it's where the new reconciliation procedure lives and is the load-bearing change. Then read **\`references/labels.md\`** end-to-end (the suitable-match guidance table is the spot most likely to need tuning). Skim the agent files and \`check-findings.py\` last — those are pure rename. Watch for: any place still saying "create idempotently" or "paste verbatim" (should be none); any leftover slash-form label names (verified clean via \`grep\`).

## Test plan

- [x] \`grep -rE "(scan|sec|edge|cov|severity|confidence|area)/[a-z]"\` across the skill returns nothing label-shaped (only \`repo-scan\`, \`edge-case\` category value, and unrelated path strings remain).
- [ ] Human: dry-run the skill against a repo that already has \`security\` / \`priority:high\` labels — verify those get reused instead of \`scan:security\` / \`severity:high\` being created alongside.
- [ ] Human: dry-run against a clean repo — verify the full canonical taxonomy is created and the reconciliation summary prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)