### PR TITLE
feat(skills): add devpilot-dead-code-cleanup skill

### DIFF
--- a/skills/devpilot-dead-code-cleanup/SKILL.md
+++ b/skills/devpilot-dead-code-cleanup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: devpilot-dead-code-cleanup
+description: Use when the user wants to find and remove dead code, unused exports, unreachable functions, or unused symbols in a Go or TypeScript repository — "clean up dead code", "remove unused functions", "find unused exports", "prune dead code", "what's unreferenced", "/dead-code". Do NOT use for unused-dependency cleanup only, formatting cleanup, or refactoring of live code.
+---
+
+# Dead Code Cleanup (Go & TypeScript)
+
+## Overview
+
+A detector's report is a **candidate list, not a hit list**. Every finding must be cross-checked against the language's escape hatches (reflection, dynamic dispatch, public API, generated code, build tags) before deletion. Remove in leaves-first order, with build + test between clusters, one cluster per commit.
+
+## When to Use
+
+- "Clean up dead code in this repo"
+- "Find unused functions / exports / types"
+- "What can I delete safely?"
+- Pre-release cleanup or post-feature-removal sweep
+
+**Don't use for:** dependency-only cleanup (run `go mod tidy` / `knip --dependencies`), refactoring live code, or eyeball deletions without a detector.
+
+## Workflow
+
+```dot
+digraph dead_code {
+    "Run detector" [shape=box];
+    "Filter false positives" [shape=box];
+    "Remove one cluster (leaves first)" [shape=box];
+    "Build + test passes?" [shape=diamond];
+    "Commit cluster" [shape=box];
+    "Revert + recheck" [shape=box];
+    "More candidates?" [shape=diamond];
+    "Done" [shape=doublecircle];
+
+    "Run detector" -> "Filter false positives" -> "Remove one cluster (leaves first)" -> "Build + test passes?";
+    "Build + test passes?" -> "Commit cluster" [label="yes"];
+    "Build + test passes?" -> "Revert + recheck" [label="no"];
+    "Revert + recheck" -> "Filter false positives";
+    "Commit cluster" -> "More candidates?";
+    "More candidates?" -> "Remove one cluster (leaves first)" [label="yes"];
+    "More candidates?" -> "Done" [label="no"];
+}
+```
+
+## Detectors
+
+| Lang | Command | Notes |
+|------|---------|-------|
+| Go | `deadcode -test ./...` | `go install golang.org/x/tools/cmd/deadcode@latest`. Whole-program reachability — strongest signal. |
+| Go | `staticcheck -checks U1000 ./...` | Unused unexported symbols. Misses some interface satisfaction cases. |
+| TS | `npx knip` | Files, exports, types, deps. **Configure entry points first** or output is noise. |
+| TS | `npx ts-prune` | Unused exports, lighter fallback. |
+| TS | `tsc --noUnusedLocals --noUnusedParameters` | Locals & params only. |
+
+## False Positives — Always Check
+
+| Trap | Language | What to do |
+|------|----------|-----------|
+| Reflection / `reflect.*`, `json.Marshal`, struct tags | Go | Search for `reflect.` and tag usage. Default KEEP. |
+| Stdlib-interface method names (`MarshalJSON`, `ServeHTTP`, `String`, `Error`, `Read`, `Write`, `Close`) | Go | KEEP — interface dispatch invisible to call-graph. |
+| `init()` | Go | Side-effect registration (`sql.Register`, codecs). KEEP unless proven inert. |
+| Build tags (`//go:build linux`) | Go | Re-run detectors per `GOOS`/`GOARCH`. |
+| Generated files (`*.pb.go`, `mock_*.go`, `wire_gen.go`, `// Code generated`) | Go/TS | Never hand-edit. Fix the source and regenerate. |
+| Exported symbol in a library module (`pkg/`, package consumed by other repos) | Go/TS | KEEP unless external consumers verified. Flag for owner review. |
+| Framework conventions (Next.js `pages/`/`app/`, route handlers, `getServerSideProps`, NestJS decorators, RSC) | TS | Configure detector entry points; KEEP if framework-invoked. |
+| Dynamic imports / string-based requires (`` import(`./plugins/${name}`) ``) | TS | Symbol may appear in a string literal. KEEP. |
+| Decorators / DI (NestJS, TypeORM, class-validator) | TS | Methods invoked via metadata. KEEP. |
+| `import type` consumed cross-package | TS | Type-only re-exports look unused. KEEP if external consumer. |
+| Test fixtures, `testdata/`, Storybook, MDX | Go/TS | Never delete from detector output alone. |
+
+When unsure: `rg -n '\bSymbolName\b'` across the repo and known consumers. One match in a string literal is enough to keep it.
+
+## Removal Order — Leaves First
+
+1. Unused private helpers with no callers.
+2. Unused unexported types/constants referenced only by step 1.
+3. Exported symbols, **only after** confirming no external consumers.
+4. Now-empty files.
+5. Now-unused dependencies (`go mod tidy`, `knip --dependencies`).
+
+After each cluster (≤ ~10 symbols, one logical group):
+
+```bash
+# Go
+go build ./... && go test ./...
+
+# TS
+npx tsc --noEmit && npm test
+```
+
+Green → commit (`chore: remove unused helpers in <pkg>`). Red → revert that cluster, recheck false positives. One cluster per commit; never bundle behavior changes.
+
+## Common Mistakes & Red Flags — STOP
+
+- Deleting straight from the detector dump without filtering.
+- Deleting exported symbols from a library without checking external consumers.
+- Hand-editing generated files (regenerate instead).
+- Deleting an `init()` without proof of no side effect.
+- Deleting a method whose name matches a stdlib interface (`ServeHTTP`, `MarshalJSON`, …).
+- Symbol name appears in a string literal anywhere → likely reflective; KEEP.
+- Skipping `go test` / `npm test` between clusters — reflection-driven code only fails at runtime.
+- Detector reports >30% of files as dead → config issue, not real code death.
+- One huge "remove dead code" commit instead of per-cluster commits.
+
+If any of these apply, **stop, re-check, and split into smaller clusters**.
+
+## Reporting
+
+When done: tools used, raw candidate count, kept-count grouped by false-positive category, removed-count grouped by cluster/commit, LOC delta, and anything flagged "probably dead but needs owner sign-off".

--- a/skills/index.json
+++ b/skills/index.json
@@ -52,6 +52,13 @@
       ]
     },
     {
+      "name": "devpilot-dead-code-cleanup",
+      "description": "Use when the user wants to find and remove dead code, unused exports, unreachable functions, or unused symbols in a Go or TypeScript repository. Do NOT use for unused-dependency cleanup only, formatting cleanup, or refactoring of live code.",
+      "files": [
+        "SKILL.md"
+      ]
+    },
+    {
       "name": "devpilot-daily-toolkit",
       "description": "Personal daily-life toolkit for an Auckland, NZ user — bundles RSS news (世界科技/AI/政治/财经/新西兰), real-time exchange rates, GitHub daily activity reports, and NZ public holidays behind one skill, plus a combined morning-briefing mode that runs all four.",
       "files": [


### PR DESCRIPTION
## Summary

Adds `devpilot-dead-code-cleanup` — a skill for finding and removing dead code in Go and TypeScript repos. Two files changed:

- `skills/devpilot-dead-code-cleanup/SKILL.md` (new) — the skill itself.
- `skills/index.json` — registers the skill (alphabetical slot between `devpilot-cv-writer` and `devpilot-daily-toolkit`).

## What the skill covers

- **Detectors:** Go → `deadcode -test ./...` + `staticcheck -checks U1000`; TypeScript → `knip` (primary) / `ts-prune` / `tsc --noUnusedLocals`.
- **False-positive table** indexed by trap × language: reflection (`MarshalJSON`, struct tags), stdlib-interface method names (`ServeHTTP`, `String`, `Error`, `Read`/`Write`/`Close`), `init()` side effects, build tags, generated files (`wire_gen.go`, `*.pb.go`, `mock_*.go`), exported library API, Next.js / NestJS framework conventions, dynamic imports, decorator-driven DI, type-only re-exports, `testdata/` and Storybook.
- **Removal discipline:** leaves-first order, ≤10 symbols per cluster, `go build && go test` (or `tsc --noEmit && npm test`) between clusters, one cluster per commit, never bundle behavior changes.

## Description hygiene

Description is **triggers-only**: lists when to use vs when not to use, and deliberately does NOT summarize the workflow — per superpowers `writing-skills` CSO guidance, workflow summaries in the description cause future Claude to shortcut and skip the body.

## Pressure-test notes

The skill was tested with parallel subagent scenarios (with vs without skill) on a Go report containing classic traps (`MarshalJSON`, `init`, `wire_gen.go`, exported `pkg/` symbol, `ServeHTTP`). Strong models got 8/8 right even without the skill; the skill's value is on subtler traps (custom reflective dispatch, framework conventions, sunk-cost discipline). After testing, the SKILL.md was trimmed from 1387 → 843 words and the description rewritten to drop the workflow summary.

## Review Guide

Start with `skills/devpilot-dead-code-cleanup/SKILL.md`:
1. Skim the **Overview** and **When to Use** to verify the skill scope.
2. Read the **False Positives** table — that's the core value of the skill; check completeness for any Go/TS framework you regularly use.
3. Confirm the description in the YAML frontmatter is triggers-only (no workflow summary).
4. Then `skills/index.json` for the registration entry — should be alphabetically placed.

Tricky decisions to watch for:
- Whether any common framework convention is missing from the false-positives table.
- Whether the cluster-per-commit + leaves-first rule is stated clearly enough that an agent under deadline pressure won't skip verification.

## Test plan

- [x] `python3 -c "import json; json.load(open('skills/index.json'))"` — JSON valid.
- [x] `wc -w skills/devpilot-dead-code-cleanup/SKILL.md` → 843 words (under the 1000-ish soft cap for non-frequently-loaded skills).
- [x] Pressure-tested via parallel subagents on a Go scenario with 8 symbols (5 false positives + 3 real); skill agent flagged the library-export symbol for owner review and explicitly mentioned regenerate-from-source for the wire file.
- [x] Try the skill on a real cleanup pass in a Go repo to confirm the workflow holds end-to-end.
- [x] Try on a TS/Next.js or NestJS repo to confirm the framework-conventions guidance is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)