### PR TITLE
docs(skills): tidy devpilot-issue-triage description punctuation

### DIFF
--- a/skills/devpilot-issue-triage/SKILL.md
+++ b/skills/devpilot-issue-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devpilot-issue-triage
-description: Use when the user wants to triage, classify, sort, or sweep open GitHub issues to decide what's worth working on — "triage these issues", "整理 backlog", "哪些可以马上修", "/triage", "sort the open issues". Sits between devpilot-scanning-repos (which files issues) and devpilot-resolve-issues (which fixes them). Read-only against GitHub: drafts comments and labels into a local report but never posts. Do NOT use for filing new issues, executing fixes, or reviewing a single PR.
+description: Use when the user wants to triage, classify, sort, or sweep open GitHub issues to decide what's worth working on — "triage these issues", "整理 backlog", "哪些可以马上修", "/triage", "sort the open issues". Sits between devpilot-scanning-repos (which files issues) and devpilot-resolve-issues (which fixes them). Read-only against GitHub — drafts comments and labels into a local report but never posts. Do NOT use for filing new issues, executing fixes, or reviewing a single PR.
 license: MIT
 ---
 


### PR DESCRIPTION
## Summary

Replaces a colon with an em-dash in the `description` frontmatter of `skills/devpilot-issue-triage/SKILL.md` so the sentence reads as one continuous clause rather than two: `Read-only against GitHub — drafts comments and labels into a local report but never posts.`

No behavior change; description text only.

## Review Guide

- Single file: `skills/devpilot-issue-triage/SKILL.md` line 3.
- Confirm the punctuation tweak doesn't break any frontmatter parser expectations (still valid YAML — em-dash inside a double-quoted-free scalar is fine).

## Test plan

- [x] `git diff` reviewed — one-character punctuation change
- [ ] Skill still loads in Claude Code (human verify)