### PR TITLE
feat(skills): tag NEEDS-HUMAN issues with need:human label

### DIFF
--- a/skills/devpilot-resolve-issues/SKILL.md
+++ b/skills/devpilot-resolve-issues/SKILL.md
@@ -168,7 +168,7 @@ Read the full issue body. If the issue was filed by `devpilot-scanning-repos` it
 |---|---|---|
 | **REAL** | You traced the code and reproduced / confirmed the bug, gap, or risk. | Proceed to step 5. **Stay assigned** until the PR merges — `Closes #N` on merge closes the issue cleanly when it's authored by the assignee. |
 | **FALSE-POSITIVE** | You traced the code and the premise is wrong — already fixed, wrong file, misread of the code, scanner hallucination, or pre-existing and intentional. | Post the FALSE-POSITIVE comment from `references/verdict-comments.md`, close with the `wontfix` label, unassign. Next issue. |
-| **NEEDS-HUMAN** | Concern is real but fixing requires domain knowledge you don't have — business logic, product decisions, contracts with external services. | Post the NEEDS-HUMAN comment with 1–3 concrete questions, unassign. Next issue. |
+| **NEEDS-HUMAN** | Concern is real but fixing requires domain knowledge you don't have — business logic, product decisions, contracts with external services. | Post the NEEDS-HUMAN comment with 1–3 concrete questions, add the `need:human` label, unassign. Next issue. |
 
 **Do not classify as REAL just to "take a shot."** False positives close in 60 seconds; wrong REAL verdicts spawn implementer subagents that produce useless diffs and poison the PR history.
 
@@ -242,7 +242,7 @@ make lint
 Or the project-specific equivalents (`go test ./...`, `pnpm test`, `cargo test`). Trust-but-verify: implementer and reviewer subagents can both misreport — innocently or because a test harness is broken.
 
 - Everything passes → step 8.
-- Anything fails → escalate the issue `NEEDS-HUMAN`: push the branch as a draft (`git push -u origin "$BRANCH"`), comment on the issue with the failing output and the branch URL, unassign, then proceed to step 10 (worktree cleanup) before the next issue. The per-task reviews already ate the retry budget; don't burn another round here.
+- Anything fails → escalate the issue `NEEDS-HUMAN`: push the branch as a draft (`git push -u origin "$BRANCH"`), comment on the issue with the failing output and the branch URL, add the `need:human` label (`gh issue edit <num> --add-label "need:human"`), unassign, then proceed to step 10 (worktree cleanup) before the next issue. The per-task reviews already ate the retry budget; don't burn another round here. See `references/verdict-comments.md` for the label-creation one-liner if the label doesn't exist yet.
 
 ### 8. Create the PR
 

--- a/skills/devpilot-resolve-issues/references/verdict-comments.md
+++ b/skills/devpilot-resolve-issues/references/verdict-comments.md
@@ -74,10 +74,25 @@ Unassigning so whoever owns this can pick it up. Ping me (or re-run `/resolve-is
 Then:
 
 ```bash
-gh issue edit <num> --remove-assignee @me
+gh issue edit <num> --add-label "need:human" --remove-assignee @me
 ```
 
-Do not close the issue. Do not add `wontfix`. It stays open.
+If the label doesn't exist yet, create it once per repo (yellow, short description):
+
+```bash
+gh label create "need:human" --color "fbca04" --description "Blocked on human input — business rules, product decision, or external contract" 2>/dev/null || true
+```
+
+Do not close the issue. Do not add `wontfix`. It stays open with the `need:human` label so maintainers can filter the backlog for what's blocked on them.
+
+**This label applies to every NEEDS-HUMAN exit path**, not just the triage verdict in step 4:
+
+- BLOCKED return from an implementer subagent (step 6b)
+- Round-3 review failure on any task (step 6c)
+- Second verification failure inside a subagent (step 6b)
+- Final-verify failure in the worktree (step 7)
+
+In the mid-fix escalation paths the branch is pushed as a draft first; the `need:human` label and the escalation comment still go on the **issue**, not the PR.
 
 ## Real → PR opened (posted after the PR is created)
 


### PR DESCRIPTION
## Summary

When `devpilot-resolve-issues` escalates an issue to `NEEDS-HUMAN`, also apply a `need:human` GitHub label so maintainers can filter the backlog for what's blocked on them. Previously the skill only posted a comment and unassigned — the only signal was buried in the comment thread.

Applies to **all four** escalation paths, not just the triage verdict:
- Step 4 triage verdict (`NEEDS-HUMAN`)
- Step 6b BLOCKED implementer return
- Step 6c round-3 review failure
- Step 7 final-verify failure in the worktree

## Changes

- `skills/devpilot-resolve-issues/SKILL.md`
  - Step 4 verdict table — NEEDS-HUMAN action now includes adding the label
  - Step 7 escalation path — `gh issue edit --add-label "need:human"` threaded in
- `skills/devpilot-resolve-issues/references/verdict-comments.md`
  - NEEDS-HUMAN `gh issue edit` command now adds `need:human` and unassigns in one call
  - Added a one-shot `gh label create` invocation (yellow `#fbca04`) for repos that don't have the label yet
  - Explicit list of the four escalation paths the label applies to, so the rule isn't easy to miss when reading mid-fix sections

## Review Guide

Start with `references/verdict-comments.md` — that's where the label behavior is canonically defined and where the four-path list lives. Then check `SKILL.md:171` (verdict table) and the step-7 escalation paragraph for consistency.

Watch for: the label is applied to the **issue** in mid-fix escalations, not to the draft PR that gets pushed alongside.

## Test plan

- [x] `make lint` — no Go code touched, docs-only change
- [x] Manually verify on a test repo: run `/resolve-issues`, force a NEEDS-HUMAN verdict, confirm `need:human` label is created and applied
- [x] Confirm the label one-liner is idempotent on a repo where the label already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)