### PR TITLE
feat: incremental re-review and existing-comment dedupe in devpilot-pr-review

### DIFF
--- a/skills/devpilot-pr-review/SKILL.md
+++ b/skills/devpilot-pr-review/SKILL.md
@@ -49,7 +49,12 @@ Self-check before post      → references/rationalizations.md
 
 ### 0. Eligibility gate
 
-Before anything else, run the gate in `references/eligibility.md`. If the PR is closed, draft, automation-only, generated-only, or already has a review from you, stop and tell the user. Cheap; saves an entire fanout.
+Before anything else, run the gate in `references/eligibility.md`. If the PR is closed, draft, automation-only, generated-only, or already reviewed by you **at the current head SHA**, stop and tell the user. Cheap; saves an entire fanout.
+
+The gate also produces two outputs the later steps consume:
+
+- **Review mode** — `full` (no prior devpilot review) or `incremental` (prior review exists but head has moved; fanout runs against `last_reviewed_sha..head_sha`, not the full PR diff).
+- **Existing review comments** — `/tmp/existing_review_comments.json`, every prior inline comment on this PR from any reviewer. Used by step 3 to drop findings that duplicate an existing comment.
 
 ### 1. Load the PR
 
@@ -63,6 +68,8 @@ Or `git diff <base>...HEAD` for a local branch, or read a pasted patch directly.
 ### 2. Parallel fanout (5 subagents)
 
 Dispatch all five in a single message so they run in parallel. Each receives the PR metadata, the diff, and one focused brief. Each returns findings with `Confidence: 0–100` and `Severity`. See `references/fanout.md` for the prompts.
+
+In **incremental mode**, the diff passed to subagents is the range diff (`last_reviewed_sha..head_sha`), not the full PR diff — agents should look at the new commits only. Agent A still grounds its blast-radius checks in the full repo, but findings must be anchored to lines changed in the new commits.
 
 | Agent | Angle |
 |---|---|
@@ -79,7 +86,7 @@ The main session does NOT also do these passes itself. Subagent context savings 
 Apply the rubric in `references/confidence.md`:
 
 - Drop findings with `Confidence < 70`.
-- Drop findings that match the false-positive list in `references/eligibility.md` (pre-existing issues, lines the PR did not modify, linter/typechecker-catchable, ignored-by-comment, etc.).
+- Drop findings that match the false-positive list in `references/eligibility.md` (pre-existing issues, lines the PR did not modify, linter/typechecker-catchable, ignored-by-comment, **already raised by an existing review comment at the same anchor**, etc.). The existing-comments file from step 0 is the source of truth for the duplicate check.
 - Dedupe across agents (same line, same defect → one inline comment, take the higher confidence).
 - Assign each surviving finding an inline anchor `(path, line)`. Cross-cutting findings anchor to the most representative line.
 

--- a/skills/devpilot-pr-review/references/eligibility.md
+++ b/skills/devpilot-pr-review/references/eligibility.md
@@ -10,7 +10,7 @@ Stop and tell the user explicitly when any of the following hold. Do **not** sil
 |---|---|---|
 | PR is **closed or merged** | `gh pr view --json state -q .state` | "PR is `MERGED`/`CLOSED`; nothing to review." |
 | PR is a **draft** and the user did not explicitly ask | `gh pr view --json isDraft -q .isDraft` | "PR is a draft. Want me to review it anyway?" |
-| **Already reviewed by you** (devpilot marker present) | `gh pr view --json reviews -q '.reviews[].body'` grep for `<!-- devpilot-pr-review` | "I already posted a review. Want me to update it, or focus on new commits since?" |
+| **Already reviewed by you at the current head SHA** (devpilot marker present AND `commit_id` of the latest devpilot review == current `headRefOid`) | See "Already-reviewed check" below | "I already reviewed this exact commit. Want me to re-run anyway?" |
 | **Automation-only PR** (Dependabot, Renovate, release-please, sync bots) | `gh pr view --json author -q .author.login` matches known bot handle | "Looks like an automated PR. Quick sanity check only, or full review?" |
 | **Generated-files-only diff** (lockfiles, mocks, generated code) | All paths in `gh pr view --json files` match a generator pattern (`*.lock`, `**/generated/**`, `**/*.pb.go`, etc.) | "Diff is generated files only; no behavior to review." |
 | **Empty diff** | `gh pr diff` returns no hunks | "Empty diff." |
@@ -18,11 +18,43 @@ Stop and tell the user explicitly when any of the following hold. Do **not** sil
 
 If none apply, proceed to the fanout.
 
+## Already-reviewed check (incremental re-review)
+
+A prior devpilot review is **not** a stop condition on its own — only a stop condition when the PR head has not moved since. Resolve it with:
+
+```bash
+head_sha=$(gh pr view "$url" --json headRefOid -q .headRefOid)
+
+# Pull every review you (devpilot) have left, newest first, with its commit_id.
+gh pr view "$url" --json reviews \
+  -q '[.reviews[] | select(.body | test("<!-- devpilot-pr-review"))] | sort_by(.submittedAt) | reverse | .[0] // empty' \
+  > /tmp/last_devpilot_review.json
+
+last_reviewed_sha=$(jq -r '.commit_id // empty' /tmp/last_devpilot_review.json)
+```
+
+Decision:
+
+| State | Action |
+|---|---|
+| No prior devpilot review | Full review of the entire PR diff. |
+| `last_reviewed_sha == head_sha` | Stop per the gate row above. |
+| `last_reviewed_sha` set and `!= head_sha` | **Incremental re-review.** Diff the new commits only: `gh pr diff "$url" --patch` against the *range* `last_reviewed_sha..head_sha` (e.g. `git diff "$last_reviewed_sha".."$head_sha"`). Run the fanout on that range, not the full PR diff. The review body's TL;DR must say "Re-reviewing commits since `<short_sha>`". |
+
+In incremental mode, also load every existing review comment on the PR (from anyone, not just devpilot) so the filter step can drop duplicates — see the false-positive list below.
+
+```bash
+gh api "repos/$owner/$repo/pulls/$num/comments" \
+  --jq '[.[] | {path, line, side, body, user: .user.login, commit_id}]' \
+  > /tmp/existing_review_comments.json
+```
+
 ## False-positive list (filtered out at step 3, not surfaced)
 
 These never become inline findings. Subagents may surface them; the main session drops them before drafting. Match against this list explicitly when filtering.
 
 - **Pre-existing issues** — the defect already existed on the base branch. Not this PR's job.
+- **Already raised by an existing review comment** — if any comment in `/tmp/existing_review_comments.json` (devpilot's prior runs or another reviewer) anchors at the same `(path, line)` (±3 lines) and discusses the same defect, drop the new finding. Exception: the existing comment was marked resolved/outdated by a later commit and the defect is still present — then it's in scope, and the new comment must reference the prior one ("re-raising — still present after `<short_sha>`"). Treat the existing-comments file as authoritative; do not re-post the same defect to spare the author another notification.
 - **Lines the PR did not modify** — even if buggy, not in scope. Exception: the PR's change makes the line reachable / hot for the first time; then it is in scope and the comment must say so.
 - **Linter / typechecker / compiler-catchable issues** — missing imports, type errors, formatting, unused-var warnings. CI runs separately; do not duplicate.
 - **Broken tests / failing CI** — surfaced separately; not a review finding.


### PR DESCRIPTION
## Summary

Two related changes to `skills/devpilot-pr-review` so re-running the skill on an evolving PR produces useful work instead of either bailing out or spamming duplicate comments.

1. **Incremental re-review.** The eligibility gate previously hard-stopped whenever any prior devpilot review existed on the PR. It now only stops when the latest devpilot review's `commit_id` equals the current `headRefOid`. When the head has moved, the skill enters an **incremental** mode that runs the fanout against the `last_reviewed_sha..head_sha` range diff (not the full PR diff), and the review body's TL;DR is required to say "Re-reviewing commits since `<short_sha>`".

2. **Existing-comment dedupe.** Step 0 of the gate now writes every prior inline review comment on the PR (from anyone, not just devpilot) to `/tmp/existing_review_comments.json`. The confidence-filter step in `SKILL.md` and a new entry in the false-positive list in `references/eligibility.md` reference that file as the source of truth: any new finding anchored at the same `(path, line)` (±3 lines) and discussing the same defect is dropped. Exception carved out for re-raising a defect that the author didn't actually fix — in that case the new comment must reference the prior one.

## Review Guide

Start with `skills/devpilot-pr-review/references/eligibility.md` — the gate row change and the new "Already-reviewed check" section drive everything else. Then read `skills/devpilot-pr-review/SKILL.md` to see how steps 0/2/3 are wired to consume the new outputs (`review mode`, `/tmp/existing_review_comments.json`). The `±3 lines` tolerance in the false-positive entry is the main judgment call worth a second look.

## Test plan

- [ ] Manually run the skill against a PR with a prior devpilot review at an older SHA; confirm it enters incremental mode and only flags new commits.
- [ ] Manually run the skill against a PR with an existing devpilot review at the *current* head SHA; confirm the gate still stops.
- [ ] Manually run the skill against a PR where another reviewer already left a comment on a line a fanout subagent would flag; confirm the finding is dropped.
- [ ] Skill is documentation only — no lint/test commands apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)