### PR TITLE
feat(skills): add devpilot-daily-toolkit skill

### DIFF
--- a/skills/devpilot-daily-toolkit/SKILL.md
+++ b/skills/devpilot-daily-toolkit/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: devpilot-daily-toolkit
+description: >
+  Personal daily-life toolkit for someone living in Auckland, NZ. Bundles four
+  tools behind one skill: RSS news (世界科技 / AI / 世界政治 / 经济金融 / 新西兰),
+  real-time exchange rates (any currency pair via cdn.moneyconvert.net), GitHub
+  daily activity reports (commits / PRs / issues across the user's active repos),
+  and NZ public holidays (Auckland-highlighted via Nager.Date). USE WHEN the
+  user asks for any of: a personal daily / morning briefing, "my daily digest",
+  exchange rates ("汇率", "USD to NZD", "100 AUD 换多少人民币"), NZ public
+  holidays ("下个假期", "next NZ holiday", "Auckland anniversary day"), a daily
+  GitHub activity report ("今日 github", "github daily report", "what did I
+  push today"), or a blended "give me everything" briefing that combines all
+  four. Triggers on: "daily toolkit", "my daily", "morning briefing", "今日简报",
+  "晨报", "汇率", "exchange rate", "currency convert", "convert X to Y", "NZ
+  holiday", "新西兰假期", "Auckland holiday", "github daily report", "今日 github",
+  "what did I ship today". For a pure long-form general news digest with no
+  other topics, prefer devpilot-news-digest; for everyday Auckland-local
+  utilities and combined briefings, use this skill.
+---
+
+# Daily Toolkit (Auckland personal helper)
+
+Router for four daily-life utilities — news, exchange rates, GitHub activity,
+and NZ public holidays — plus a combined morning-briefing mode that runs all
+four and assembles one digest.
+
+The four tools are self-contained Python scripts under `scripts/`. The skill's
+job is to (1) pick the right tool for the user's request, (2) call it with the
+right arguments, and (3) format the raw output into something readable —
+especially for the news tool, whose output is raw English RSS that needs to
+be translated and summarized into Chinese.
+
+## Tools at a glance
+
+| Intent | Script | What it returns |
+|--------|--------|-----------------|
+| News by category | `scripts/fetch_news.py` | Raw English RSS items grouped into 5 categories |
+| Exchange rates | `scripts/get_rate.py` | Single pair, multi-target, or cross-rate matrix |
+| GitHub daily activity | `scripts/github_daily_report.py` | Today's commits / PRs / issues across active repos |
+| NZ public holidays | `scripts/get_holidays.py` | National + Auckland holidays + next-holiday countdown |
+
+Dependencies: `feedparser` (news), `requests` (exchange rate), `gh` CLI logged
+in (github report). Holidays uses stdlib only. If `feedparser` or `requests`
+is missing, install with `pip install feedparser requests` before running.
+
+## Routing the user's intent
+
+Before running anything, decide which tool the user actually wants. Use these
+heuristics:
+
+- **News** — "今日新闻", "daily news", "today's headlines", "what's happening",
+  "新西兰新闻". Output is raw RSS — you must translate/summarize into Chinese
+  (see *News post-processing* below).
+- **Exchange rate** — any currency code (NZD, AUD, USD, CNY, EUR, GBP, JPY,
+  KRW, HKD, …), "汇率", "1000 AUD 换多少 CNY", "convert X to Y", "USD to NZD".
+- **GitHub daily activity** — "今日 github", "github daily report", "what did
+  I ship/push today", "commits today", "daily report".
+- **NZ holidays** — "下个假期", "next holiday", "is X a public holiday",
+  "Auckland anniversary day", "labour day", "新西兰公共假期".
+- **Combined briefing** — "morning briefing", "my daily", "今日简报", "晨报",
+  "give me everything", "daily digest". Run all four and assemble (see
+  *Combined briefing mode*).
+
+If the user's intent is genuinely ambiguous (e.g., just "daily" with no other
+context), ask **one** short clarifying question before running. Don't run all
+four when the user only wanted one — that wastes time and tokens.
+
+## Tool 1 — News
+
+```bash
+python3 scripts/fetch_news.py
+```
+
+The script reads `feeds.json` (sibling of `scripts/`) and fetches RSS feeds in
+five categories: 世界科技动态, AI 专项, 世界政治, 经济/金融, 新西兰新闻.
+Output is raw English entries grouped by category, 6 items per category max,
+deduplicated by title prefix.
+
+### News post-processing
+
+The raw output is in English. The user almost always wants Chinese, so after
+running the script:
+
+1. Preserve the five categories in the original order.
+2. For each item, translate the title into Chinese and write a 2–3 sentence
+   Chinese summary based on the English `summary` text. Don't hallucinate
+   details that aren't in the summary — if the summary is empty, just give
+   the translated headline.
+3. Keep the `[source | YYYY-MM-DD]` attribution.
+4. If something is clearly major breaking news (war, market crash, disaster,
+   major political event), pin it at the top with a 📌 marker. Use judgment;
+   don't over-pin.
+
+If the script exits with `ERROR: All feeds failed to fetch.`, treat that as a
+network problem — tell the user, don't pretend you got news.
+
+## Tool 2 — Exchange rate
+
+`get_rate.py` is a small CLI. Pick the form that fits the request — don't run
+the default if the user named specific currencies.
+
+```bash
+# Default: NZD → CNY/AUD/USD (only use if user said nothing specific)
+python3 scripts/get_rate.py
+
+# Specific pair: base target
+python3 scripts/get_rate.py AUD CNY
+
+# With amount: amount base target
+python3 scripts/get_rate.py 1000 AUD CNY
+
+# Custom base + target list
+python3 scripts/get_rate.py --base USD CNY EUR JPY
+
+# Cross-rate matrix
+python3 scripts/get_rate.py --cross NZD AUD USD CNY
+```
+
+Currency codes are uppercase ISO codes. The default and `--base` forms accept
+lowercase and uppercase the args internally; `--cross` is the one form that
+does NOT auto-uppercase, so always pass uppercase to it. The script already
+knows the Chinese names of common ones (CNY 人民币, NZD 纽币, AUD 澳币, USD
+美元, …) and the API supports the full standard ISO set.
+
+**Picking the right form:**
+- Single pair, no amount → default form (`AUD CNY`)
+- Single pair, with amount → amount form (`1000 AUD CNY`)
+- One base, multiple targets, no amount → `--base USD CNY EUR JPY`
+- All-pairs comparison table → `--cross NZD AUD USD CNY`
+- **Compound: one amount converted to multiple targets** → the CLI has no
+  single form for this. Loop the amount form once per target (e.g., for
+  "5000 NZD to JPY/AUD/USD" run three calls). Don't try to combine `--base`
+  with an amount — `--base` ignores amounts.
+
+For "USD 今天什么价" / "查一下汇率" with no specific target, use the plain
+default (or `--base USD` if they named USD as the base).
+
+## Tool 3 — GitHub daily report
+
+```bash
+# Today across all recently-active repos
+python3 scripts/github_daily_report.py
+
+# Specific date (YYYY-MM-DD)
+python3 scripts/github_daily_report.py --date 2026-04-30
+
+# Specific repo
+python3 scripts/github_daily_report.py --repo owner/repo
+```
+
+Requires `gh` CLI installed and authenticated. The script auto-discovers
+recently active repos from the authenticated user's repo list. If `gh` is not
+configured, tell the user to run `gh auth login` first rather than retrying.
+
+The script's output is already grouped, classified (features / fixes /
+refactors / docs / others), and Chinese-friendly — present it as-is unless
+the user asks for a tighter summary. If the user asks "what did I ship
+today?", the per-repo "今日改动总结" section at the bottom is usually the
+best answer.
+
+## Tool 4 — NZ public holidays
+
+```bash
+# Current year, Auckland-highlighted (default)
+python3 scripts/get_holidays.py
+
+# Specific year
+python3 scripts/get_holidays.py 2026
+
+# Include all regions, not just Auckland
+python3 scripts/get_holidays.py --all
+```
+
+Uses the free Nager.Date API (no key needed). Auckland is the default focus
+region — the script automatically promotes Auckland-related holidays and
+shows the next upcoming one with a day countdown.
+
+For "下个假期是什么" → just the default. For "明年的假期" → pass next year.
+For a non-Auckland question (e.g., "Wellington anniversary") → pass `--all`.
+
+## Combined briefing mode
+
+When the user asks for a combined briefing ("morning briefing", "my daily",
+"今日简报", "晨报", "give me everything"):
+
+1. Run all four scripts. Run them sequentially — that's simple, network calls
+   are short, and it avoids hammering rate-limited APIs.
+2. Assemble one Chinese-language briefing in this fixed order:
+
+```
+📅 今日简报 — YYYY-MM-DD (Auckland)
+============================================
+
+🇳🇿 假期
+  • <next holiday + countdown, or "今天是 <holiday>" if it's today>
+
+💱 汇率速览 (1 NZD = ...)
+  • CNY: <rate>   AUD: <rate>   USD: <rate>
+
+🐙 GitHub 动态
+  <one line per active repo with non-zero activity, top 3 by activity count;
+   say "今日无活动" if none>
+
+📰 今日要闻
+  ## 世界科技动态
+    • <top 3, translated, 1-2 sentence Chinese summary each>
+  ## AI 专项
+    • <top 3>
+  ## 世界政治
+    • <top 3>
+  ## 经济/金融
+    • <top 3>
+  ## 新西兰新闻
+    • <top 3>
+```
+
+Keep each section tight — the briefing should be glanceable, not a wall of
+text. If a section has no data, say so in one line rather than silently
+dropping it.
+
+If a tool fails (e.g., `gh` not configured, network error on RSS), include
+the other sections and note the failure inline. Don't refuse to produce a
+partial briefing.
+
+## Gotchas (surfaced from real runs)
+
+- `fetch_news.py` prints `[WARN] Failed to parse <feed>: …` lines to **stderr**
+  whenever an upstream RSS source is malformed (RSSHub-backed feeds break
+  occasionally). These are diagnostic noise — do **not** surface them in the
+  user-facing output. The script handles them and degrades gracefully.
+- `get_rate.py --cross` does not auto-uppercase its currency args. The other
+  two forms do. Always pass uppercase to `--cross`.
+- `github_daily_report.py` discovers active repos from `gh repo list` for the
+  authed user. If the user wants activity on a repo they don't own (e.g., an
+  org repo they only contribute to), pass `--repo owner/repo` explicitly.
+- `feedparser` and `requests` are required (`pip install -r requirements.txt`
+  from the skill root). Holidays uses stdlib only.
+
+## When NOT to use this skill
+
+- Pure long-form general news digest with no other topics → `devpilot-news-digest`
+- Summarizing an article the user pasted → `devpilot-learn`
+- Real-time stock prices, crypto, weather → not covered here, decline politely
+- GitHub PR review or issue triage → `devpilot-pr-review` / `devpilot-resolve-issues`

--- a/skills/devpilot-daily-toolkit/evals/evals.json
+++ b/skills/devpilot-daily-toolkit/evals/evals.json
@@ -1,0 +1,64 @@
+{
+  "skill_name": "devpilot-daily-toolkit",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "1000 AUD 换多少人民币？",
+      "expected_output": "A clear answer using get_rate.py with the amount form (1000 AUD CNY), showing both the per-unit rate and the total converted amount, with a fresh timestamp.",
+      "files": [],
+      "assertions": [
+        {"name": "uses_get_rate_amount_form", "description": "Invokes scripts/get_rate.py with arguments '1000 AUD CNY' (or equivalent amount form)"},
+        {"name": "shows_total_conversion", "description": "Output includes the converted CNY total for 1000 AUD, not just the unit rate"},
+        {"name": "no_default_run", "description": "Does not run the default no-arg form (which would only show NZD pairs)"}
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "下一个新西兰公共假期是什么时候？我在奥克兰",
+      "expected_output": "Runs get_holidays.py and reports the next upcoming holiday relevant to Auckland, with date and day countdown, in Chinese.",
+      "files": [],
+      "assertions": [
+        {"name": "uses_get_holidays", "description": "Invokes scripts/get_holidays.py"},
+        {"name": "names_specific_holiday", "description": "Output names a specific upcoming holiday (e.g., King's Birthday, Matariki, Auckland Anniversary Day, Labour Day)"},
+        {"name": "shows_countdown", "description": "Output includes a day countdown or absolute date for the next holiday"},
+        {"name": "auckland_aware", "description": "Either prefers Auckland regional holidays or notes Auckland eligibility"}
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "今日 github daily report",
+      "expected_output": "Runs github_daily_report.py with no date arg (today) and presents the 改动总结 / activity overview for the user's active repos.",
+      "files": [],
+      "assertions": [
+        {"name": "uses_github_report", "description": "Invokes scripts/github_daily_report.py"},
+        {"name": "no_unprompted_repo_filter", "description": "Does not pass --repo unless the user named one (covers all active repos by default)"},
+        {"name": "presents_summary_section", "description": "Output includes either the 今日概览 totals or the per-repo 今日改动总结"}
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "给我今日简报，所有内容都要",
+      "expected_output": "Combined briefing: runs all four scripts, assembles a single Chinese digest with sections for holidays, exchange rates, GitHub activity, and translated news in the order specified by the skill.",
+      "files": [],
+      "assertions": [
+        {"name": "runs_all_four_scripts", "description": "Invokes fetch_news.py, get_rate.py, github_daily_report.py, and get_holidays.py at least once each"},
+        {"name": "single_combined_digest", "description": "Produces one assembled Chinese digest, not four separate dumps"},
+        {"name": "contains_all_four_sections", "description": "Final digest has visible sections for holidays, exchange rates (NZD pairs), GitHub activity, and news"},
+        {"name": "news_translated_to_chinese", "description": "News headlines/summaries are rendered in Chinese, not raw English RSS"},
+        {"name": "categories_preserved", "description": "News section preserves the five categories: 世界科技动态, AI 专项, 世界政治, 经济/金融, 新西兰新闻"}
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "今天有什么新闻？",
+      "expected_output": "Runs fetch_news.py and translates the raw English RSS output into a Chinese digest grouped by the five categories from feeds.json, with [source | date] attribution.",
+      "files": [],
+      "assertions": [
+        {"name": "uses_fetch_news", "description": "Invokes scripts/fetch_news.py"},
+        {"name": "output_in_chinese", "description": "Headlines and summaries are translated to Chinese"},
+        {"name": "five_categories", "description": "Output groups items under the five original categories from feeds.json"},
+        {"name": "has_source_attribution", "description": "Each item retains a [source | YYYY-MM-DD] tag"}
+      ]
+    }
+  ]
+}

--- a/skills/devpilot-daily-toolkit/feeds.json
+++ b/skills/devpilot-daily-toolkit/feeds.json
@@ -1,0 +1,30 @@
+{
+  "categories": {
+    "世界科技动态": [
+      {"name": "TechCrunch", "url": "https://techcrunch.com/feed/"},
+      {"name": "The Verge", "url": "https://www.theverge.com/rss/index.xml"},
+      {"name": "Ars Technica", "url": "https://feeds.arstechnica.com/arstechnica/index"}
+    ],
+    "AI 专项": [
+      {"name": "MIT Technology Review", "url": "https://www.technologyreview.com/feed/"},
+      {"name": "OpenAI Blog", "url": "https://openai.com/blog/rss.xml"},
+      {"name": "DeepMind Blog", "url": "https://deepmind.google/blog/rss.xml"},
+      {"name": "Anthropic (via Google News)", "url": "https://news.google.com/rss/search?q=Anthropic+Claude&hl=en"}
+    ],
+    "世界政治": [
+      {"name": "BBC World", "url": "https://feeds.bbci.co.uk/news/world/rss.xml"},
+      {"name": "AP News", "url": "https://rsshub.app/apnews/topics/apf-topnews"},
+      {"name": "Al Jazeera", "url": "https://www.aljazeera.com/xml/rss/all.xml"}
+    ],
+    "经济/金融": [
+      {"name": "CNBC", "url": "https://www.cnbc.com/id/100003114/device/rss/rss.html"},
+      {"name": "MarketWatch", "url": "https://feeds.content.dowjones.io/public/rss/mw_topstories"},
+      {"name": "Bloomberg via RSSHub", "url": "https://rsshub.app/bloomberg"}
+    ],
+    "新西兰新闻": [
+      {"name": "RNZ", "url": "https://www.rnz.co.nz/rss/national.xml"},
+      {"name": "NZ Herald", "url": "https://www.nzherald.co.nz/arc/outboundfeeds/rss/curated/78/?outputType=xml"},
+      {"name": "Stuff", "url": "https://www.stuff.co.nz/rss"}
+    ]
+  }
+}

--- a/skills/devpilot-daily-toolkit/requirements.txt
+++ b/skills/devpilot-daily-toolkit/requirements.txt
@@ -1,0 +1,2 @@
+feedparser
+requests

--- a/skills/devpilot-daily-toolkit/scripts/fetch_news.py
+++ b/skills/devpilot-daily-toolkit/scripts/fetch_news.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Fetch RSS news feeds and output structured text by category."""
+
+import json
+import re
+import sys
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+
+import feedparser
+
+
+ITEMS_PER_CATEGORY = 6
+FETCH_TIMEOUT = 10
+DEDUP_PREFIX_LEN = 50
+
+
+def load_feeds(path):
+    """Load feed configuration from JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)["categories"]
+
+
+def fetch_single_feed(name, url):
+    """Fetch and parse a single RSS feed. Returns (name, entries) or (name, [])."""
+    try:
+        feed = feedparser.parse(url, request_headers={"User-Agent": "DailyNewsBot/1.0"})
+        if feed.bozo and not feed.entries:
+            print(f"[WARN] Failed to parse {name}: {feed.bozo_exception}", file=sys.stderr)
+            return name, []
+        entries = []
+        for entry in feed.entries:
+            published = None
+            for date_field in ("published_parsed", "updated_parsed"):
+                parsed = getattr(entry, date_field, None)
+                if parsed:
+                    try:
+                        published = datetime(*parsed[:6])
+                    except Exception:
+                        pass
+                    break
+            title = getattr(entry, "title", "").strip()
+            raw_summary = re.sub(r"<[^>]+>", "", getattr(entry, "summary", ""))
+            summary = re.sub(r"&\w+;", " ", raw_summary).strip()
+            link = getattr(entry, "link", "")
+            if title:
+                entries.append({
+                    "title": title,
+                    "summary": summary[:500],
+                    "link": link,
+                    "published": published,
+                    "source": name,
+                })
+        return name, entries
+    except Exception as e:
+        print(f"[WARN] Error fetching {name}: {e}", file=sys.stderr)
+        return name, []
+
+
+def deduplicate(entries):
+    """Remove duplicate entries based on lowercase title prefix."""
+    seen = set()
+    result = []
+    for entry in entries:
+        key = entry["title"].lower().strip()[:DEDUP_PREFIX_LEN]
+        if key not in seen:
+            seen.add(key)
+            result.append(entry)
+    return result
+
+
+def fetch_all(categories):
+    """Fetch all feeds concurrently and return entries grouped by category."""
+    tasks = []
+    for category, feeds in categories.items():
+        for feed in feeds:
+            tasks.append((category, feed["name"], feed["url"]))
+
+    raw = {cat: [] for cat in categories}
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = {}
+        for category, name, url in tasks:
+            future = pool.submit(fetch_single_feed, name, url)
+            futures[future] = category
+
+        for future in as_completed(futures):
+            category = futures[future]
+            try:
+                _, entries = future.result(timeout=FETCH_TIMEOUT + 5)
+                raw[category].extend(entries)
+            except Exception as e:
+                print(f"[WARN] Future failed for {category}: {e}", file=sys.stderr)
+
+    result = {}
+    for category, entries in raw.items():
+        entries.sort(key=lambda e: e["published"] or datetime.min, reverse=True)
+        entries = deduplicate(entries)
+        result[category] = entries[:ITEMS_PER_CATEGORY]
+
+    return result
+
+
+def format_output(results, categories):
+    """Format results as structured text, preserving category order from config."""
+    lines = []
+    for category in categories:
+        entries = results.get(category, [])
+        lines.append(f"## {category}")
+        lines.append("")
+        if not entries:
+            lines.append("(No articles fetched for this category)")
+            lines.append("")
+            continue
+        for i, entry in enumerate(entries, 1):
+            date_str = entry["published"].strftime("%Y-%m-%d") if entry["published"] else "unknown"
+            lines.append(f"{i}. [{entry['source']} | {date_str}] {entry['title']}")
+            if entry["summary"]:
+                lines.append(f"   {entry['summary']}")
+            lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    feeds_path = os.path.join(script_dir, "..", "feeds.json")
+
+    categories = load_feeds(feeds_path)
+    results = fetch_all(categories)
+
+    total = sum(len(v) for v in results.values())
+    if total == 0:
+        print("ERROR: All feeds failed to fetch.", file=sys.stderr)
+        sys.exit(1)
+
+    print(format_output(results, categories))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/devpilot-daily-toolkit/scripts/get_holidays.py
+++ b/skills/devpilot-daily-toolkit/scripts/get_holidays.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Query New Zealand public holidays using the free Nager.Date API.
+Usage: python3 get_holidays.py [year]
+"""
+
+import sys
+import json
+import urllib.request
+from datetime import datetime
+
+def get_nz_holidays(year=None):
+    """Get New Zealand public holidays for a given year."""
+    if year is None:
+        year = datetime.now().year
+    
+    url = f"https://date.nager.at/api/v3/publicholidays/{year}/NZ"
+    
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=10) as response:
+            data = json.loads(response.read().decode('utf-8'))
+            return data
+    except Exception as e:
+        print(f"Error fetching holidays: {e}", file=sys.stderr)
+        sys.exit(1)
+
+# 奥克兰地区代码
+AUCKLAND_REGIONS = ["NZ-AUK", "NZ-NTL", "NZ-WKO", "NZ-GIS", "NZ-BOP"]
+
+def is_auckland_holiday(holiday):
+    """Check if a holiday applies to Auckland region."""
+    counties = holiday.get('counties', []) or []
+    return any(c in AUCKLAND_REGIONS for c in counties)
+
+def format_holidays(holidays, show_all=False, highlight_auckland=True):
+    """Format holidays for display."""
+    today = datetime.now().date()
+    
+    # Separate global and regional holidays
+    global_holidays = [h for h in holidays if h.get('global')]
+    regional_holidays = [h for h in holidays if not h.get('global')]
+    
+    # Filter Auckland holidays if highlighting
+    auckland_holidays = [h for h in regional_holidays if is_auckland_holiday(h)]
+    other_regional = [h for h in regional_holidays if not is_auckland_holiday(h)]
+    
+    result = []
+    result.append("🇳🇿 新西兰公共假期")
+    result.append("=" * 40)
+    result.append("")
+    
+    # National holidays
+    result.append("📅 全国性假期")
+    result.append("-" * 40)
+    
+    for holiday in global_holidays:
+        date_str = holiday['date']
+        name = holiday['localName']
+        
+        # Parse date
+        date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
+        days_until = (date_obj - today).days
+        
+        # Format date nicely
+        date_formatted = date_obj.strftime("%m月%d日")
+        
+        # Add indicator for past/upcoming
+        if days_until < 0:
+            indicator = "✅"
+        elif days_until == 0:
+            indicator = "🎉 今天!"
+        elif days_until <= 7:
+            indicator = f"⏳ {days_until}天后"
+        else:
+            indicator = ""
+        
+        line = f"  {date_formatted} - {name}"
+        if indicator:
+            line += f" {indicator}"
+        result.append(line)
+    
+    # Auckland regional holidays
+    if highlight_auckland and auckland_holidays:
+        result.append("")
+        result.append("🏠 奥克兰地区假期")
+        result.append("-" * 40)
+        
+        for holiday in auckland_holidays:
+            date_str = holiday['date']
+            name = holiday['localName']
+            date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
+            days_until = (date_obj - today).days
+            date_formatted = date_obj.strftime("%m月%d日")
+            
+            # Add indicator for past/upcoming
+            if days_until < 0:
+                indicator = "✅"
+            elif days_until == 0:
+                indicator = "🎉 今天!"
+            elif days_until <= 7:
+                indicator = f"⏳ {days_until}天后"
+            else:
+                indicator = ""
+            
+            line = f"  {date_formatted} - {name}"
+            if indicator:
+                line += f" {indicator}"
+            result.append(line)
+    
+    if show_all and other_regional:
+        result.append("")
+        result.append("📍 其他地区假期")
+        result.append("-" * 40)
+        
+        for holiday in other_regional:
+            date_str = holiday['date']
+            name = holiday['localName']
+            date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
+            date_formatted = date_obj.strftime("%m月%d日")
+            result.append(f"  {date_formatted} - {name}")
+    
+    return "\n".join(result)
+
+def get_next_holiday(holidays, include_auckland_only=True):
+    """Get the next upcoming holiday."""
+    today = datetime.now().date()
+    
+    # Filter holidays relevant to Auckland user
+    relevant_holidays = []
+    for holiday in holidays:
+        date_obj = datetime.strptime(holiday['date'], "%Y-%m-%d").date()
+        if date_obj >= today:
+            # Include if it's a national holiday or Auckland regional holiday
+            if holiday.get('global') or (include_auckland_only and is_auckland_holiday(holiday)):
+                relevant_holidays.append(holiday)
+    
+    # Return the closest one
+    if relevant_holidays:
+        return min(relevant_holidays, key=lambda h: datetime.strptime(h['date'], "%Y-%m-%d").date())
+    return None
+
+if __name__ == "__main__":
+    year = None
+    show_all = False
+    
+    if len(sys.argv) > 1:
+        if sys.argv[1] in ['--all', '-a']:
+            show_all = True
+        else:
+            try:
+                year = int(sys.argv[1])
+            except ValueError:
+                print(f"Usage: {sys.argv[0]} [year|--all]", file=sys.stderr)
+                sys.exit(1)
+    
+    if len(sys.argv) > 2 and sys.argv[2] in ['--all', '-a']:
+        show_all = True
+    
+    holidays = get_nz_holidays(year)
+    
+    # Print formatted list (highlight Auckland by default)
+    print(format_holidays(holidays, show_all, highlight_auckland=True))
+    
+    # Show next upcoming holiday (relevant to Auckland)
+    next_holiday = get_next_holiday(holidays, include_auckland_only=True)
+    if next_holiday:
+        print("")
+        print("🎯 下一个假期")
+        print("-" * 40)
+        date_obj = datetime.strptime(next_holiday['date'], "%Y-%m-%d").date()
+        days_until = (date_obj - datetime.now().date()).days
+        holiday_name = next_holiday['localName']
+        
+        # Add location indicator
+        if next_holiday.get('global'):
+            location = "全国性假期"
+        elif is_auckland_holiday(next_holiday):
+            location = "奥克兰地区假期"
+        else:
+            location = "地区性假期"
+        
+        print(f"  {holiday_name}")
+        print(f"  日期: {date_obj.strftime('%Y年%m月%d日')}")
+        print(f"  类型: {location}")
+        if days_until == 0:
+            print("  🎉 就是今天!")
+        else:
+            print(f"  ⏳ 还有 {days_until} 天")

--- a/skills/devpilot-daily-toolkit/scripts/get_rate.py
+++ b/skills/devpilot-daily-toolkit/scripts/get_rate.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+汇率查询脚本 - 支持任意货币对之间的汇率查询和金额换算
+默认以 NZD 为基准货币
+"""
+
+import requests
+import sys
+from datetime import datetime
+
+# 货币名称映射
+CURRENCY_NAMES = {
+    "CNY": "人民币",
+    "NZD": "纽币",
+    "AUD": "澳币",
+    "USD": "美元",
+    "EUR": "欧元",
+    "GBP": "英镑",
+    "JPY": "日元",
+    "KRW": "韩元",
+    "HKD": "港币",
+    "TWD": "台币",
+    "SGD": "新加坡元",
+    "CAD": "加元",
+    "CHF": "瑞士法郎",
+    "THB": "泰铢",
+}
+
+
+def _fetch_rates():
+    """获取最新汇率数据（USD 为基准）"""
+    url = "https://cdn.moneyconvert.net/api/latest.json"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def _currency_label(code):
+    """返回 '货币代码(中文名)' 格式"""
+    name = CURRENCY_NAMES.get(code)
+    return f"{code}({name})" if name else code
+
+
+def get_exchange_rate(target_currency="CNY", base_currency="NZD", amount=1):
+    """
+    获取任意两种货币之间的汇率
+
+    Args:
+        target_currency: 目标货币代码 (默认 CNY)
+        base_currency: 基准货币代码 (默认 NZD)
+        amount: 换算金额 (默认 1)
+
+    Returns:
+        dict: 包含汇率信息的字典
+    """
+    try:
+        data = _fetch_rates()
+
+        # USD 是 API 的基准，汇率为 1
+        rates = data["rates"]
+        rates["USD"] = 1.0
+
+        if base_currency not in rates:
+            return {"success": False, "error": f"不支持的基准货币: {base_currency}"}
+        if target_currency not in rates:
+            return {"success": False, "error": f"不支持的目标货币: {target_currency}"}
+
+        # 通过 USD 中转计算任意货币对
+        rate = rates[target_currency] / rates[base_currency]
+        converted = amount * rate
+
+        query_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        return {
+            "success": True,
+            "base_currency": base_currency,
+            "target_currency": target_currency,
+            "rate": round(rate, 4),
+            "amount": amount,
+            "converted": round(converted, 4),
+            "timestamp": query_time,
+            "source": "cdn.moneyconvert.net",
+        }
+
+    except requests.exceptions.RequestException as e:
+        return {"success": False, "error": f"网络请求失败: {str(e)}"}
+    except KeyError as e:
+        return {"success": False, "error": f"货币代码无效: {str(e)}"}
+    except Exception as e:
+        return {"success": False, "error": f"未知错误: {str(e)}"}
+
+
+def get_all_rates(base_currency="NZD", targets=None):
+    """
+    获取基准货币到多个目标货币的汇率
+
+    Args:
+        base_currency: 基准货币代码 (默认 NZD)
+        targets: 目标货币列表 (默认 CNY, AUD, USD)
+
+    Returns:
+        dict: 包含多个汇率信息的字典
+    """
+    if targets is None:
+        targets = ["CNY", "AUD", "USD"]
+    # 排除基准货币自身
+    targets = [t for t in targets if t != base_currency]
+
+    try:
+        data = _fetch_rates()
+        rates_data = data["rates"]
+        rates_data["USD"] = 1.0
+
+        if base_currency not in rates_data:
+            return {"success": False, "error": f"不支持的基准货币: {base_currency}"}
+
+        base_rate = rates_data[base_currency]
+        rates = {}
+        for t in targets:
+            if t in rates_data:
+                rates[t] = round(rates_data[t] / base_rate, 4)
+
+        query_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        return {
+            "success": True,
+            "base_currency": base_currency,
+            "rates": rates,
+            "timestamp": query_time,
+            "source": "cdn.moneyconvert.net",
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def get_cross_rates(currencies=None):
+    """
+    获取多个货币之间的交叉汇率表
+
+    Args:
+        currencies: 货币列表 (默认 NZD, AUD, USD, CNY)
+
+    Returns:
+        dict: 包含交叉汇率矩阵的字典
+    """
+    if currencies is None:
+        currencies = ["NZD", "AUD", "USD", "CNY"]
+
+    try:
+        data = _fetch_rates()
+        rates_data = data["rates"]
+        rates_data["USD"] = 1.0
+
+        matrix = {}
+        for base in currencies:
+            if base not in rates_data:
+                continue
+            matrix[base] = {}
+            for target in currencies:
+                if target not in rates_data:
+                    continue
+                if base == target:
+                    matrix[base][target] = 1.0
+                else:
+                    matrix[base][target] = round(rates_data[target] / rates_data[base], 4)
+
+        query_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        return {
+            "success": True,
+            "currencies": currencies,
+            "matrix": matrix,
+            "timestamp": query_time,
+            "source": "cdn.moneyconvert.net",
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def format_output(result):
+    """格式化输出结果"""
+    if not result["success"]:
+        return f"查询失败: {result['error']}"
+
+    if "matrix" in result:
+        # 交叉汇率表输出
+        currencies = result["currencies"]
+        header = "         " + "  ".join(f"{c:>10}" for c in currencies)
+        lines = ["汇率交叉表", header]
+        for base in currencies:
+            row = result["matrix"].get(base, {})
+            vals = "  ".join(f"{row.get(t, '-'):>10}" for t in currencies)
+            lines.append(f"{base:>8} {vals}")
+        lines.extend([
+            "",
+            f"更新时间: {result['timestamp']}",
+            f"数据来源: {result['source']}",
+        ])
+        return "\n".join(lines)
+
+    if "rates" in result:
+        # 多货币输出
+        base = result["base_currency"]
+        lines = [
+            "汇率查询结果",
+            f"基准货币: {_currency_label(base)}",
+            "",
+            f"汇率 (1 {base} = ):",
+        ]
+        for currency, rate in result["rates"].items():
+            lines.append(f"  {_currency_label(currency)}: {rate}")
+        lines.extend([
+            "",
+            f"更新时间: {result['timestamp']}",
+            f"数据来源: {result['source']}",
+        ])
+        return "\n".join(lines)
+
+    # 单货币输出（含金额换算）
+    base = result["base_currency"]
+    target = result["target_currency"]
+    amount = result.get("amount", 1)
+    converted = result.get("converted", result["rate"])
+
+    lines = [
+        "汇率查询结果",
+        f"1 {_currency_label(base)} = {result['rate']} {_currency_label(target)}",
+    ]
+    if amount != 1:
+        lines.append(f"{amount} {base} = {converted} {target}")
+    lines.extend([
+        "",
+        f"更新时间: {result['timestamp']}",
+        f"数据来源: {result['source']}",
+    ])
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+
+    if not args:
+        # 无参数：显示 NZD 的常用汇率
+        result = get_all_rates()
+        print(format_output(result))
+    elif args[0] == "--cross":
+        # 交叉汇率表
+        currencies = args[1:] if len(args) > 1 else None
+        result = get_cross_rates(currencies)
+        print(format_output(result))
+    elif args[0] == "--base":
+        # 指定基准货币查看常用汇率: --base AUD
+        base = args[1].upper() if len(args) > 1 else "NZD"
+        targets = [a.upper() for a in args[2:]] if len(args) > 2 else None
+        result = get_all_rates(base_currency=base, targets=targets)
+        print(format_output(result))
+    else:
+        # 简易用法: [金额] 基准货币 目标货币
+        # 例: python3 get_rate.py AUD CNY
+        #     python3 get_rate.py 100 AUD CNY
+        amount = 1
+        idx = 0
+        try:
+            amount = float(args[0])
+            idx = 1
+        except ValueError:
+            pass
+
+        base = args[idx].upper() if len(args) > idx else "NZD"
+        target = args[idx + 1].upper() if len(args) > idx + 1 else "CNY"
+        result = get_exchange_rate(target_currency=target, base_currency=base, amount=amount)
+        print(format_output(result))

--- a/skills/devpilot-daily-toolkit/scripts/github_daily_report.py
+++ b/skills/devpilot-daily-toolkit/scripts/github_daily_report.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""
+GitHub Daily Report Generator with AI Summary
+汇总当天的所有 GitHub 活动，并用 AI 生成改动总结
+"""
+
+import subprocess
+import json
+import sys
+from datetime import datetime, timedelta
+import argparse
+from collections import defaultdict
+
+
+def run_gh_command(args):
+    """运行 gh CLI 命令并返回结果"""
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        return None
+
+
+def get_recent_repos(days=2):
+    """获取最近有活动的仓库"""
+    result = run_gh_command([
+        "repo", "list",
+        "--limit", "20",
+        "--json", "nameWithOwner,updatedAt,pushedAt"
+    ])
+    
+    if result:
+        try:
+            repos = json.loads(result)
+            cutoff = (datetime.now() - timedelta(days=days)).isoformat()
+            return [r for r in repos if r.get("pushedAt", "") > cutoff]
+        except:
+            pass
+    return []
+
+
+def get_repo_commits(repo, date):
+    """获取仓库某天的 commits"""
+    since = f"{date}T00:00:00Z"
+    until_date = (datetime.strptime(date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+    until = f"{until_date}T00:00:00Z"
+    
+    result = run_gh_command([
+        "api",
+        f"repos/{repo}/commits",
+        "--paginate",
+        "--jq", f'map(select(.commit.author.date >= "{since}" and .commit.author.date < "{until}")) | map({{sha: .sha[:7], message: .commit.message, author: .commit.author.name, date: .commit.author.date, url: .html_url}})'
+    ])
+    
+    if result:
+        try:
+            commits = json.loads(result)
+            return [c for c in commits if c]
+        except:
+            pass
+    return []
+
+
+def get_repo_prs(repo, date):
+    """获取仓库某天的 PR 活动"""
+    created_prs = []
+    merged_prs = []
+    
+    result = run_gh_command([
+        "api",
+        f"repos/{repo}/pulls",
+        "--paginate",
+        "--jq", "map({number: .number, title: .title, state: .state, created_at: .created_at, merged_at: .mergedAt, user: .user.login, url: .html_url, body: .body})"
+    ])
+    
+    if result:
+        try:
+            prs = json.loads(result)
+            for pr in prs:
+                created_date = pr.get("created_at", "")[:10] if pr.get("created_at") else ""
+                merged_date = pr.get("merged_at", "")[:10] if pr.get("merged_at") else ""
+                
+                pr_data = {
+                    "number": pr.get("number", 0),
+                    "title": pr.get("title", "Untitled"),
+                    "url": pr.get("url", ""),
+                    "author": pr.get("user", ""),
+                    "body": pr.get("body", "")[:200] if pr.get("body") else ""
+                }
+                
+                if created_date == date:
+                    created_prs.append(pr_data)
+                if merged_date == date:
+                    merged_prs.append(pr_data)
+        except:
+            pass
+    
+    return {"created": created_prs, "merged": merged_prs}
+
+
+def get_repo_issues(repo, date):
+    """获取仓库某天的 Issue 活动"""
+    created_issues = []
+    closed_issues = []
+    
+    result = run_gh_command([
+        "api",
+        f"repos/{repo}/issues",
+        "--paginate",
+        "--jq", "map({number: .number, title: .title, state: .state, created_at: .created_at, closed_at: .closed_at, user: .user.login, url: .html_url})"
+    ])
+    
+    if result:
+        try:
+            issues = json.loads(result)
+            for issue in issues:
+                if "/pull/" in issue.get("url", ""):
+                    continue
+                    
+                created_date = issue.get("created_at", "")[:10] if issue.get("created_at") else ""
+                closed_date = issue.get("closed_at", "")[:10] if issue.get("closed_at") else ""
+                
+                issue_data = {
+                    "number": issue.get("number", 0),
+                    "title": issue.get("title", "Untitled"),
+                    "url": issue.get("url", ""),
+                    "author": issue.get("user", "")
+                }
+                
+                if created_date == date:
+                    created_issues.append(issue_data)
+                if closed_date == date:
+                    closed_issues.append(issue_data)
+        except:
+            pass
+    
+    return {"created": created_issues, "closed": closed_issues}
+
+
+def get_commit_diff(repo, sha):
+    """获取 commit 的改动统计"""
+    result = run_gh_command([
+        "api",
+        f"repos/{repo}/commits/{sha}",
+        "--jq", "{additions: .stats.additions, deletions: .stats.deletions, total: .stats.total, files: [.files[].filename]}"
+    ])
+    
+    if result:
+        try:
+            return json.loads(result)
+        except:
+            pass
+    return None
+
+
+def generate_change_descriptions(analysis, repo_name):
+    """生成自然语言的改动描述"""
+    descriptions = []
+    
+    # 分析功能开发
+    if analysis["features"]:
+        feature_msgs = [c.get("message", "").lower() for c in analysis["features"]]
+        
+        # 提取关键词
+        if any("seo" in m for m in feature_msgs):
+            descriptions.append("优化了网站的 SEO，添加了结构化数据和站点地图")
+        if any("ui" in m or "component" in m for m in feature_msgs):
+            descriptions.append("开发了新的 UI 组件和页面功能")
+        if any("api" in m or "backend" in m for m in feature_msgs):
+            descriptions.append("实现了后端 API 接口")
+        if any("auth" in m or "login" in m for m in feature_msgs):
+            descriptions.append("添加了用户认证和登录功能")
+        
+        # 通用描述
+        if len(analysis["features"]) > 3 and len(descriptions) == 0:
+            descriptions.append(f"开发了 {len(analysis['features'])} 个新功能")
+    
+    # 分析 Bug 修复
+    if analysis["fixes"]:
+        fix_msgs = [c.get("message", "").lower() for c in analysis["fixes"]]
+        
+        if any("responsive" in m or "mobile" in m for m in fix_msgs):
+            descriptions.append("修复了响应式布局问题，优化了移动端显示")
+        if any("typo" in m or "text" in m for m in fix_msgs):
+            descriptions.append("修正了文字错误和拼写问题")
+        if any("import" in m or "build" in m for m in fix_msgs):
+            descriptions.append("解决了构建和依赖相关的问题")
+        if any("crash" in m or "error" in m for m in fix_msgs):
+            descriptions.append("修复了程序崩溃和错误处理问题")
+        
+        if len(analysis["fixes"]) > 2 and not any("修复" in d for d in descriptions):
+            descriptions.append(f"修复了 {len(analysis['fixes'])} 处问题")
+    
+    # 分析重构
+    if analysis["refactors"]:
+        refactor_msgs = [c.get("message", "").lower() for c in analysis["refactors"]]
+        
+        if any("extract" in m or "component" in m for m in refactor_msgs):
+            descriptions.append("重构了组件结构，提取了可复用组件")
+        if any("optimize" in m or "performance" in m for m in refactor_msgs):
+            descriptions.append("优化了代码性能")
+        if any("clean" in m or "remove" in m for m in refactor_msgs):
+            descriptions.append("清理了无用代码，提升了代码质量")
+        
+        if len(analysis["refactors"]) > 2 and not any("重构" in d for d in descriptions):
+            descriptions.append(f"进行了 {len(analysis['refactors'])} 处代码重构")
+    
+    # 分析文档
+    if analysis["docs"]:
+        descriptions.append("更新了项目文档和说明")
+    
+    # 分析其他
+    if analysis["others"]:
+        other_msgs = [c.get("message", "").lower() for c in analysis["others"]]
+        
+        if any("style" in m or "css" in m for m in other_msgs):
+            descriptions.append("调整了样式和视觉效果")
+        if any("config" in m or "setup" in m for m in other_msgs):
+            descriptions.append("更新了配置和项目设置")
+    
+    # 如果没有生成任何描述，使用通用描述
+    if not descriptions:
+        total = len(analysis["features"]) + len(analysis["fixes"]) + len(analysis["refactors"]) + len(analysis["docs"]) + len(analysis["others"])
+        descriptions.append(f"进行了 {total} 项代码更新")
+    
+    return descriptions[:5]  # 最多返回5条
+
+
+def analyze_commits(commits, repo):
+    """分析 commits，提取改动类型和文件"""
+    analysis = {
+        "features": [],
+        "fixes": [],
+        "docs": [],
+        "refactors": [],
+        "others": [],
+        "files_changed": set(),
+        "total_additions": 0,
+        "total_deletions": 0
+    }
+    
+    for commit in commits:
+        msg = commit.get("message", "").lower()
+        sha = commit.get("sha", "")
+        
+        # 分类 commit
+        if any(kw in msg for kw in ["feat", "feature", "add", "implement", "new"]):
+            analysis["features"].append(commit)
+        elif any(kw in msg for kw in ["fix", "bugfix", "hotfix", "resolve", "patch"]):
+            analysis["fixes"].append(commit)
+        elif any(kw in msg for kw in ["doc", "readme", "comment", "guide"]):
+            analysis["docs"].append(commit)
+        elif any(kw in msg for kw in ["refactor", "clean", "optimize", "improve", "update"]):
+            analysis["refactors"].append(commit)
+        else:
+            analysis["others"].append(commit)
+        
+        # 获取文件改动统计（可选，因为 API 调用较多）
+        # diff = get_commit_diff(repo, sha)
+        # if diff:
+        #     analysis["total_additions"] += diff.get("additions", 0)
+        #     analysis["total_deletions"] += diff.get("deletions", 0)
+        #     analysis["files_changed"].update(diff.get("files", []))
+    
+    return analysis
+
+
+def generate_repo_summary(repo_name, commits, prs, issues):
+    """生成单个仓库的总结"""
+    lines = []
+    lines.append(f"\n🔹 {repo_name}")
+    lines.append("-" * 40)
+    
+    if not commits and not prs["created"] and not prs["merged"] and not issues["created"] and not issues["closed"]:
+        lines.append("  No activity today")
+        return "\n".join(lines)
+    
+    # 分析 commits
+    if commits:
+        analysis = analyze_commits(commits, repo_name)
+        
+        lines.append(f"\n  📊 改动分析 ({len(commits)} commits):")
+        
+        if analysis["features"]:
+            lines.append(f"    ✨ 新功能 ({len(analysis['features'])}):")
+            for c in analysis["features"][:3]:
+                msg = c.get('message', '').split('\n')[0][:45]
+                lines.append(f"      • {msg}")
+        
+        if analysis["fixes"]:
+            lines.append(f"    🐛 Bug 修复 ({len(analysis['fixes'])}):")
+            for c in analysis["fixes"][:3]:
+                msg = c.get('message', '').split('\n')[0][:45]
+                lines.append(f"      • {msg}")
+        
+        if analysis["refactors"]:
+            lines.append(f"    🔧 重构优化 ({len(analysis['refactors'])}):")
+            for c in analysis["refactors"][:3]:
+                msg = c.get('message', '').split('\n')[0][:45]
+                lines.append(f"      • {msg}")
+        
+        if analysis["docs"]:
+            lines.append(f"    📝 文档更新 ({len(analysis['docs'])}):")
+            for c in analysis["docs"][:3]:
+                msg = c.get('message', '').split('\n')[0][:45]
+                lines.append(f"      • {msg}")
+        
+        if analysis["others"]:
+            lines.append(f"    📌 其他 ({len(analysis['others'])}):")
+            for c in analysis["others"][:2]:
+                msg = c.get('message', '').split('\n')[0][:45]
+                lines.append(f"      • {msg}")
+    
+    # PRs
+    if prs["created"]:
+        lines.append(f"\n  🔀 新建 PR ({len(prs['created'])}):")
+        for pr in prs["created"][:3]:
+            lines.append(f"    + #{pr['number']} {pr['title'][:40]}")
+    
+    if prs["merged"]:
+        lines.append(f"\n  ✅ 合并 PR ({len(prs['merged'])}):")
+        for pr in prs["merged"][:3]:
+            lines.append(f"    ✓ #{pr['number']} {pr['title'][:40]}")
+    
+    # Issues
+    if issues["created"]:
+        lines.append(f"\n  🐛 新建 Issue ({len(issues['created'])}):")
+        for issue in issues["created"][:3]:
+            lines.append(f"    + #{issue['number']} {issue['title'][:40]}")
+    
+    if issues["closed"]:
+        lines.append(f"\n  ✓ 关闭 Issue ({len(issues['closed'])}):")
+        for issue in issues["closed"][:3]:
+            lines.append(f"    ✓ #{issue['number']} {issue['title'][:40]}")
+    
+    return "\n".join(lines)
+
+
+def get_all_activity(date):
+    """获取所有仓库的活动"""
+    repos = get_recent_repos(days=2)
+    activity = {}
+    
+    print(f"Checking {len(repos)} recently active repositories...", file=sys.stderr)
+    
+    for repo in repos:
+        repo_name = repo.get("nameWithOwner", "")
+        if not repo_name:
+            continue
+        
+        commits = get_repo_commits(repo_name, date)
+        prs = get_repo_prs(repo_name, date)
+        issues = get_repo_issues(repo_name, date)
+        
+        if commits or prs["created"] or prs["merged"] or issues["created"] or issues["closed"]:
+            activity[repo_name] = {
+                "commits": commits,
+                "prs_created": prs["created"],
+                "prs_merged": prs["merged"],
+                "issues_created": issues["created"],
+                "issues_closed": issues["closed"]
+            }
+            total = len(commits) + len(prs["created"]) + len(prs["merged"]) + len(issues["created"]) + len(issues["closed"])
+            print(f"  ✓ {repo_name}: {total} activities", file=sys.stderr)
+    
+    return activity
+
+
+def format_detailed_report(activity, date):
+    """格式化详细报告"""
+    report = []
+    
+    # 标题
+    report.append("=" * 60)
+    report.append(f"📊 GitHub Daily Activity Report")
+    report.append(f"📅 {date}")
+    report.append("=" * 60)
+    report.append("")
+    
+    # 统计概览
+    total_commits = sum(len(r["commits"]) for r in activity.values())
+    total_prs_created = sum(len(r["prs_created"]) for r in activity.values())
+    total_prs_merged = sum(len(r["prs_merged"]) for r in activity.values())
+    total_issues_created = sum(len(r["issues_created"]) for r in activity.values())
+    total_issues_closed = sum(len(r["issues_closed"]) for r in activity.values())
+    
+    report.append("📈 今日概览")
+    report.append("-" * 40)
+    report.append(f"  📝 Commits: {total_commits}")
+    report.append(f"  🔀 PRs Created: {total_prs_created}")
+    report.append(f"  ✅ PRs Merged: {total_prs_merged}")
+    report.append(f"  🐛 Issues Created: {total_issues_created}")
+    report.append(f"  ✓ Issues Closed: {total_issues_closed}")
+    report.append(f"  📦 Active Repositories: {len(activity)}")
+    report.append("")
+    
+    # 按仓库详细列出
+    if activity:
+        report.append("📦 Repository Details")
+        report.append("=" * 60)
+        
+        # 按活动数量排序
+        sorted_repos = sorted(
+            activity.items(),
+            key=lambda x: (
+                len(x[1]["commits"]) +
+                len(x[1]["prs_created"]) +
+                len(x[1]["prs_merged"]) +
+                len(x[1]["issues_created"]) +
+                len(x[1]["issues_closed"])
+            ),
+            reverse=True
+        )
+        
+        for repo_name, data in sorted_repos:
+            summary = generate_repo_summary(
+                repo_name,
+                data["commits"],
+                {"created": data["prs_created"], "merged": data["prs_merged"]},
+                {"created": data["issues_created"], "closed": data["issues_closed"]}
+            )
+            report.append(summary)
+            report.append("")
+    else:
+        report.append("📭 No activity today")
+        report.append("")
+    
+    # 添加每个仓库的 AI 总结
+    if activity:
+        report.append("\n" + "=" * 60)
+        report.append("🤖 今日改动总结")
+        report.append("=" * 60)
+        report.append("")
+        
+        # 按仓库生成总结
+        for repo_name, data in sorted_repos:
+            commits = data["commits"]
+            if not commits:
+                continue
+                
+            report.append(f"\n*{repo_name}*")
+            report.append("")
+            
+            # 分析该仓库的 commits
+            analysis = analyze_commits(commits, repo_name)
+            
+            # 生成一句话总结
+            summary_parts = []
+            if analysis["features"]:
+                summary_parts.append(f"新增了 {len(analysis['features'])} 个功能")
+            if analysis["fixes"]:
+                summary_parts.append(f"修复了 {len(analysis['fixes'])} 个 bug")
+            if analysis["refactors"]:
+                summary_parts.append(f"进行了 {len(analysis['refactors'])} 处重构优化")
+            if analysis["docs"]:
+                summary_parts.append(f"更新了 {len(analysis['docs'])} 处文档")
+            
+            if summary_parts:
+                report.append(f"今日主要{'，'.join(summary_parts)}。")
+            else:
+                report.append(f"今日提交了 {len(commits)} 个 commits。")
+            
+            # 生成 AI 风格的具体改动总结
+            report.append("")
+            report.append("具体改动：")
+            
+            # 分析 commits 内容，生成自然语言描述
+            descriptions = generate_change_descriptions(analysis, repo_name)
+            for desc in descriptions:
+                report.append(f"• {desc}")
+            
+            report.append("")
+    
+    return "\n".join(report)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GitHub Daily Report Generator")
+    parser.add_argument("--date", help="Date to generate report for (YYYY-MM-DD)", default=None)
+    parser.add_argument("--repo", help="Specific repository (owner/repo)", default=None)
+    args = parser.parse_args()
+    
+    # 确定日期
+    if args.date:
+        date = args.date
+    else:
+        date = datetime.now().strftime("%Y-%m-%d")
+    
+    print(f"Generating GitHub report for {date}...", file=sys.stderr)
+    
+    if args.repo:
+        print(f"Checking repository: {args.repo}", file=sys.stderr)
+        commits = get_repo_commits(args.repo, date)
+        prs = get_repo_prs(args.repo, date)
+        issues = get_repo_issues(args.repo, date)
+        
+        activity = {}
+        if commits or prs["created"] or prs["merged"] or issues["created"] or issues["closed"]:
+            activity[args.repo] = {
+                "commits": commits,
+                "prs_created": prs["created"],
+                "prs_merged": prs["merged"],
+                "issues_created": issues["created"],
+                "issues_closed": issues["closed"]
+            }
+    else:
+        activity = get_all_activity(date)
+    
+    # 生成报告
+    report = format_detailed_report(activity, date)
+    
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/index.json
+++ b/skills/index.json
@@ -45,6 +45,20 @@
       ]
     },
     {
+      "name": "devpilot-daily-toolkit",
+      "description": "Personal daily-life toolkit for an Auckland, NZ user — bundles RSS news (世界科技/AI/政治/财经/新西兰), real-time exchange rates, GitHub daily activity reports, and NZ public holidays behind one skill, plus a combined morning-briefing mode that runs all four.",
+      "files": [
+        "evals/evals.json",
+        "feeds.json",
+        "requirements.txt",
+        "scripts/fetch_news.py",
+        "scripts/get_holidays.py",
+        "scripts/get_rate.py",
+        "scripts/github_daily_report.py",
+        "SKILL.md"
+      ]
+    },
+    {
       "name": "devpilot-google-go-style",
       "description": "ALWAYS use when working in a Go project — writing new Go code, modifying .go files, reviewing Go PRs, or discussing Go design decisions.",
       "files": [


### PR DESCRIPTION
## Summary

New skill `devpilot-daily-toolkit` — a personal daily-life toolkit for an Auckland, NZ user that bundles four utilities behind one skill, plus a combined morning-briefing mode that runs all four and assembles a Chinese-language digest.

The four tools are self-contained Python scripts the skill routes between based on user intent:

| Tool | Script | Purpose |
|------|--------|---------|
| News | `scripts/fetch_news.py` | RSS across 5 categories (世界科技 / AI / 世界政治 / 经济金融 / 新西兰), driven by `feeds.json` |
| Exchange rate | `scripts/get_rate.py` | Single pair, multi-target, `--cross` matrix, with optional amount |
| GitHub activity | `scripts/github_daily_report.py` | Today's commits / PRs / issues across active repos via `gh` CLI |
| NZ holidays | `scripts/get_holidays.py` | Nager.Date API, Auckland-highlighted, with next-holiday countdown |

`skills/index.json` is updated to register the new skill (per the CLAUDE.md convention that index entries land in the same PR).

## Files

- `skills/devpilot-daily-toolkit/SKILL.md` — routing rules, per-tool usage, combined-briefing template, gotchas
- `skills/devpilot-daily-toolkit/feeds.json` — RSS feed list grouped by category
- `skills/devpilot-daily-toolkit/requirements.txt` — `feedparser`, `requests`
- `skills/devpilot-daily-toolkit/scripts/*.py` — the four tools (holidays uses stdlib; news/rate need pip deps; github needs `gh` auth)
- `skills/devpilot-daily-toolkit/evals/evals.json` — eval cases
- `skills/index.json` — register entry

## Review Guide

Start with `skills/devpilot-daily-toolkit/SKILL.md` to understand the routing model and the combined-briefing format — that's the contract. Then skim each script in `scripts/` for argument shape and output format; the SKILL.md gotchas section calls out the non-obvious bits (e.g. `--cross` does not auto-uppercase, `fetch_news.py` writes warnings to stderr that should not be surfaced to users). `skills/index.json` is just the catalog registration.

## Test plan

- [ ] `python3 skills/devpilot-daily-toolkit/scripts/get_holidays.py` — should list NZ holidays with Auckland highlighted and a next-holiday countdown
- [ ] `python3 skills/devpilot-daily-toolkit/scripts/get_rate.py AUD CNY` — should return a single pair quote
- [ ] `python3 skills/devpilot-daily-toolkit/scripts/fetch_news.py` — should print 5 categories of raw RSS items (requires `feedparser`)
- [ ] `python3 skills/devpilot-daily-toolkit/scripts/github_daily_report.py` — should print today's activity (requires `gh auth login`)
- [ ] Trigger the skill end-to-end with "morning briefing" / "今日简报" and verify all four sections render

## For Reviewers (human)

- [ ] Skill description accurately conveys when to trigger vs. when to defer to `devpilot-news-digest` / `devpilot-learn`
- [ ] `skills/index.json` entry matches the `files` actually present
- [ ] Combined-briefing output format is glanceable (not a wall of text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)