### PR TITLE
feat(skills): rewrite devpilot-pr-review with eligibility gate + parallel fanout

### DIFF
--- a/skills/devpilot-pr-review/SKILL.md
+++ b/skills/devpilot-pr-review/SKILL.md
@@ -3,48 +3,95 @@ name: devpilot-pr-review
 description: Use when the user asks to review a pull request, merge request, or a diff — "review this PR", "review PR #123", "look over these changes", "check my diff before I merge", "/review", or when they share a PR URL and ask for thoughts. Findings are posted as inline comments anchored to specific lines so the author can act on each one in place. Do NOT use for pure style/lint review, formatting-only changes, or language-specific idiom review (defer to style skills like devpilot-google-go-style).
 ---
 
-# PR Review (Inline-First, Behavior-Aware)
+# PR Review (Eligibility-Gated, Parallel-Fanout, Inline-First)
 
 ## Overview
 
-A PR review the author can act on: every concrete finding is posted as an **inline comment anchored to the line it talks about**, so the author can see exactly which code is in question and decide finding-by-finding whether to fix. The summary in the review body stays short — TL;DR, the blind-spot sweep, the verdict.
+A PR review the author can act on: every concrete finding is posted as an **inline comment anchored to the line it talks about**, drawn from a **parallel multi-angle scan** and filtered through an explicit **confidence rubric** so the author sees signal, not noise. The body holds a short verdict, strengths, the blind-spot sweep, and counts.
 
-Findings come from two complementary passes, both required:
+Three structural ideas drive this skill:
 
-1. **Behavior sweep** — the five blind-spot questions plus a behavior trace. Catches the parts of the change a narrow diff view misses (`references/unknown-unknowns.md`).
-2. **Quality checklist** — code quality, architecture, testing, requirements, production readiness. Catches the parts a behavior pass would skip (`references/checklist.md`).
-
-The behavior sweep is what makes this review more than a style pass. The quality checklist is what makes it more than a behavior trace. Run both.
+1. **Eligibility gate** — decide the PR is worth a full review before spending tokens on it. Dependabot, drafts, generated-file PRs, "already reviewed" all stop here.
+2. **Parallel fanout** — five subagents look at the change from five independent angles in parallel. Coverage comes from diversity of angle, not depth of a single pass. The main session dispatches and merges; subagents read code.
+3. **Confidence filtering** — every finding carries `Confidence: 0–100`. Findings below 70 are dropped by default. Coverage at collection, filtering at posting.
 
 ## When NOT to Use
 
 - Pure formatting / lint / rename PRs — defer to the relevant style skill.
-- Generated-file or dependency-bump PRs with no behavior change — quick sanity check, skip the sweep.
+- Generated-file or dependency-bump PRs with no behavior change — the eligibility gate stops here.
 - No PR, diff, or branch given — ask the user for one.
 
 ## Three rules that govern every finding
 
-<coverage_first_findings>
-Report every finding you reach after tracing the code, including ones you are uncertain about or judge low-severity. Your job at this stage is **coverage**, not filtering. Each finding carries its own `Confidence` and `Severity` so the author and any downstream reviewer can rank and filter. A finding that later gets filtered out is fine; a finding that was silently dropped because it felt minor is not.
-</coverage_first_findings>
+<coverage_in_collection_filtering_at_posting>
+Subagents report every finding they reach, including uncertain ones — that is the only way to get coverage. The main session filters by Confidence and Severity at posting time. A finding silently dropped by a subagent because it "felt minor" is a defect in the review; a finding scored 40 and filtered out at the gate is fine.
+</coverage_in_collection_filtering_at_posting>
 
 <investigate_before_asserting>
-State how the code behaves only after opening and reading the relevant files. When a finding depends on a caller or test you have not located, mark it `Confidence: low` and record the gap in `Open Questions` rather than speculating.
+State how the code behaves only after opening and reading the relevant files. When a finding depends on a caller or test the subagent did not locate, it MUST score Confidence ≤ 50 and record the gap. No speculation passed off as fact.
 </investigate_before_asserting>
 
 <inline_by_default>
-Every finding tied to a specific line goes in as an inline review comment, never in the body. The body holds only the TL;DR, the sweep summary, the inline-finding counts, what's working well, and Open Questions. If a finding has no obvious anchor (cross-cutting concern, missing-but-not-present code), anchor it to the most representative line and say so in the comment — do not promote it to the body.
+Every finding tied to a specific line goes in as an inline review comment, never in the body. The body holds only the Verdict, TL;DR, Strengths, the sweep summary, finding counts, and Open Questions. If a finding has no obvious anchor (cross-cutting concern, missing-but-not-present code), anchor it to the most representative line and say so in the comment — do not promote it to the body.
 </inline_by_default>
 
 ## Workflow
 
-1. **Load the PR.** `gh pr view <url> --json title,body,files,baseRefName,author` + `gh pr diff <url>`; or `git diff <base>...HEAD` for a local branch; or read a pasted patch directly. A PR with no stated intent is itself a finding.
-2. **Run the behavior sweep.** Five blind-spot questions + behavior trace. See `references/unknown-unknowns.md`.
-3. **Run the quality checklist.** Code quality, architecture, testing, requirements, production readiness. See `references/checklist.md`.
-4. **Draft the review.** One inline comment per anchored finding (`references/template.md` → "Inline comment template"); one summary body for the review (`references/template.md` → "Review body template"). Apply tone, stance, and language rules from `references/style.md`. Calibrate against `references/example-review.md` on first use.
-5. **Post it.** Single combined POST: body + inline comments + event. See `references/posting.md`.
+```
+0. Eligibility gate         → references/eligibility.md
+1. Load PR                  → gh / git / pasted patch
+2. Parallel fanout          → references/fanout.md (5 subagents, parallel)
+3. Filter + merge           → references/confidence.md (threshold 70, dedupe)
+4. Draft review             → references/template.md + style.md
+5. Post one combined POST   → references/posting.md
+Self-check before post      → references/rationalizations.md
+```
 
-Before posting, walk the self-check in `references/rationalizations.md`.
+### 0. Eligibility gate
+
+Before anything else, run the gate in `references/eligibility.md`. If the PR is closed, draft, automation-only, generated-only, or already has a review from you, stop and tell the user. Cheap; saves an entire fanout.
+
+### 1. Load the PR
+
+```bash
+gh pr view <url> --json title,body,files,baseRefName,headRefOid,author
+gh pr diff <url>
+```
+
+Or `git diff <base>...HEAD` for a local branch, or read a pasted patch directly. Capture the **head SHA** — link rendering depends on it (see `references/posting.md`). A PR with no stated intent is itself a finding.
+
+### 2. Parallel fanout (5 subagents)
+
+Dispatch all five in a single message so they run in parallel. Each receives the PR metadata, the diff, and one focused brief. Each returns findings with `Confidence: 0–100` and `Severity`. See `references/fanout.md` for the prompts.
+
+| Agent | Angle |
+|---|---|
+| A | Behavior sweep (5 blind-spot questions + behavior trace) |
+| B | Shallow bug scan on the diff |
+| C | CLAUDE.md / AGENTS.md compliance |
+| D | Git blame & history + comments on prior PRs touching these files |
+| E | Code comments & in-file conventions in modified files |
+
+The main session does NOT also do these passes itself. Subagent context savings are the point.
+
+### 3. Filter, dedupe, merge
+
+Apply the rubric in `references/confidence.md`:
+
+- Drop findings with `Confidence < 70`.
+- Drop findings that match the false-positive list in `references/eligibility.md` (pre-existing issues, lines the PR did not modify, linter/typechecker-catchable, ignored-by-comment, etc.).
+- Dedupe across agents (same line, same defect → one inline comment, take the higher confidence).
+- Assign each surviving finding an inline anchor `(path, line)`. Cross-cutting findings anchor to the most representative line.
+
+### 4. Draft the review
+
+One inline comment per anchored finding using `references/template.md` → "Inline comment template". One body using `references/template.md` → "Review body template": Verdict + TL;DR + Strengths + Unknown-Unknowns Sweep summary (from Agent A) + counts + Open Questions. Apply tone/stance/language from `references/style.md`. Calibrate against `references/example-review.md` on first use.
+
+### 5. Post
+
+Single combined POST: body + inline comments + event. Links in body use full-SHA format. See `references/posting.md`.
+
+Before posting, walk `references/rationalizations.md` self-check.
 
 ## Cross-References
 
@@ -56,10 +103,13 @@ Before posting, walk the self-check in `references/rationalizations.md`.
 
 | File | What's in it |
 |---|---|
-| `references/unknown-unknowns.md` | Behavior sweep: five blind-spot questions, change-class pitfalls, behavior trace. |
-| `references/checklist.md` | Quality categories: code, architecture, testing, requirements, production readiness. |
-| `references/template.md` | Two templates — inline comment per finding, summary body for the review. Severity rubric, version resolution. |
+| `references/eligibility.md` | Gate rules + false-positive list (when to skip review entirely, what to never flag). |
+| `references/fanout.md` | Five subagent prompts (Behavior, Bug scan, CLAUDE.md, Git history, In-file comments). |
+| `references/confidence.md` | 0–100 rubric, threshold 70, severity vs. confidence axes, dedupe rules. |
+| `references/unknown-unknowns.md` | Behavior sweep details — Agent A's playbook. |
+| `references/checklist.md` | Quality dimensions referenced by Agent B's bug scan and Agent A's checklist tail. |
+| `references/template.md` | Inline comment template + review body template (Verdict, Strengths, sweep, counts). |
 | `references/style.md` | Tone, stance, and language rules for both body and inline comments. |
-| `references/posting.md` | `gh api` invocation for one combined POST with inline comments + body; GitLab equivalent. |
-| `references/example-review.md` | Worked example: body summary + multiple inline comments. |
-| `references/rationalizations.md` | Common shortcuts with rebuttals, plus the pre-post self-check list. |
+| `references/posting.md` | One combined POST (`gh api`), event mapping, full-SHA link format, GitLab equivalent. |
+| `references/example-review.md` | Worked example: body + inline comments. |
+| `references/rationalizations.md` | Common shortcuts + pre-post self-check. |

--- a/skills/devpilot-pr-review/references/confidence.md
+++ b/skills/devpilot-pr-review/references/confidence.md
@@ -1,0 +1,72 @@
+# Confidence Rubric, Filtering, and Merge
+
+The five fanout agents return findings with `confidence: 0–100`. This file is the rubric they score against and the procedure the main session uses to filter, dedupe, and merge their output.
+
+## Confidence rubric (0–100)
+
+Confidence measures **how sure you are the finding is real**, independent of how bad it would be (that's Severity).
+
+| Score | Meaning |
+|---|---|
+| 100 | Literal-string evidence. The defect is visible as a single phrase in the diff. |
+| 85–95 | Traced through code on this branch. The reviewer opened the relevant files and reproduced the path. |
+| 70–84 | Strong pattern match. The defect is clear from the code, but the reviewer didn't trace every caller / test. |
+| 50–69 | Plausible but unverified. A caller or test would confirm, but the reviewer couldn't locate it. |
+| 25–49 | Speculation grounded in general knowledge, not in this codebase. |
+| 0–24 | Not really a finding. Should not have been surfaced. |
+
+## Default threshold: 70
+
+Drop every finding with `confidence < 70` before drafting.
+
+**Why 70:**
+- Below 70 the reviewer has not opened the code that would confirm. Posting it lowers signal.
+- 70 is below "traced on this branch" (85+) but above pure pattern-match speculation. It keeps high-pattern-match findings worth a sentence.
+
+**When to override:**
+- The user explicitly asked for "everything, including maybes" → threshold = 50.
+- The user asked for "only certain" → threshold = 85.
+- Otherwise: 70. Don't bargain with yourself.
+
+## Severity vs. Confidence are orthogonal
+
+A high-severity bug you are moderately sure about is `Severity: Blocking, Confidence: 75`. Low confidence never automatically demotes severity. Severity describes *impact if true*; confidence describes *probability of being true*.
+
+| Severity | Description |
+|---|---|
+| Blocking | Would cause data loss, security regression, outage, or silently wrong behavior in production. |
+| Should-fix | Real bug on a reachable code path, missing test for a risky path, unhandled pitfall. |
+| Consider | Design or maintainability feedback worth the author's attention. |
+| Nit | Style, naming, wording. |
+
+## Inline-comment confidence label
+
+The inline comment template (`template.md`) shows `Confidence: high | medium | low`, not the raw 0–100 score. Mapping:
+
+| 0–100 | Label |
+|---|---|
+| 85–100 | high |
+| 70–84 | medium |
+| < 70 | (dropped — does not render) |
+
+The numeric score is internal to the fanout pipeline. The label is what the PR author sees.
+
+## Merge procedure (after the fanout returns)
+
+1. **Collect** all findings from agents A–E into one list.
+2. **Filter:**
+   - Drop `confidence < 70` (or the user-overridden threshold).
+   - Drop anything matching the false-positive list in `eligibility.md`.
+3. **Dedupe:**
+   - Same `(path, line)` and same defect class from multiple agents → one finding. Keep the highest confidence; merge the fixes if they differ.
+   - **Same defect across multiple lines or files** (e.g. four files all log the same secret) → **one consolidated inline comment** anchored to the worst/most-representative occurrence. List the other `path:line` locations inside the comment body as a short bullet list (`Same defect also at: a.go:42, b.go:91, c.go:30`). Also note the recurrence count in the body sweep summary under "Blast radius". Do NOT post one near-identical comment per file — that is the noise inline-first is meant to avoid.
+4. **Anchor:**
+   - Every surviving finding needs `(path, line, side)`. Cross-cutting findings (e.g. "this PR has no tests") anchor to the most representative line — the new function's signature, the first new line of the changed file. The comment body MUST say so.
+5. **Count** by severity. The counts go in the body.
+6. **Derive the review event** (`REQUEST_CHANGES` / `COMMENT` / `APPROVE`) from the highest-severity surviving finding. See `posting.md` → "Event mapping".
+
+## What to do when the fanout returns nothing
+
+- Verify the gate in `eligibility.md` didn't already explain why (generated-only, automation, etc.).
+- Re-read the diff yourself for a one-pass sanity check. A clean fanout on a non-trivial PR is a yellow flag — either the PR is genuinely clean, or the briefs missed something.
+- If still clean: post `event: APPROVE` with the body's "Strengths" filled in, sweep summary present, finding counts all zero.

--- a/skills/devpilot-pr-review/references/eligibility.md
+++ b/skills/devpilot-pr-review/references/eligibility.md
@@ -1,0 +1,40 @@
+# Eligibility Gate and False-Positive List
+
+Run this gate **before** dispatching the fanout. It is cheap (one or two `gh` calls + a glance at the diff) and prevents wasting tokens on PRs that don't benefit from a full review.
+
+## Gate: when to stop and not review
+
+Stop and tell the user explicitly when any of the following hold. Do **not** silently skip — the user asked for a review; tell them why you're not running one.
+
+| Condition | How to check | What to say |
+|---|---|---|
+| PR is **closed or merged** | `gh pr view --json state -q .state` | "PR is `MERGED`/`CLOSED`; nothing to review." |
+| PR is a **draft** and the user did not explicitly ask | `gh pr view --json isDraft -q .isDraft` | "PR is a draft. Want me to review it anyway?" |
+| **Already reviewed by you** (devpilot marker present) | `gh pr view --json reviews -q '.reviews[].body'` grep for `<!-- devpilot-pr-review` | "I already posted a review. Want me to update it, or focus on new commits since?" |
+| **Automation-only PR** (Dependabot, Renovate, release-please, sync bots) | `gh pr view --json author -q .author.login` matches known bot handle | "Looks like an automated PR. Quick sanity check only, or full review?" |
+| **Generated-files-only diff** (lockfiles, mocks, generated code) | All paths in `gh pr view --json files` match a generator pattern (`*.lock`, `**/generated/**`, `**/*.pb.go`, etc.) | "Diff is generated files only; no behavior to review." |
+| **Empty diff** | `gh pr diff` returns no hunks | "Empty diff." |
+| **No PR / diff / branch** given | n/a | Ask the user for one. |
+
+If none apply, proceed to the fanout.
+
+## False-positive list (filtered out at step 3, not surfaced)
+
+These never become inline findings. Subagents may surface them; the main session drops them before drafting. Match against this list explicitly when filtering.
+
+- **Pre-existing issues** — the defect already existed on the base branch. Not this PR's job.
+- **Lines the PR did not modify** — even if buggy, not in scope. Exception: the PR's change makes the line reachable / hot for the first time; then it is in scope and the comment must say so.
+- **Linter / typechecker / compiler-catchable issues** — missing imports, type errors, formatting, unused-var warnings. CI runs separately; do not duplicate.
+- **Broken tests / failing CI** — surfaced separately; not a review finding.
+- **Issues explicitly silenced in code** — `//nolint`, `# noqa`, `// eslint-disable-next-line`, in-line `_ = unused`. Trust the silencer unless the silencer itself is wrong.
+- **Pedantic style nitpicks** that a senior engineer would not raise (newline placement, single-line ternary vs. if, etc.).
+- **General "could have more tests" without a specific risky path** — Agent A and B name a specific untested risky path or it does not count.
+- **General "could have better docs"** — unless `CLAUDE.md`/`AGENTS.md` explicitly requires docs for this kind of change.
+- **Changes obviously intentional and directly part of the PR's stated purpose**, even if they "look like" a change.
+- **Suggestions to add features the PR did not aim to add** — scope creep on the reviewer's side.
+
+Findings that survive this list AND have `Confidence ≥ 70` go inline. Everything else is dropped silently.
+
+## Edge case: PR description missing or empty
+
+A PR with no stated intent is itself a finding — surface it in the body's Open Questions, not as an inline comment. Run the rest of the review against your best inference of intent from the diff, and say so in the TL;DR.

--- a/skills/devpilot-pr-review/references/example-review.md
+++ b/skills/devpilot-pr-review/references/example-review.md
@@ -18,8 +18,16 @@ Thanks for the change. Inline comments cover the per-line findings; the summary 
 
 ## PR Review: feat(auth): add session refresh on 401 (#214)
 
+### Verdict
+**Ready to merge:** No
+One Blocking inline finding: the refresh path recurses on a 401 from `/refresh`.
+
 ### TL;DR
-Not safe to merge as-is. The refresh path calls back into itself when the refresh endpoint returns 401, which will stack-overflow the process. Other findings are inline.
+The refresh path calls back into itself when the refresh endpoint returns 401, which will stack-overflow the process. Two other findings are inline (concurrent-refresh race, token leak in logs).
+
+### Strengths
+- Clear separation between `RoundTrip` and `refreshToken` makes the recursion guard a local fix ([`internal/auth/client.go#L60-L75`](https://github.com/SiyuQian/devpilot/blob/3c0e8f7b2a91e4d6f5c8a17b29e4d3b1a8f7e9c2/internal/auth/client.go#L60-L75)).
+- `TestRoundTrip_RefreshOn401` exercises the happy path cleanly.
 
 ### Unknown-Unknowns Sweep
 1. Local pattern fit: `internal/auth/client.go` already has a `doWithRetry` helper. This PR adds a parallel retry path instead of extending it.
@@ -32,10 +40,6 @@ Not safe to merge as-is. The refresh path calls back into itself when the refres
 - Blocking: 1
 - Should-fix: 1
 - Consider: 1
-
-### What's working well
-- Clear separation between `RoundTrip` and `refreshToken` makes the recursion guard a local fix.
-- `TestRoundTrip_RefreshOn401` exercises the happy path cleanly.
 
 ### Open Questions
 - Is this `RoundTrip` reused by the mobile SDK? I did not find callers outside this repo.

--- a/skills/devpilot-pr-review/references/fanout.md
+++ b/skills/devpilot-pr-review/references/fanout.md
@@ -1,0 +1,161 @@
+# Parallel Fanout: Five Subagent Briefs
+
+Dispatch all five subagents in a **single message with five parallel Task calls** so they run concurrently. Each subagent gets the same PR header (URL, title, head SHA, base SHA, files changed list, full diff) and one focused brief from this file.
+
+Each subagent returns a JSON-ish list of findings:
+
+```
+- path: <repo-relative>
+  line: <int, head SHA>     # use new-side line for added/changed; old-side for deleted (note `side: LEFT`)
+  side: RIGHT | LEFT
+  severity: Blocking | Should-fix | Consider | Nit
+  confidence: 0–100
+  title: <≤80 chars>
+  behavior: <what the code actually does today on this branch>
+  why: <impact on users / data / operability>
+  fix: <concrete direction, name the helper/package/function>
+  agent: <A | B | C | D | E>
+```
+
+Subagents MUST NOT post anything; their output is purely returned to the main session for filtering and merging.
+
+---
+
+## Agent A — Behavior Sweep
+
+You are reviewing a pull request for behavior-level defects. Your job is the five-question blind-spot sweep plus a behavior trace. You read code, including callers and tests, before asserting anything.
+
+**Inputs:**
+- PR URL, title, body, head SHA, base SHA, files changed.
+- Full diff (`gh pr diff <url>`).
+
+**Process:**
+1. Read the diff end-to-end. Then read the full files touched (not just the hunks).
+2. Run the five blind-spot questions from `references/unknown-unknowns.md`:
+   1. Local pattern fit
+   2. Blast radius (grep callers of every exported symbol changed)
+   3. Known pitfalls for this change class (auth, concurrency, migration, DB query, retry, cache, LLM, input boundary, data write, reversibility)
+   4. Stale-training check (verify versions in `go.mod`/`package.json`)
+   5. Hand-rolled vs. off-the-shelf (search repo + deps for existing utilities)
+3. Trace at least one golden-path input and one edge-case input through the change. Record the observable behavior delta.
+4. Produce a one-line summary per question for the body (`### Unknown-Unknowns Sweep` section). Concrete defects discovered during the sweep ALSO become individual findings anchored to lines.
+
+**Output:** Findings list (one per concrete defect) + a `sweep_summary` block with five lines (one per question).
+
+**Confidence calibration:**
+- 100: literal-string evidence in the diff (e.g. "log statement leaks the token").
+- 85–95: traced through code on this branch; you opened the relevant files.
+- 70–84: defect inferred from a clear pattern, but you didn't trace every path.
+- 50–69: plausible but you couldn't open the caller/test that would confirm.
+- < 50: speculation. Drop unless you can raise confidence.
+
+---
+
+## Agent B — Shallow Bug Scan
+
+You are looking for **obvious bugs in the diff itself**. Read the changes, do not chase callers. Focus on large bugs; ignore nits.
+
+**Process:**
+1. Read the diff.
+2. For each changed function, look for: swapped conditions, off-by-one, nil/zero handling, error swallowing, panic in library code, defer/Close leaks, resource leaks, missing cancellation, dead branches, copy-paste bugs, wrong format specifier, wrong unit (seconds vs. ms).
+3. Apply the false-positive filter in `references/eligibility.md` to your own output before returning.
+
+**Hard rules:**
+- Do not flag pre-existing code that the PR didn't touch.
+- Do not flag things a linter or typechecker would catch.
+- Do not flag general "code quality" issues — those are Agent C's job if CLAUDE.md says so.
+
+**Confidence calibration:**
+- 90–100: bug you can describe in one sentence pointing at a specific line.
+- 75–89: likely bug; the surrounding code makes it plausible.
+- < 70: speculation; drop.
+
+**Output:** Findings list, each anchored to a line.
+
+---
+
+## Agent C — CLAUDE.md / AGENTS.md Compliance
+
+You enforce the repo's own rules as written in `CLAUDE.md` and `AGENTS.md`.
+
+**Process:**
+1. List all `CLAUDE.md` and `AGENTS.md` files reachable from the repo root and from the directories whose files this PR modifies. Use `find` / `git ls-files`.
+2. Read each. Extract the rules that apply at review time (not the ones aimed at code-writing-time only).
+3. For each rule, check the diff against it. Cite the file path and the quoted rule text in your finding.
+
+**Hard rules:**
+- A rule must be **literally present** in a `CLAUDE.md`/`AGENTS.md`. Do not invent rules from "good practice".
+- If the code has an explicit silence (`//nolint`, ignore comment), respect it.
+- A rule violation is a finding even if Agent B didn't flag it.
+
+**Confidence calibration:**
+- 100: rule is literal in CLAUDE.md AND violation is literal in the diff.
+- 80–95: rule is literal; violation requires light interpretation.
+- < 70: rule requires interpretation. Drop.
+
+**Output:** Findings list, each citing the exact CLAUDE.md path and quoted text.
+
+---
+
+## Agent D — Git History & Prior PR Comments
+
+You read the history of the files this PR touches to surface context the diff alone misses.
+
+**Process:**
+1. For each modified file, run `git log --oneline -20 -- <path>` and skim recent commits.
+2. Run `git blame <path> -L <changed-lines>` for the lines being changed — note who wrote the surrounding code and when.
+3. List prior PRs that touched these files: `gh pr list --search "<path>" --state merged --limit 10 --json number,title,url`.
+4. For the most recent 3–5 prior PRs, fetch review comments: `gh api repos/:owner/:repo/pulls/:num/comments --jq '.[] | {path, line, body}'`.
+5. Look for: comments that flagged something now re-introduced in this PR, design decisions explained in commit messages, revert/rollback history (a line that was reverted before is high-risk to re-add).
+
+**Hard rules:**
+- A finding here needs a concrete pointer (commit SHA or PR URL).
+- Don't surface old comments unless they apply to the current change.
+
+**Confidence calibration:**
+- 90–100: prior PR comment flagged exactly this defect on the same line/symbol.
+- 70–89: prior history strongly suggests this pattern was rejected before.
+- < 70: drop.
+
+**Output:** Findings list. Each finding cites a commit SHA or prior PR URL.
+
+---
+
+## Agent E — In-File Comments & Conventions
+
+You read the comments inside the modified files and check the diff against them.
+
+**Process:**
+1. Read each modified file's existing comments — file headers, function docstrings, in-line `// NOTE` / `// TODO` / `// invariant:` / `// must be called with lock held` style notes.
+2. Check whether the diff respects them. New code that violates a documented invariant is a finding.
+3. Also check naming conventions visible in neighboring code in the same package.
+
+**Hard rules:**
+- Cite the exact comment text and its line.
+- Don't flag the absence of a doc comment unless CLAUDE.md requires it (that's Agent C).
+
+**Confidence calibration:**
+- 90–100: comment states the rule and the diff visibly violates it.
+- 70–89: convention is consistent across neighboring code and the diff diverges.
+- < 70: drop.
+
+**Output:** Findings list, each citing the comment line.
+
+---
+
+## Dispatch template (main session)
+
+```python
+# Pseudocode — actually invoked as 5 parallel Task tool calls in one message.
+parallel_tasks = []
+for agent in ["A", "B", "C", "D", "E"]:
+    parallel_tasks.append(
+        Task(
+            description=f"PR review fanout agent {agent}",
+            subagent_type="general-purpose",
+            prompt=BRIEF[agent] + SHARED_PR_HEADER,
+        )
+    )
+```
+
+After all five return, proceed to `references/confidence.md` for filtering and merging.

--- a/skills/devpilot-pr-review/references/posting.md
+++ b/skills/devpilot-pr-review/references/posting.md
@@ -65,6 +65,22 @@ gh pr view "$url" --json url,number,baseRepository \
 
 …or split the URL `https://github.com/<owner>/<repo>/pull/<num>`.
 
+### Link format for the body
+
+Links in the **body** (TL;DR, Strengths, sweep summary, Open Questions) MUST use the full-SHA `blob` form so GitHub renders the snippet preview:
+
+```
+https://github.com/<owner>/<repo>/blob/<full-40-char-sha>/<path>#L<start>-L<end>
+```
+
+Rules:
+- **Full SHA only** — `git rev-parse HEAD` output. `main`, `HEAD`, `$(git rev-parse HEAD)`, or short SHAs do NOT render in Markdown previews.
+- `#` separator after the path; line range as `L<start>-L<end>`.
+- Provide ≥ 1 line of context before and after the line you're citing. Commenting about line 12? Link `L11-L13`.
+- The repo segment must match the PR's repo, not a fork.
+
+Inline comments do NOT need these links — their anchor (`path`, `line`) is structured metadata. Use links only in the body.
+
 ### Pre-post sanity check
 
 Before the POST:

--- a/skills/devpilot-pr-review/references/rationalizations.md
+++ b/skills/devpilot-pr-review/references/rationalizations.md
@@ -24,6 +24,15 @@ Common shortcuts the reviewer may reach for, and what to do instead. The "Realit
 | "I'll split blockers and nits into two reviews." | One review per pass. The author gets one notification, one set of comments, one verdict. |
 | "A small emoji softens the tone." | Keep the review in professional prose. The review is part of the PR record. |
 | "Greeting feels redundant, skipping it." | The greeting is part of the template and addresses the author by handle. |
+| "I'll skip the eligibility gate and just review." | The gate is 1–2 `gh` calls. Skipping it wastes a fanout on a dependabot PR or duplicates a review you already posted. |
+| "I'll run the five passes myself instead of dispatching subagents." | The fanout is parallel for a reason — five agents in one turn finish in the time of one, and the main session keeps its context for filtering and drafting. Sequential single-thread defeats the design. |
+| "I'll skip one of the five agents — Agent D/E rarely finds anything." | The angles are independent. Skipping an angle by hunch is how silent defects survive. Run all five; the filter step is where you discard noise. |
+| "Confidence 65, but the bug feels real — I'll round up to 75." | Don't bargain with yourself. Open the file that would raise confidence to 85, or drop it. The rubric exists so 70 means something. |
+| "All findings are < 70 — I'll lower the threshold to surface something." | A clean fanout is allowed to produce zero findings. Approve and move on. Lowering the threshold to fill space is noise. |
+| "Same defect on 4 lines — I'll post 4 nearly-identical comments." | One consolidated inline comment anchored to the worst occurrence, with the other `path:line`s listed inside. Recurrence count goes in the body sweep summary. Four near-identical comments is the noise inline-first is meant to avoid. |
+| "I'll put the body link in short-SHA form, the reader can figure it out." | GitHub Markdown previews require the full 40-char SHA. Short SHA or branch name → no rendered preview. Use `git rev-parse HEAD`. |
+| "I'll skip the Verdict — readers can infer it from the counts." | The Verdict is the one thing every reader looks at. State it explicitly: Yes / With fixes / No. |
+| "I'll skip Strengths — sounds performative." | Accurate praise gates trust in the rest of the review. Two specific bullets, not generic compliments. |
 | "The version comment is noise, I'll drop it." | Keep `<!-- devpilot-pr-review (devpilot vX.Y.Z) -->` so readers can attribute the review. |
 | "Disclaimer feels defensive, I'll skip or shorten it." | Keep the disclaimer. It protects authors from treating AI findings as authoritative. |
 | "I'll ask 'what happens when X?' so the author clarifies." | If the code can answer it, state the answer. Author questions live in Open Questions only. |
@@ -33,8 +42,12 @@ Common shortcuts the reviewer may reach for, and what to do instead. The "Realit
 
 Before running `gh pr review`, run through this list. A "yes" on any item means the review is not ready; fix the underlying issue and re-check.
 
+- Eligibility gate skipped — PR turned out to be draft / merged / dependabot / already reviewed.
+- Fanout collapsed: only 1–2 of the five agents ran, or all five ran sequentially in the main session.
+- Findings with `confidence < 70` made it into the review.
+- Verdict (`Ready to merge: ...`) missing from the body.
+- Strengths section missing or replaced by generic compliments.
 - Writing findings before the five blind-spot questions were answered.
-- Quality checklist (`checklist.md`) skipped — only the behavior sweep was run.
 - Findings are all naming / formatting / "could be cleaner".
 - Comparing two options the author already listed instead of surfacing ones they did not consider.
 - "LGTM" without a single traced input.

--- a/skills/devpilot-pr-review/references/template.md
+++ b/skills/devpilot-pr-review/references/template.md
@@ -25,11 +25,11 @@ Every finding tied to a specific line uses this template. Posted as a single Git
 - **Length** — ≤ 8 lines of prose. Long architectural arguments belong in the body's "What's working well" / verdict, not in an inline comment.
 - **Anchor for cross-cutting findings** — when a finding has no natural single line (e.g. "this PR adds no tests"), anchor to the most representative line and add a one-liner: *"This comment is about the change as a whole; anchored here for visibility."*
 - **Language** — matches the PR's language end-to-end. Chinese PR → Chinese comment, including the field labels.
-- **Severity and confidence are independent.** A high-severity bug you are moderately sure about is `Severity: Blocking, Confidence: medium`. Low confidence never automatically demotes severity.
+- **Severity and confidence are independent.** A high-severity bug you are moderately sure about is `Severity: Blocking, Confidence: medium`. Low confidence never automatically demotes severity. See `confidence.md` for the 0–100 rubric the fanout uses internally and the high/medium/low label mapping shown to the author.
 
 ## Review body template
 
-The body holds only what doesn't belong on a single line: TL;DR, the sweep summary, inline-finding counts, what's working well, Open Questions, disclaimer, metadata. Render the skeleton; fill every placeholder.
+The body holds only what doesn't belong on a single line: Verdict, TL;DR, Strengths, the sweep summary, inline-finding counts, Open Questions, disclaimer, metadata. Render the skeleton; fill every placeholder.
 
 ```
 <!-- devpilot-pr-review (devpilot <version>) -->
@@ -39,8 +39,15 @@ Thanks for the change. Inline comments cover the per-line findings; the summary 
 
 ## PR Review: <title / #number>
 
+### Verdict
+**Ready to merge:** <Yes | With fixes | No>
+<one-sentence reasoning>
+
 ### TL;DR
-<1–2 sentences: safe to merge? single most important thing to address?>
+<1–2 sentences: single most important thing to address (or, if approving, what makes this clean)>
+
+### Strengths
+<2–3 bullets worth preserving — accurate praise so the author trusts the rest>
 
 ### Unknown-Unknowns Sweep
 1. Local pattern fit: <finding or "matches convention in X">
@@ -54,9 +61,6 @@ Thanks for the change. Inline comments cover the per-line findings; the summary 
 - Should-fix: <n>
 - Consider: <n>
 - Nit: <n>
-
-### What's working well
-<2–3 bullets worth preserving>
 
 ### Open Questions (optional — omit heading if empty)
 <only things the code could not answer, one line each>
@@ -78,6 +82,10 @@ Inline comments: <total count>
 - **`<version>`** — resolve via `devpilot --version` at post time. Take the `vX.Y.Z` token. Fall back to `unknown` if the command is unavailable. Same value goes in both the leading marker and the trailing HTML comment.
 - **`<author-handle>`** — `gh pr view --json author -q .author.login`. Fall back to "Hi there," (no handle) when unavailable.
 - **Language** — render every section (TL;DR, sweep, counts, what's working well, Open Questions, disclaimer, metadata) in the PR's language. Translate the disclaimer while preserving its meaning: automated, not authoritative, human judgment required.
+- **Verdict** — derived from the highest-severity surviving inline finding:
+  - Any Blocking → `Ready to merge: No`
+  - Only Should-fix / Consider / Nit → `Ready to merge: With fixes`
+  - Zero findings → `Ready to merge: Yes`
 - **Severity counts** — derived from the inline comments actually posted. Drop zero-count buckets from the list.
 - **Empty sections** — `Open Questions` is the only section omitted-when-empty (drop the heading). TL;DR, Sweep, Inline findings counts, What's working well, disclaimer, and both metadata blocks are always present.
 - **Review event** — derived from the highest-severity inline finding:


### PR DESCRIPTION
## Summary

Rewrites `devpilot-pr-review` into a 5-step workflow that borrows the strongest ideas from `/code-review:code-review` (eligibility gate, parallel multi-agent fanout, confidence filtering) and `superpowers:requesting-code-review` (Verdict + Strengths in the body), while keeping this skill's inline-first output shape that the author can act on per-line.

**Workflow now:**

0. **Eligibility gate** (`references/eligibility.md`) — stop early for drafts, dependabot/automation, already-reviewed PRs, generated-files-only diffs. Also defines the false-positive list (preexisting bugs, linter-catchable, unmodified lines, ignored-by-comment).
1. **Load PR** — `gh pr view` + `gh pr diff` (or local branch / pasted patch).
2. **Parallel fanout** (`references/fanout.md`) — 5 subagents in a single dispatch:
   - A: Behavior sweep (5 blind-spot questions + behavior trace)
   - B: Shallow bug scan on the diff
   - C: CLAUDE.md / AGENTS.md compliance
   - D: Git blame + prior PR comments
   - E: In-file comments & conventions
3. **Confidence filter** (`references/confidence.md`) — 0–100 rubric, default threshold 70, dedupe + anchor procedure. Cross-file identical defects consolidate to one inline comment (with other `path:line`s listed inside), not N spam comments.
4. **Draft** — body adds `Verdict` (Yes / With fixes / No, derived from highest severity) and `Strengths` sections; inline comments unchanged.
5. **Post** — single combined POST, full-SHA blob links in body (`references/posting.md`).

## Files changed

| Status | File | What's in it |
|---|---|---|
| Modified | `SKILL.md` | New 5-step workflow + three rules; reference index updated. |
| Added | `references/eligibility.md` | Gate rules + false-positive list. |
| Added | `references/fanout.md` | Five subagent briefs with confidence calibration per angle. |
| Added | `references/confidence.md` | 0–100 rubric, threshold 70, dedupe/anchor procedure. |
| Modified | `references/template.md` | Verdict + Strengths in body template; high/medium/low ↔ 0–100 mapping. |
| Modified | `references/posting.md` | Full-SHA blob link format for body citations. |
| Modified | `references/rationalizations.md` | +10 entries (gate skip, fanout collapse, confidence bargaining, short SHA, Verdict skip, Strengths skip). |
| Modified | `references/example-review.md` | Updated to new body structure (Verdict + Strengths). |

## Pressure-test

Tested across 9 scenarios with parallel subagents role-playing fresh Claude sessions:

| # | Scenario | Result |
|---|---|---|
| S1 | Dependabot PR + 'just LGTM' pressure | ✅ Gate stops, agent cites rule |
| S2 | Already-reviewed PR + 'author pushed more' | ✅ Switches to incremental review |
| S3 | Tiny rename PR + 'skip fanout' | ⚠️ Fixture hit 'When NOT to Use' exception (test invalid) |
| S4 | Confidence 65 + 'bump to 75' | ✅ Refuses, offers to verify caller or post as Question |
| S5 | 8 findings + 'collapse to body' | ✅ Pushes back + **surfaced real bug in dedupe rule** |
| S6 | Non-trivial PR + 'skip 5-agent overkill' | ✅ Keeps fanout; offers to trim D/E |
| S7 | 'Drop Verdict + Strengths' | ✅ Cites rationalizations table directly |
| S8 | 'Use short SHA / branch name' | ✅ Insists on full SHA; explains rendering + rot |
| S9 | Dep-bump + new hand-written code | ✅ Correctly falls through gate to fanout |

Bug surfaced by S5 has been fixed: cross-file identical defects now consolidate per `confidence.md` Step 3.

## Review Guide

- Start with **`SKILL.md`** to understand the new workflow shape and three rules.
- Then **`references/fanout.md`** — this is the new core. Each agent brief is independently usable; check the calibration rules.
- **`references/confidence.md`** — confirms threshold 70 and how 0–100 maps to the inline `high/medium/low` label authors see.
- **`references/eligibility.md`** — note the false-positive list at the bottom; it's what subagents filter their own output against.
- The other files are smaller deltas: skim `template.md` for Verdict/Strengths, `posting.md` for the full-SHA link rule, `rationalizations.md` for the new self-check entries.

## Test plan

- [x] All 9 pressure scenarios run via parallel subagents; results above.
- [x] Skill bug surfaced by S5 fixed and the rationalization table updated to lock in the fix.
- [ ] Real-world dry-run on a live PR (no `gh api` POST) to verify the fanout actually returns 5 parallel results and the merge procedure produces a coherent body — not done yet, follow-up.
- [ ] Multi-language verification (Chinese PR → Chinese review end-to-end) — not retested in this rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)