### PR TITLE
feat(skills): add devpilot-issue-triage skill

### DIFF
--- a/docs/superpowers/specs/2026-05-01-devpilot-issue-triage-design.md
+++ b/docs/superpowers/specs/2026-05-01-devpilot-issue-triage-design.md
@@ -1,0 +1,67 @@
+# devpilot-issue-triage — Design
+
+## Purpose
+
+Bridge the gap between `devpilot-scanning-repos` (creates issues) and `devpilot-resolve-issues` (executes fixes) by classifying an existing GitHub issue backlog into actionable buckets and drafting — but **not posting** — the follow-up actions.
+
+## Triggering
+
+Use when the user wants to triage, classify, sort, or sweep open GitHub issues to decide what's worth working on. Triggers: "triage these issues", "what's worth fixing", "sort the backlog", "/triage", "分诊 issues", "整理 backlog".
+
+Do **not** use for: filing new issues (→ `devpilot-scanning-repos`), executing fixes (→ `devpilot-resolve-issues`), or reviewing a single PR (→ `devpilot-pr-review`).
+
+## Workflow
+
+1. **Collect**: `gh issue list` (open, optional filter: label, author, age) → produce ordered list.
+2. **Batch classify** — for each issue, assign exactly one bucket:
+   - `ready-to-fix` — clear scope, reproducible, small, no design questions; eligible for `devpilot-resolve-issues`.
+   - `needs-info` — missing repro / env / expected behavior; reporter must answer questions.
+   - `needs-design` — real problem, but solution requires discussion or trade-off decisions.
+   - `duplicate` — same as another open or closed issue (link required).
+   - `stale` / `won't-fix` — outdated, abandoned, or out-of-direction.
+   - `out-of-scope` — legitimate request, wrong repo.
+   Bucket choice MUST come with one-line evidence ("no repro steps", "duplicates #88").
+3. **Deep dive** — for every `ready-to-fix` issue only:
+   - Read cited files, scan related code paths.
+   - Note suspected root cause (1–2 sentences).
+   - Estimate fix size: XS (< 30 min) / S (< 2h) / M (half-day) / L (split first).
+   - If deep-dive reveals the issue is actually `needs-design` or `needs-info`, demote it.
+4. **Draft actions** — write but do not post:
+   - For `needs-info`: drafted question comment.
+   - For `duplicate`: drafted close-comment with link.
+   - For `stale`: drafted close-comment with rationale.
+   - For `ready-to-fix`: 1-line handoff hint for `devpilot-resolve-issues`.
+   - Suggested labels per issue.
+5. **Output**: a single markdown report at `./issue-triage-<owner>-<repo>-<YYYY-MM-DD>.md` containing:
+   - Summary counts per bucket.
+   - Per-issue section: number + title, bucket, evidence, drafted action, suggested labels, deep-dive (if applicable).
+   - Footer: copy-pasteable command to feed the `ready-to-fix` list into `devpilot-resolve-issues`.
+
+## Hard rules (the "B" boundary)
+
+- **Read-only against GitHub.** Never call `gh issue comment`, `gh issue close`, `gh issue edit`, `gh label`, etc.
+- All proposed mutations live in the report as drafts.
+- Closing the loop (actually posting) is the user's job, or they can hand the report to a different skill.
+
+## Non-goals
+
+- No automatic re-triage on a schedule.
+- No cross-repo dedup beyond the current repo.
+- No prioritization scoring beyond bucket + size — leave priority to humans.
+
+## Files
+
+```
+skills/devpilot-issue-triage/
+  SKILL.md
+  references/
+    bucket-rubric.md     # decision tree for bucket assignment + examples
+    report-template.md   # exact markdown skeleton for the output file
+    draft-comments.md    # canonical wording for needs-info / duplicate / stale comments
+```
+
+## Success criteria
+
+- A subagent given a 10-issue sample classifies every issue into exactly one bucket with cited evidence.
+- The report is immediately actionable: every drafted comment is paste-ready, every `ready-to-fix` entry has a handoff hint.
+- No GitHub state was modified during the run.

--- a/skills/devpilot-issue-triage/SKILL.md
+++ b/skills/devpilot-issue-triage/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: devpilot-issue-triage
+description: Use when the user wants to triage, classify, sort, or sweep open GitHub issues to decide what's worth working on — "triage these issues", "整理 backlog", "哪些可以马上修", "/triage", "sort the open issues". Sits between devpilot-scanning-repos (which files issues) and devpilot-resolve-issues (which fixes them). Read-only against GitHub: drafts comments and labels into a local report but never posts. Do NOT use for filing new issues, executing fixes, or reviewing a single PR.
+---
+
+# Triage GitHub Issue Backlog (Read-Only)
+
+## Files in this skill
+
+| File | When to load |
+|---|---|
+| `references/bucket-rubric.md` | Step 2 — assigning a bucket. Rubric + counter-examples for each of the 6 buckets. |
+| `references/draft-comments.md` | Step 4 — exact wording for `needs-info`, `duplicate`, `stale` draft comments. |
+| `references/report-template.md` | Step 5 — the exact markdown skeleton for the output file, including the `devpilot-resolve-issues` handoff footer. |
+
+## Overview
+
+End-to-end loop that takes the open-issue backlog of one GitHub repo and produces a single local markdown report classifying each issue, drafting follow-up actions, and (for `ready-to-fix` only) deep-diving into the code. **Nothing is posted to GitHub.** The user is the one who decides whether to act on the report.
+
+**Core principle:** Read-only against GitHub. Every proposed mutation lives in the report as a draft. Anything else turns this skill into a half-baked `devpilot-resolve-issues` and breaks the boundary that makes triage safe to run unattended.
+
+## When NOT to Use
+
+- Creating new issues from a fresh code scan → `devpilot-scanning-repos`.
+- Actually fixing the `ready-to-fix` shortlist → hand the report to `devpilot-resolve-issues`.
+- Reviewing a PR the user already opened → `devpilot-pr-review`.
+- A single ad-hoc bug report — just discuss it directly, no triage report needed.
+
+## The 6 Buckets (exhaustive — pick exactly one)
+
+| Bucket | Meaning |
+|---|---|
+| `ready-to-fix` | Clear scope, reproducible, small enough to fix without a design discussion. Eligible for `devpilot-resolve-issues`. |
+| `needs-info` | Real candidate but blocked on missing repro / env / expected behavior from the reporter. |
+| `needs-design` | Real problem; solution requires a trade-off discussion or product decision before code. |
+| `duplicate` | Same as another open or closed issue. **Must** cite the other issue number. |
+| `stale` | Outdated, abandoned, or no longer relevant. Recommend closing. |
+| `out-of-scope` | Legitimate request, but belongs in a different repo or product. |
+
+Pick exactly one. If torn between two, see `references/bucket-rubric.md` for tie-breakers.
+
+## The flow
+
+```dot
+digraph triage_flow {
+  "Collect open issues (gh issue list)" [shape=box];
+  "Per issue: assign bucket + 1-line evidence" [shape=box];
+  "Bucket == ready-to-fix?" [shape=diamond];
+  "Deep-dive: read cited files, root-cause guess, size XS/S/M/L" [shape=box];
+  "Draft action: comment text / label suggestion / handoff hint" [shape=box];
+  "Write report to ./issue-triage-<owner>-<repo>-<YYYY-MM-DD>.md" [shape=box];
+  "Done" [shape=doublecircle];
+
+  "Collect open issues (gh issue list)" -> "Per issue: assign bucket + 1-line evidence";
+  "Per issue: assign bucket + 1-line evidence" -> "Bucket == ready-to-fix?";
+  "Bucket == ready-to-fix?" -> "Deep-dive: read cited files, root-cause guess, size XS/S/M/L" [label="yes"];
+  "Bucket == ready-to-fix?" -> "Draft action: comment text / label suggestion / handoff hint" [label="no"];
+  "Deep-dive: read cited files, root-cause guess, size XS/S/M/L" -> "Draft action: comment text / label suggestion / handoff hint";
+  "Draft action: comment text / label suggestion / handoff hint" -> "Write report to ./issue-triage-<owner>-<repo>-<YYYY-MM-DD>.md";
+  "Write report to ./issue-triage-<owner>-<repo>-<YYYY-MM-DD>.md" -> "Done";
+}
+```
+
+## Steps
+
+### 1. Collect
+
+```sh
+gh issue list --repo <owner>/<repo> --state open --limit 100 \
+  --json number,title,body,labels,author,createdAt,updatedAt,comments
+```
+
+Honor any user-provided filter (`--label`, `--author`, age). If the user didn't give one, take everything open.
+
+### 2. Classify (batch)
+
+For each issue, in order, assign **exactly one** of the 6 buckets and write a 1-line evidence string. Examples:
+
+- `ready-to-fix` — "well-scoped: cited file + line range + suggested fix"
+- `needs-info` — "no repro steps, no env, no expected behavior"
+- `needs-design` — "API shape change touches 3 callers, requires decision"
+- `duplicate` — "duplicates #88 (same root cause, same files)"
+- `stale` — "last activity 18 months ago, references removed module"
+- `out-of-scope` — "feature request belongs in `<other-repo>`"
+
+If unsure between buckets → consult `references/bucket-rubric.md`. Do not invent new buckets.
+
+### 3. Deep-dive (ready-to-fix only)
+
+For every issue bucketed `ready-to-fix`:
+
+1. Read the files cited in the issue body (use `Read`, not `gh`).
+2. Confirm the issue is reproducible from what the code shows. If the deep-dive reveals it's actually `needs-design` or `needs-info`, **demote** the bucket and skip the size estimate.
+3. Note suspected root cause in 1–2 sentences.
+4. Estimate fix size: `XS` (< 30 min, single file), `S` (< 2h, ≤ 3 files), `M` (half-day, multi-file or new dependency), `L` (split into multiple issues first).
+
+Do not deep-dive issues in any other bucket — that's wasted work.
+
+### 4. Draft actions
+
+For each issue, draft (do not post) what would close the loop:
+
+| Bucket | Draft |
+|---|---|
+| `ready-to-fix` | 1-line handoff hint for `devpilot-resolve-issues`, plus any code-level note from deep-dive. |
+| `needs-info` | Paste-ready comment asking the missing questions. Use template in `references/draft-comments.md`. |
+| `needs-design` | Paste-ready comment listing the trade-offs that need decisions. |
+| `duplicate` | Paste-ready close-comment linking the canonical issue. |
+| `stale` | Paste-ready close-comment with rationale. |
+| `out-of-scope` | Paste-ready close-comment naming the right destination. |
+
+Also propose 1–3 labels per issue (e.g. `triage:ready`, `triage:needs-info`). Labels are suggestions, not applied.
+
+### 5. Write the report
+
+Output filename: `./issue-triage-<owner>-<repo>-<YYYY-MM-DD>.md` (in the cwd, not `/tmp`, not `docs/`).
+
+Use the exact skeleton in `references/report-template.md`. The skeleton already includes:
+- Summary counts per bucket
+- Per-issue section in spec order
+- Footer with the copy-pasteable command to feed `ready-to-fix` issue numbers into `devpilot-resolve-issues`
+
+### 6. Stop
+
+Tell the user: report written, bucket counts, suggested next move (usually "review the `ready-to-fix` section, then run `devpilot-resolve-issues`"). **Do not** also produce a prioritization plan, suggested PR groupings, or "order of attack" — that's the user's call, not yours.
+
+## Hard rules
+
+- **Read-only against GitHub.** Never run `gh issue comment`, `gh issue close`, `gh issue edit`, `gh label create/edit/add`, `gh issue lock`, etc. If you catch yourself reaching for any `gh` write subcommand, stop.
+- **Exactly 6 buckets.** No new ones, no merging, no "needs-info-or-design".
+- **Deep-dive only for `ready-to-fix`.** Reading code for `stale` issues is wasted work.
+- **No prioritization.** Bucket + size is what we offer. Order is the user's job.
+- **Output path is `./issue-triage-<owner>-<repo>-<YYYY-MM-DD>.md`** — not `/tmp`, not stdout-only. (If the user explicitly names a different path, honor it — user instructions beat the default. Without an explicit override, use the default.)
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Inventing new buckets ("Fix Soon", "Maybe") | Pick one of the 6. If torn, see `references/bucket-rubric.md`. |
+| Saying "what to do" instead of writing the comment | Draft the literal comment text. Paste-ready means paste-ready. |
+| Skipping the deep-dive for `ready-to-fix` | A bucket without a size estimate isn't really `ready-to-fix`. Read the cited files. |
+| Writing to `/tmp` or printing inline only | The user wants a file in the repo cwd they can hand off. |
+| Adding an "order of attack" section | Out of scope. Triage classifies; humans prioritize. |
+| Calling `gh issue comment` because "the user obviously wants it posted" | They don't. The whole point of this skill is the read-only boundary. |
+
+## Red Flags — STOP
+
+- About to type `gh issue comment` / `gh issue close` / `gh issue edit` / `gh label add`
+- About to invent a 7th bucket
+- About to deep-dive a `stale` or `duplicate` issue
+- About to write the report to `/tmp/`
+- About to add a "recommended PR ordering" section
+
+All of these mean: stop, re-read the Hard rules, fix course.

--- a/skills/devpilot-issue-triage/references/bucket-rubric.md
+++ b/skills/devpilot-issue-triage/references/bucket-rubric.md
@@ -1,0 +1,40 @@
+# Bucket Rubric
+
+Use this when you're torn between two buckets. Pick the **first** matching rule.
+
+## Decision order
+
+1. **Is there an exact-match open or closed issue with the same root cause and files?**
+   → `duplicate`. Cite the canonical issue number.
+
+2. **Is the issue about something this repo doesn't own (different product, different service, vendor bug)?**
+   → `out-of-scope`.
+
+3. **Last activity > 12 months AND no recent comments AND references code that no longer exists?**
+   → `stale`.
+
+4. **Reporter didn't say what they did, what they expected, or what they got — AND the body has no cited file/line/log?**
+   → `needs-info`. Even if you can guess, you'd be guessing.
+
+5. **There's a real bug or missing feature, but the fix requires picking between ≥ 2 reasonable approaches, or changes a public API, or touches > 5 files?**
+   → `needs-design`.
+
+6. **Otherwise** — issue cites code, has a proposed fix or obvious one, fits in a single PR:
+   → `ready-to-fix`.
+
+## Counter-examples (common mistakes)
+
+- "Issue from a scanner with severity:high" — does **not** automatically mean `ready-to-fix`. Severity is about impact, not scope. Apply rule 5 first.
+- "Old issue but reporter is still active" — not `stale`. Stale means the *issue* has rotted, not the reporter.
+- "Suggested fix is in the issue body" — doesn't override rule 5. If the suggested fix changes a public API, it's still `needs-design`.
+- "I personally know the answer to the missing-info question" — doesn't override rule 4. The skill's job is to classify what the issue *contains*, not what you happen to know. Bucket as `needs-info`; your knowledge goes into the drafted question comment as context.
+
+## Tie-breakers
+
+- `needs-info` vs `needs-design` → if asking the reporter 1–2 questions could plausibly resolve it, pick `needs-info`. If even with full info the team would still need to debate, pick `needs-design`.
+- `duplicate` vs `stale` → `duplicate` wins. Linking is more useful than closing as stale.
+- `ready-to-fix` vs `needs-design` → if the deep-dive (step 3) shows multiple plausible fix paths, demote to `needs-design`.
+
+## Bucket size limit
+
+There is no quota. If 90% of the backlog is `ready-to-fix`, that's fine. If 90% is `needs-info`, that's a reporting-quality signal, not a bug in the rubric.

--- a/skills/devpilot-issue-triage/references/draft-comments.md
+++ b/skills/devpilot-issue-triage/references/draft-comments.md
@@ -1,0 +1,66 @@
+# Draft Comments
+
+These are paste-ready comment templates. Fill in the bracketed placeholders. Each draft goes into the report under the issue's section — never posted directly.
+
+## `needs-info`
+
+```
+Thanks for the report. To make this actionable, could you share:
+
+- [Specific question 1, e.g. exact steps that reproduce the issue]
+- [Specific question 2, e.g. browser / Node version / OS]
+- [Specific question 3, e.g. expected vs actual behavior]
+
+Without [the most critical missing piece], we can't reliably reproduce or scope a fix.
+```
+
+Rule: ask for the **specific** missing pieces, not a generic "please provide more info". Maximum 3 questions — pick the ones that unblock the most.
+
+## `needs-design`
+
+```
+This is a real issue, but the fix requires a decision before we write code:
+
+- [Trade-off 1, e.g. "do we change the public response shape (breaking) or add a new field (clutter)"]
+- [Trade-off 2, e.g. "is performance or correctness the priority for this path"]
+
+Tagging for design discussion. Once we pick a direction, this can move to `ready-to-fix`.
+```
+
+Rule: list the trade-offs as concrete either/or choices, not vague "we should think about this".
+
+## `duplicate`
+
+```
+Closing as duplicate of #[N] (same root cause: [one-line reason]). Please follow that issue for updates.
+```
+
+Rule: always cite the canonical issue number. The 1-line reason proves it's actually the same root cause, not just similar symptoms.
+
+## `stale`
+
+```
+Closing as stale: [specific reason — last activity 18 months ago / references the removed `XYZ` module / superseded by the rewrite in #N].
+
+If this is still affecting you on the current version, please open a new issue with a fresh repro.
+```
+
+Rule: name the specific reason. "Stale because old" isn't a reason; "stale because the file it references was deleted in #N" is.
+
+## `out-of-scope`
+
+```
+This belongs in [other-repo / other-product] rather than here. Closing — please re-file at [link or repo name] with the same details.
+```
+
+Rule: name the right destination. If you don't know it, demote the bucket to `needs-design` instead.
+
+## `ready-to-fix` (handoff hint, not a comment)
+
+This isn't a comment to post — it's a 1-line hint that goes into the report so `devpilot-resolve-issues` (or a human) has a head start:
+
+```
+Handoff: [size XS/S/M/L] — [root cause in one sentence] — [primary file(s) to edit].
+```
+
+Example: `Handoff: S — catch block returns undefined; client crashes on missing summary — src/app/api/quotation/calculate/route.ts.`

--- a/skills/devpilot-issue-triage/references/report-template.md
+++ b/skills/devpilot-issue-triage/references/report-template.md
@@ -1,0 +1,114 @@
+# Report Template
+
+Use this exact skeleton for `./issue-triage-<owner>-<repo>-<YYYY-MM-DD>.md`. Section order is fixed. Buckets with zero issues should still appear with "_None._" — empty buckets are signal.
+
+```markdown
+# Issue Triage — <owner>/<repo>
+
+Date: <YYYY-MM-DD>
+Open issues triaged: <N>
+Filter applied: <none | label=foo | author=bar | …>
+
+## Summary
+
+| Bucket | Count |
+|---|---|
+| ready-to-fix | <n> |
+| needs-info | <n> |
+| needs-design | <n> |
+| duplicate | <n> |
+| stale | <n> |
+| out-of-scope | <n> |
+
+## ready-to-fix
+
+### #<num> — <title>
+
+- **Evidence:** <one line>
+- **Suspected root cause:** <1–2 sentences from deep-dive>
+- **Size:** XS | S | M | L
+- **Suggested labels:** `triage:ready`, `<other>`
+- **Handoff hint:** <one line for devpilot-resolve-issues>
+
+(repeat per ready-to-fix issue, in ascending issue-number order)
+
+## needs-info
+
+### #<num> — <title>
+
+- **Evidence:** <missing pieces, one line>
+- **Suggested labels:** `triage:needs-info`, `<other>`
+- **Drafted comment** (do not post):
+
+  > <paste-ready comment from references/draft-comments.md>
+
+(repeat)
+
+## needs-design
+
+### #<num> — <title>
+
+- **Evidence:** <one line>
+- **Suggested labels:** `triage:needs-design`, `<other>`
+- **Drafted comment** (do not post):
+
+  > <paste-ready comment>
+
+(repeat)
+
+## duplicate
+
+### #<num> — <title>
+
+- **Duplicates:** #<other-num>
+- **Evidence:** <one-line shared root cause>
+- **Suggested labels:** `triage:duplicate`
+- **Drafted close-comment** (do not post):
+
+  > <paste-ready close-comment>
+
+(repeat)
+
+## stale
+
+### #<num> — <title>
+
+- **Evidence:** <specific staleness reason>
+- **Suggested labels:** `triage:stale`
+- **Drafted close-comment** (do not post):
+
+  > <paste-ready close-comment>
+
+(repeat)
+
+## out-of-scope
+
+### #<num> — <title>
+
+- **Belongs in:** <repo or product>
+- **Suggested labels:** `triage:out-of-scope`
+- **Drafted close-comment** (do not post):
+
+  > <paste-ready close-comment>
+
+(repeat)
+
+## Next step
+
+Hand the `ready-to-fix` list to `devpilot-resolve-issues`:
+
+```
+gh issue list --repo <owner>/<repo> --state open --label triage:ready --json number
+```
+
+Or, after applying the suggested labels manually, run `devpilot-resolve-issues` filtered to `label:triage:ready`.
+
+_This report did not modify any GitHub state._
+```
+
+## Rules
+
+- Section order is fixed: ready-to-fix → needs-info → needs-design → duplicate → stale → out-of-scope → Next step.
+- Within each bucket, sort by ascending issue number.
+- Do **not** add an "Order of Attack", "Recommended PR groupings", or any prioritization section. Out of scope.
+- The trailing "_This report did not modify any GitHub state._" line is mandatory — it's how the user (and you) confirm the read-only contract held.

--- a/skills/index.json
+++ b/skills/index.json
@@ -94,6 +94,16 @@
       ]
     },
     {
+      "name": "devpilot-issue-triage",
+      "description": "Use when the user wants to triage, classify, sort, or sweep open GitHub issues to decide what's worth working on. Sits between devpilot-scanning-repos (files issues) and devpilot-resolve-issues (executes fixes). Read-only against GitHub: drafts comments and labels into a local report but never posts.",
+      "files": [
+        "references/bucket-rubric.md",
+        "references/draft-comments.md",
+        "references/report-template.md",
+        "SKILL.md"
+      ]
+    },
+    {
       "name": "devpilot-learn",
       "description": "Summarize any single article, document, or web page into a standalone HTML digest file with reader-mode styling.",
       "files": [


### PR DESCRIPTION
## Summary

Adds `devpilot-issue-triage`, a read-only triage skill that bridges the gap between `devpilot-scanning-repos` (files issues) and `devpilot-resolve-issues` (executes fixes). Classifies open GitHub issues into 6 fixed buckets (`ready-to-fix`, `needs-info`, `needs-design`, `duplicate`, `stale`, `out-of-scope`), deep-dives `ready-to-fix` items into the cited code, and drafts paste-ready follow-up comments — but never posts to GitHub.

Created with TDD per `superpowers:writing-skills`: a baseline subagent run on `SiyuQian/yunet-web` documented 8 specific gaps (invented bucket names, missing draft text, no size estimates, unsolicited prioritization sections, etc.); SKILL.md addresses each gap; a re-run with the skill loaded closed all 8 and resisted forbidden behaviors (e.g. adding an "order of attack" section). Design rationale lives in `docs/superpowers/specs/2026-05-01-devpilot-issue-triage-design.md`.

## Review Guide

- Start with `skills/devpilot-issue-triage/SKILL.md` — the flow, 6 buckets, hard rules, and red-flags list.
- Then `references/bucket-rubric.md` — 6-rule decision order plus tie-breakers; this is the most opinionated piece.
- `references/draft-comments.md` and `references/report-template.md` are reference artifacts loaded on demand by the skill steps.
- `skills/index.json` adds the entry between `devpilot-harness-engineering` and `devpilot-learn` (alphabetical by `i`).
- `docs/superpowers/specs/...` is the design doc from the brainstorm; drop it if you'd rather keep specs out of the repo.

## Test Plan

- [x] `python3 -c "import json; json.load(open('skills/index.json'))"` — index parses.
- [x] Baseline RED run on \`SiyuQian/yunet-web\` (6 open issues) without the skill — captured 8 gaps.
- [x] GREEN re-run with the skill loaded — all 8 gaps closed, drafted comments paste-ready, read-only contract held (no \`gh\` write calls).
- [ ] Reviewer eyeballs the rubric — rule 5 (\`≥ 2 reasonable approaches → needs-design\`) is the most subjective gate; consider whether to tighten it to "materially different approaches".

🤖 Generated with [Claude Code](https://claude.com/claude-code)