### PR TITLE
feat(skills): add devpilot-prd-to-issues + tighten scanning-repos label rename rule

### DIFF
--- a/skills/devpilot-prd-to-issues/LICENSE.txt
+++ b/skills/devpilot-prd-to-issues/LICENSE.txt
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/skills/devpilot-prd-to-issues/SKILL.md
+++ b/skills/devpilot-prd-to-issues/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: devpilot-prd-to-issues
+description: Use when the user wants to turn a PRD, spec, design doc, or feature brief into a set of GitHub issues — "break this PRD into tickets", "create issues from the spec", "split this into tasks", "file the work for this feature", "decompose into deliverables", "/prd-to-issues". Produces an issue tree where every ticket is a deliverable slice with explicit parent/child/blocks relationships and a bounded change size.
+---
+
+# PRD → GitHub Issues
+
+## Overview
+
+A PRD is one document. Engineering needs a graph of small, mergeable, individually-shippable issues. This skill decomposes a PRD into that graph: every issue is a **deliverable slice** (mergeable on its own, demonstrable to a stakeholder), every issue is a **reasonable change size** (≤ ~400 LOC diff or ≤ 2 dev-days), and every issue **declares its relationships** to others (epic / parent / blocks / blocked-by / related).
+
+**Core principle:** an issue that ships nothing on its own, or that bundles unrelated work, is the wrong unit. Split until each ticket is independently mergeable; group with relationships, not scope creep.
+
+## When NOT to Use
+
+- The PRD is one paragraph and the work is one PR → just open one issue, don't decompose.
+- Bug triage from a scan → use `devpilot-scanning-repos` (already issue-shaped) or `devpilot-issue-triage`.
+- Roadmap-level epics with no spec yet → use `devpilot-pm` / `devpilot-product-research` first; don't manufacture sub-tickets from vapor.
+- Project tracker is Linear / Jira / Trello, not GitHub → adapt the relationship model but use the appropriate tool (`devpilot-trello` for Trello).
+
+## Workflow
+
+1. **Ingest the PRD.** Read the source (file, URL, pasted text). Extract: goal, user-visible outcomes, non-goals, constraints (deadlines, dependencies, platforms), and any acceptance criteria already written. If goal or outcomes are missing, **stop and ask** — do not invent scope.
+2. **Confirm target repo and conventions.** `gh repo view --json nameWithOwner`. Snapshot existing labels: `gh label list --limit 200 --json name,description`. Check for an existing epic / parent-issue convention (e.g. `epic`, `tracking`, task-list checkboxes in a parent issue, GitHub sub-issues, or Projects v2 hierarchy). Reuse what the repo already does — do **not** introduce a new relationship model.
+3. **Draft the work breakdown (no issues filed yet).** Produce a single markdown plan in the conversation with this shape:
+
+   ```
+   Epic: <PRD title>
+   ├── #A1 <slice>            [parent: epic] [blocks: A2, A3]
+   ├── #A2 <slice>            [parent: epic] [blocked-by: A1]
+   ├── #A3 <slice>            [parent: epic] [blocked-by: A1] [related: B1]
+   └── #B1 <slice>            [parent: epic]
+   ```
+   Each node has: provisional ID, one-line title, est. size (S/M/L = ½ day / 1 day / 2 days), and explicit relationships. **Show this to the user and get explicit "go" before filing anything.** Iterating on paper is cheap; iterating on filed issues is not.
+4. **Apply the size-and-shape rules to every node.** See "Slice rules" below. If any ticket fails the rules, split or merge before filing. Re-show the tree if it changed materially.
+5. **File issues bottom-up.** Create leaf issues first so parents can reference real numbers in their task lists. For each issue use the body template below, the **canonical title format**, and the **canonical label set** (see "Title & label conventions"). Reconcile against the step-2 label snapshot — reuse exact matches, rename non-canonical semantic matches via `gh label edit`, only create labels that have no match. Do not file any issue that is missing the title prefix or any of the four required labels.
+6. **Wire relationships using the repo's convention.** In order of preference: (a) GitHub native sub-issues (`gh api … /sub_issues`) if the repo uses them; (b) task-list checkboxes in the epic (`- [ ] #123`) which GitHub auto-tracks; (c) `Blocks:` / `Blocked by:` / `Parent:` / `Related:` lines in each issue body, with `#N` cross-links. Pick one and apply it consistently across the whole tree.
+7. **Post the summary.** Print a compact table to the user: `ID | title | size | parent | blocks | blocked-by | URL`. Confirm the epic's task list renders correctly (open it in `gh browse`) before declaring done.
+
+## Title & label conventions
+
+Every issue filed by this skill MUST use the same title shape and the same four-label spine, so the whole tree is filterable in one query and humans can read the relationship at a glance.
+
+### Title format
+
+```
+[<feature-slug>] <type>: <imperative one-liner>
+```
+
+- `<feature-slug>` — short kebab-case identifier for the PRD, identical across every issue in the tree (e.g. `oauth-rotation`, `mobile-onboarding`). Pick once in step 3, reuse everywhere. This is what makes `is:issue [oauth-rotation]` return the whole tree.
+- `<type>` — one of: `epic`, `feat`, `chore`, `infra`, `docs`, `test`, `spike`. Exactly one. The epic issue uses `epic`; everything else picks the most accurate non-epic type.
+- `<imperative one-liner>` — ≤ 70 chars, starts with a verb (`Add`, `Wire`, `Migrate`, `Expose`), no trailing period, no ticket numbers, no emoji.
+
+Examples:
+- `[oauth-rotation] epic: Rotate OAuth refresh tokens daily`
+- `[oauth-rotation] feat: Add token-rotation worker behind flag`
+- `[oauth-rotation] chore: Backfill rotation_at column`
+
+If a node can't be expressed in this format, the slice is probably wrong-shaped — fix the slice before fighting the title.
+
+### Label spine (exactly four, every issue)
+
+| Slot | Allowed values | Purpose |
+|---|---|---|
+| `feature:<slug>` | one per PRD, matches the title slug | Groups the whole tree |
+| `type:<kind>` | `type:epic`, `type:feat`, `type:chore`, `type:infra`, `type:docs`, `type:test`, `type:spike` | Mirrors the title `<type>` |
+| `size:<bucket>` | `size:S`, `size:M`, `size:L` | ≈ ½d / 1d / 2d; matches the body's Size field |
+| `area:<top-level-dir-or-surface>` | e.g. `area:api`, `area:web`, `area:cli` | Routes to the right owner |
+
+Optional fifth labels (apply only when meaningful, never as filler):
+- `priority:<p0|p1|p2>` — apply ONLY when the PRD or the user explicitly states a priority for that slice. Do not invent a default. If unsure, omit the label.
+- `blocked` — set automatically when the issue has open `Blocked by` issues; clear when they close.
+- `good-first-issue` — only when the slice is genuinely standalone, well-scoped, and a newcomer could pick it up.
+
+Repo-specific meta labels that are orthogonal to the spine (e.g. `tracked-by-roadmap`, `needs-design`, `tech-debt`) MAY be applied on top when they apply, but are never substitutes for any of the four spine slots.
+
+**Reconciliation rule (same as `devpilot-scanning-repos`):**
+- Exact match in the repo → reuse as-is.
+- Semantic match with a non-canonical name (e.g. repo has `feature` for `type:feat`, or `service/api` for `area:api`) → `gh label edit "<old>" --name "<canonical>" --description "<canonical-desc>"`. Renaming preserves all existing issue associations.
+- Too generic / wrong intent / orthogonal to this PRD (e.g. `bug` for a feature PRD, `tech-debt`, `needs-design`, `tracked-by-roadmap`) → **leave alone**, do not force a mapping. Create the canonical label fresh if the spine slot needs filling.
+- **No canonical bucket exists** (e.g. repo has `XS`/`XL` size labels but the spine only defines `size:S|M|L`) → leave alone. Do NOT rename to the closest bucket — that lies about the size budget on existing issues. New tickets from this PRD use the canonical S/M/L; legacy XS/XL remain on legacy issues.
+- **Layer vs. surface for `area:*`:** prefer surface labels (`area:api`, `area:web`, `area:ios`, `area:cli`, `area:worker`) that route to an owner. A repo label like `frontend` / `backend` is borderline — rename only when it consistently maps to one surface in this repo; if it's a cross-surface layer label, leave alone and create the surface label fresh.
+
+**Confirmation gate:** if the reconciliation plan would rename **more than 3** labels, OR rename any label currently used on more than 50 issues, show the plan to the user and get explicit "go" before running any `gh label edit`. Bulk renames touch unrelated existing issues' triage queries.
+
+**Side-effect warning:** renaming a generic label (e.g. `epic` → `type:epic`) retroactively co-tags every issue currently carrying it. Call this out in the reconciliation summary: `epic → type:epic (also tags 5 pre-existing epic issues)` so the user can veto before the rename runs.
+
+Print a reconciliation summary before filing: `N reused, R renamed (old → new, with affected-issue counts), M created, K left alone (with reason)`.
+
+### Title ⇔ label invariants
+
+These must hold for every issue, on every run. Verify before declaring done:
+
+1. The `<feature-slug>` in the title equals the value of the `feature:<slug>` label.
+2. The `<type>` in the title equals the value of the `type:<kind>` label.
+3. The Size field in the body equals the `size:<bucket>` label.
+4. Exactly one issue **in this PRD's tree** has `type:epic` and no `Parent:` line. (The repo may have other `type:epic` issues from prior PRDs — that's fine; the invariant is per-tree, not per-repo.)
+
+If any invariant fails, the title and labels are out of sync — fix before continuing. Asymmetric metadata is the same bug class as asymmetric `Blocks` / `Blocked by`.
+
+## Slice rules
+
+Every leaf issue MUST satisfy all four:
+
+| Rule | What it means | If it fails |
+|---|---|---|
+| **Deliverable** | Merging this issue alone leaves `main` better than before — feature-flagged if needed, but not a half-wired stub that breaks build or UX. | Either combine with the issue that completes it, or add a flag/scaffold so this one ships meaningfully. |
+| **Bounded** | ≤ ~400 lines diff OR ≤ 2 dev-days. Hard ceiling: 800 LOC / 3 days. Tests count toward the budget; generated code does not. | Split along a natural seam: data-model vs. handler vs. UI; happy-path vs. error-paths; one entity at a time. |
+| **Independently testable** | Has its own acceptance criteria the reviewer can verify without merging siblings. | Pull the verification surface (test fixtures, a CLI flag, a stub UI page) into this ticket. |
+| **Single-owner-friendly** | One engineer can pick it up without coordinating mid-flight with another open ticket in the tree. | If two tickets must land in the same PR to be useful, they're one ticket. Merge them. |
+
+If a node can't be made deliverable on its own, the right move is usually a **scaffolding issue** first (introduce the interface / flag / migration) so subsequent slices have a place to land.
+
+## Relationship taxonomy
+
+Every issue body declares relationships explicitly. Use exactly these four kinds — don't invent more:
+
+- **Parent** — the epic / tracking issue this rolls up to. Exactly one.
+- **Blocks** — issues that cannot start (or cannot ship) until this one merges.
+- **Blocked by** — the inverse; issues this one waits on. Symmetric with `Blocks:` on the other side.
+- **Related** — useful context, not a dependency. Use sparingly; if everything is "related" the field is noise.
+
+Every `Blocks` on issue A MUST appear as `Blocked by` on the named issue. Asymmetric edges are bugs in the breakdown — fix before filing.
+
+## Issue body template
+
+```markdown
+## Context
+<2–4 sentences: where this fits in the PRD, what problem this slice solves. Link the PRD.>
+
+## Scope
+- <bullet 1, concrete>
+- <bullet 2, concrete>
+- <bullet 3, concrete>
+
+## Out of scope
+- <thing a reviewer might assume but we are NOT doing here; usually points to a sibling issue>
+
+## Acceptance criteria
+- [ ] <observable behaviour 1>
+- [ ] <observable behaviour 2>
+- [ ] <test / verification step>
+
+## Size
+**S | M | L** (≈ ½d / 1d / 2d, ≤ ~400 LOC diff)
+
+## Relationships
+- **Parent:** #<epic>
+- **Blocks:** #<id>, #<id>
+- **Blocked by:** #<id>
+- **Related:** #<id>
+
+## PRD reference
+<link or path, plus the section heading this slice maps to>
+```
+
+The epic issue gets the same template plus a top-level task list of every child:
+
+```markdown
+## Children
+- [ ] #A1 …
+- [ ] #A2 …
+```
+
+GitHub auto-renders this list with checkboxes that flip when the child closes — that's the cheapest progress dashboard available. Use it.
+
+## Quick reference
+
+| Situation | Move |
+|---|---|
+| Slice is 1500 LOC | Split along data-model / handler / UI seam |
+| Slice "has to ship with" the next one | They're one slice — merge them |
+| Slice can't be merged without breaking main | Add a feature flag, OR push the user-visible part to a later ticket |
+| Two slices both need the same new helper | Extract a scaffolding ticket; both depend on it |
+| PRD has 30 leaf items | Group into 3–5 chapters under the epic; chapters are intermediate parents |
+| Mixed repos (frontend + backend) | One epic per repo, link them via `Related:` across the boundary |
+
+## Common mistakes
+
+- **Filing issues before the user signs off on the tree.** Iterating on a markdown plan is free. Iterating on 14 already-filed issues with cross-links is not.
+- **Inventing a relationship model the repo doesn't use.** If the repo uses task-list checkboxes, don't introduce sub-issues; if it uses sub-issues, don't fall back to plaintext `Parent:` lines. Pick what's already there.
+- **"Phase 1 / Phase 2" tickets that bundle unrelated work.** A phase isn't a slice. Each phase decomposes into its own real tickets.
+- **Bulk-renaming high-volume labels without confirmation.** Renaming `S`/`M`/`L` when ~80 existing issues carry them, or `service/api` when ~200 do, mass-mutates triage queries the team relies on. Hit the >3-renames OR >50-affected-issues threshold → confirm first.
+- **Forcing every existing label into the spine.** Orthogonal labels (`bug` on a feature PRD, `tracked-by-roadmap`, `needs-design`) get left alone, not bent into a `type:*` they don't fit.
+- **Renaming `XS`/`XL` to `size:S`/`size:L`.** The spine has no XS/XL bucket and renaming lies about size budget. Leave them alone.
+- **Inventing `priority:*` defaults.** Priority labels appear only when the PRD or user states one. "I think this is p1" is filler.
+- **Inconsistent titles or labels across the tree.** Half the issues say `[oauth-rotation]`, half say `oauth rotation —`; some carry `type:feat`, some don't. The whole point of the convention is one filter returns the whole tree. If you wouldn't bet $20 on `is:issue label:feature:<slug>` returning every child, the run failed.
+- **Asymmetric relationships.** `A blocks B` on A's body but nothing on B's body. Reviewers can't see the dependency from B. Always wire both sides.
+- **Tickets with no acceptance criteria** ("implement auth"). The reviewer has nothing to verify against. If the PRD doesn't give criteria for a slice, write them and confirm with the user before filing.
+- **Renaming the PRD as the epic title and shoving everything under one ticket.** That's not decomposition; that's a rebrand. The epic exists to *track* the children, not to *contain* the work.
+- **Breaking research / spike work into the same tree.** Spikes don't ship. File them separately or close them when their output (a doc, a decision) lands; don't put them in the deliverable graph.
+- **Skipping the dedupe step against existing open issues.** Before filing, `gh issue list --search '<keywords>' --state open` and reuse / link to anything that already covers a slice.
+
+## Acceptance criteria for a correct run
+
+A correct invocation of this skill produces:
+
+1. A markdown work-breakdown shown to the user **before** any issue is filed, and explicit user confirmation captured.
+2. Exactly one epic / tracking issue, with a task list of every child issue that GitHub auto-tracks.
+3. Every child issue: ≤ ~400 LOC estimated diff, deliverable on its own (possibly behind a flag), with its own acceptance criteria.
+4. Every relationship is **symmetric** — `Blocks` on one side ⇔ `Blocked by` on the other.
+5. Every issue title matches `[<feature-slug>] <type>: <imperative one-liner>` with the same `<feature-slug>` across the whole tree.
+6. Every issue carries the four-label spine: `feature:<slug>`, `type:<kind>`, `size:<bucket>`, `area:<surface>`. Title `<type>` and `<feature-slug>` agree with the matching labels. Existing repo labels reused or renamed to canonical; no orphan label families introduced.
+7. A final summary table printed: ID, title, size, parent, blocks, blocked-by, URL.
+
+If any of these is missing, the skill failed — stop and correct before continuing.

--- a/skills/devpilot-scanning-repos/SKILL.md
+++ b/skills/devpilot-scanning-repos/SKILL.md
@@ -34,14 +34,17 @@ A whole-repo sweep that dispatches **three parallel specialist sub-agents**, sco
 ## Workflow
 
 1. **Resolve target.** Accept `owner/repo`, a clone URL, or "this repo" (use `gh repo view --json nameWithOwner`). Verify with `gh repo view`.
-2. **Reconcile labels — reuse what the repo already has, only create what's missing.** Do NOT blindly paste a `gh label create` block. The procedure:
+2. **Reconcile labels — rename non-canonical matches, reuse exact matches, create what's missing.** Do NOT blindly paste a `gh label create` block. The procedure:
    1. **Snapshot existing labels:** `gh label list --limit 200 --json name,description > /tmp/devpilot-existing-labels.json`. If the count returned equals the limit, raise `--limit` and re-run until the result is shorter than the limit.
-   2. **For each label the skill needs** (the full taxonomy lives in `references/labels.md`): check whether the repo already has a *suitable* label for the same purpose. "Suitable" means same semantic intent, not just same name. A repo label `security` or `type:security` covers `scan:security`; `bug` does NOT cover `edge:nil-deref` (too generic). The match rule: the existing label's name OR description clearly maps onto the canonical purpose listed in `references/labels.md`. When in doubt, do NOT reuse — false reuse poisons triage queries.
-   3. **Build a name-mapping table** for this run: `canonical_name → label_to_apply` (either the canonical `type:value` name, or the suitable existing repo label). The orchestrator uses this mapping when filing issues in step 7.
-   4. **Only create the labels that have no suitable existing match.** Use the canonical `type:value` form. See `references/labels.md` for the exact `gh label create` invocation per label (colors and descriptions). Skip any label already mapped to an existing repo label.
-   5. **Print the reconciliation summary** to the user before continuing: `N reused, M created, list of each` — so they can spot a wrong reuse before issues get filed.
+   2. **For each label the skill needs** (the full taxonomy lives in `references/labels.md`): classify the closest existing repo label into one of three buckets:
+      - **Exact match** — the repo label name already equals the canonical `type:value` (e.g. repo has `scan:security`). **Reuse as-is.**
+      - **Semantic match, non-canonical name** — same intent, different name (e.g. repo has `security` or `type-security` for `scan:security`; `nil-deref` for `edge:nil-deref`). **Rename to the canonical name** with `gh label edit "<old-name>" --name "<canonical-name>" --description "<canonical-desc>"`. Renaming preserves all existing issue associations, so this is safe and brings the repo onto our taxonomy. Confirm the rename plan with the user before executing if more than 3 labels are being renamed at once.
+      - **Too generic / wrong intent** — e.g. `bug` for `edge:nil-deref`, or `enhancement` for anything scan-related. **Do NOT rename and do NOT reuse.** Create the canonical label fresh; leave the generic label alone.
+   3. **Build a name-mapping table** for this run: `canonical_name → label_to_apply`. After renames, every entry should be the canonical `type:value` name. The orchestrator uses this mapping when filing issues in step 7.
+   4. **Create the labels that had no match.** Use the canonical `type:value` form. See `references/labels.md` for the exact `gh label create` invocation per label (colors and descriptions).
+   5. **Print the reconciliation summary** to the user before continuing: `N reused, R renamed (old → new), M created` — so they can spot a wrong rename or reuse before issues get filed.
 
-   `area:*` labels follow the same rule but are reconciled lazily at filing time (step 7): for each finding, check the snapshot for an existing area-ish label covering the same top-level dir before creating `area:<dir>`.
+   `area:*` labels follow the same three-bucket rule but are reconciled lazily at filing time (step 7): for each finding, check the snapshot for an existing area-ish label covering the same top-level dir; rename it to `area:<dir>` if it's a semantic match with a non-canonical name, otherwise create.
 2.5. **Build a shared file manifest.** The orchestrator does ONE walk and hands a sampled file list to all three scanners. Scanners MUST NOT re-walk — they may only read paths in the manifest. See "Scaling for large repos" below for the algorithm. The manifest is a plain text file written to `/tmp/devpilot-scan-manifest.txt`, one repo-relative path per line. Default cap: **800 files**. Override with `--full` (raises to 2000) or `--scope <dir>` (manifest = `find <dir>` capped at 800).
 3. **Dispatch scanners in parallel.** In ONE message, launch three sub-agents using the prompts in `agents/`:
    - `agents/security-scanner.md`
@@ -57,7 +60,7 @@ A whole-repo sweep that dispatches **three parallel specialist sub-agents**, sco
      --state all --limit 1000 --json title,number,state
    ```
    Normalize titles by lower-casing, stripping the `[scan:<category>]` / `[repo-scan:<category>]` prefix, and collapsing whitespace before comparing. Skip findings whose normalized title matches an existing issue. If `--limit 1000` returns exactly 1000, paginate with `--search "... created:<<date-of-oldest>"` until empty.
-7. **File issues.** One `gh issue create` per surviving finding, using the template in `references/issue-template.md`. Labels: always exactly five — apply the labels from the step-2 mapping table for `scan:<category>`, the matching subcategory, `severity:<level>`, `confidence:<score>`, plus an `area:<top-level-dir>` resolved lazily here. For the area label: first check `/tmp/devpilot-existing-labels.json` for a suitable existing label (e.g. repo already has `area-cmd` or `cmd` covering the dir) and reuse it; only run `gh label create area:<dir>` when no suitable repo label exists.
+7. **File issues.** One `gh issue create` per surviving finding, using the template in `references/issue-template.md`. Labels: always exactly five — apply the labels from the step-2 mapping table for `scan:<category>`, the matching subcategory, `severity:<level>`, `confidence:<score>`, plus an `area:<top-level-dir>` resolved lazily here. For the area label: first check `/tmp/devpilot-existing-labels.json` for a suitable existing label (e.g. repo already has `area-cmd` or `cmd` covering the dir). If it's an exact match, reuse; if it's a semantic match with a non-canonical name, rename it to `area:<dir>` via `gh label edit`; otherwise run `gh label create area:<dir>`.
 8. **Summarize.** Print a compact table to the user: `[category] [severity] title → #issue-number`.
 
 ## Finding format
@@ -178,8 +181,9 @@ Group findings by category, send up to **25 findings per scoring sub-agent** dis
 - **Letting scanners filter their own output.** They should over-report. The scoring pass does the filtering. Merging the two loses calibration.
 - **Using the scanner agent to also create the issue.** Don't — the scanner has too much context. File issues from the main agent after scoring.
 - **Dropping the evidence block in the issue body.** Without it the human has to re-derive the finding. File a crap issue once and nobody trusts the skill.
-- **Mass-creating the full taxonomy upfront without checking the repo.** The skill MUST snapshot existing labels (step 2) and reuse any suitable ones. Blindly creating `scan:security` when the repo already has `security` doubles the label space and fragments triage queries.
-- **"Suitable" stretched too far.** Reusing `bug` for every `edge:*` finding loses the per-subcategory triage signal. When the existing label is too generic, create the canonical one.
+- **Mass-creating the full taxonomy upfront without checking the repo.** The skill MUST snapshot existing labels (step 2) and reconcile against them. Blindly creating `scan:security` when the repo already has `security` doubles the label space and fragments triage queries — rename `security` to `scan:security` instead.
+- **Reusing a non-canonical name as-is instead of renaming it.** If the repo has `security` and we file under `scan:security`, both labels now exist with overlapping intent. Rename the existing one to bring the repo onto the canonical taxonomy.
+- **Renaming a too-generic label.** Don't rename `bug` to `edge:nil-deref` — it's attached to unrelated existing issues. Generic labels stay; create the canonical one alongside.
 - **Creating subcategory or severity labels inside the issue-creation loop.** Reconcile in step 2, file in step 7. Only `area:*` is resolved lazily, and even then it goes through the same suitable-existing-label check.
 - **Asking scanners to rank severity *and* confidence.** Confidence is the scoring pass's job; scanners assign severity only.
 - **Forgetting the dedupe step.** Re-running the skill must be idempotent or the user will stop running it.

--- a/skills/index.json
+++ b/skills/index.json
@@ -132,6 +132,13 @@
       ]
     },
     {
+      "name": "devpilot-prd-to-issues",
+      "description": "Use when the user wants to turn a PRD, spec, design doc, or feature brief into a tree of GitHub issues — every ticket a deliverable slice with explicit parent/blocks/blocked-by relationships and a bounded change size.",
+      "files": [
+        "SKILL.md"
+      ]
+    },
+    {
       "name": "devpilot-pr-creator",
       "description": "Use when the user wants to create or update a pull request or merge request, open a PR/MR, push changes for review, update a PR description, or mark a draft as ready.",
       "files": [

--- a/skills/index.json
+++ b/skills/index.json
@@ -135,6 +135,7 @@
       "name": "devpilot-prd-to-issues",
       "description": "Use when the user wants to turn a PRD, spec, design doc, or feature brief into a tree of GitHub issues — every ticket a deliverable slice with explicit parent/blocks/blocked-by relationships and a bounded change size.",
       "files": [
+        "LICENSE.txt",
         "SKILL.md"
       ]
     },


### PR DESCRIPTION
## Summary

Adds a new skill **`devpilot-prd-to-issues`** that decomposes a PRD into a graph of GitHub issues where every leaf is independently deliverable, every issue carries the same canonical title format and four-label spine, and every relationship is symmetric. Also tightens **`devpilot-scanning-repos`** step 2 with the same three-bucket label reconciliation rule (exact match → reuse, semantic match with non-canonical name → rename via `gh label edit`, too-generic → leave alone) so existing repo labels are brought onto the canonical taxonomy instead of duplicated.

## What's in the new skill

- **Workflow gate:** show the breakdown tree to the user and get explicit "go" before any `gh issue create` runs. Iterating on markdown is free; iterating on filed cross-linked issues is not.
- **Slice rules:** every leaf must be Deliverable (mergeable on its own, possibly behind a flag), Bounded (≤ ~400 LOC / ≤ 2 dev-days, hard ceiling 800 / 3), Independently testable, and Single-owner-friendly.
- **Title format:** `[<feature-slug>] <type>: <imperative one-liner>`, with `<type>` ∈ `epic|feat|chore|infra|docs|test|spike` — one filter (`is:issue [<slug>]`) returns the whole tree.
- **Four-label spine:** `feature:<slug>`, `type:<kind>`, `size:S|M|L`, `area:<surface>`. Optional fifth slot for `priority:*`/`blocked`/`good-first-issue` only when the PRD or user states it.
- **Title ⇔ label invariants** enforced (slug, type, size all agree across title/body/labels; exactly one `type:epic` per tree).
- **Relationship taxonomy** capped at four kinds (Parent / Blocks / Blocked by / Related). `Blocks` ⇔ `Blocked by` must be symmetric.

## Stress testing (this is the load-bearing bit)

Ran three parallel pressure scenarios against the skill before merging:

| Test | Pressure | Outcome |
|---|---|---|
| 1 | Time pressure ("skip the breakdown gate, 10 min to standup") | Skill held; gate refused. Surfaced layer-vs-surface ambiguity for `area:*`. |
| 2 | 30-leaf PRD, urge to bundle "Phase 1/Phase 2" mega-tickets | Skill held; produced 29 leaves + 3 chapter parents. Surfaced `priority:*` filler. |
| 3 | Repo with heavily-used existing labels (`XS/S/M/L/XL`, `epic`, `service/api` × 200) | Surfaced 6 real ambiguities the skill was silent on. |

REFACTOR pass closed every surfaced gap:

1. No-canonical-bucket labels (XS/XL) → leave alone, do not lossy-rename.
2. Bulk renames (>3 labels OR any label on >50 issues) require explicit user confirmation.
3. Retroactive co-tagging side effects (e.g. renaming generic `epic` → `type:epic` co-tags pre-existing epics) must be called out in the reconciliation summary with affected-issue counts.
4. `priority:*` only applies when the PRD/user states a priority — never as filler.
5. Repo-specific orthogonal labels (`tracked-by-roadmap`, `needs-design`) live alongside the spine, not inside it.
6. The "exactly one `type:epic`" invariant is **per-tree**, not per-repo.

## scanning-repos change

Step 2 of `devpilot-scanning-repos` previously said "reuse if suitable, otherwise create." It now uses the same three-bucket rule, so a repo with `security` gets renamed to `scan:security` (preserving existing issue associations) instead of leaving both labels coexisting.

## Review Guide

- Start with `skills/devpilot-prd-to-issues/SKILL.md` — read top-to-bottom, it's self-contained.
- The two load-bearing sections are **Title & label conventions** (the contract) and **Slice rules** (the size/shape gate).
- Then check `skills/devpilot-scanning-repos/SKILL.md` step 2 + the updated common-mistakes entries for the parallel rename rule.
- `skills/index.json` registration is mechanical.
- Watch for: anywhere the skill says "rename" without saying "preserves existing issue associations" — that's the user-trust line. It should be present in both skills.

## Test plan

- [x] Stress-tested with three parallel sub-agent scenarios; all gaps surfaced were folded back into the skill.
- [x] Try the skill end-to-end against a real PRD on a fresh repo before relying on it for production work.
- [x] Re-run scenario 3 (heavy label conflicts) against the updated skill to confirm the loopholes stay closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)