### PR TITLE
feat(graph): Phase 4 — CLI surface with uniform JSON envelope

### DIFF
--- a/cmd/devpilot/main.go
+++ b/cmd/devpilot/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/siyuqian/devpilot/internal/auth"
 	"github.com/siyuqian/devpilot/internal/generate"
 	"github.com/siyuqian/devpilot/internal/gmail"
+	"github.com/siyuqian/devpilot/internal/graph"
 	"github.com/siyuqian/devpilot/internal/initcmd"
 	"github.com/siyuqian/devpilot/internal/slack"
 	"github.com/siyuqian/devpilot/internal/trello"
@@ -30,6 +31,7 @@ func main() {
 	gmail.RegisterCommands(rootCmd)
 	slack.RegisterCommands(rootCmd)
 	generate.RegisterCommands(rootCmd)
+	graph.RegisterCommands(rootCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/docs/plans/2026-05-20-devpilot-graph-phase4-plan.md
+++ b/docs/plans/2026-05-20-devpilot-graph-phase4-plan.md
@@ -1,0 +1,156 @@
+# Devpilot Graph Phase 4 — CLI Surface Bite-Sized Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the Phase 3 `internal/graph/query` package as `devpilot graph <verb>` subcommands with a uniform JSON envelope. Every command emits one JSON document on stdout that validates against a versioned schema.
+
+**Architecture:** Per project convention (CLAUDE.md: *"Cobra commands live with their domain in `commands.go` — no central `cli/` router"*), all graph subcommands are registered from `internal/graph/commands.go`. Each subcommand runner lives in `internal/graph/cli_<verb>.go`. `cmd/devpilot/main.go` calls `graph.RegisterCommands(rootCmd)` once.
+
+Envelope type + JSON-schema validator live in `internal/graph/envelope`.
+
+**Tech Stack:** Go 1.25, cobra, `github.com/santhosh-tekuri/jsonschema/v5` (new dep), stdlib `embed`, `os/exec` for e2e.
+
+**Conventions:** One passing test → one commit. `make lint && make test` before each commit.
+
+---
+
+## File Structure
+
+```
+internal/graph/
+├── commands.go                  (RegisterCommands wires all subcommands)
+├── cli_helpers.go               (resolveRepo, openStore, emit)
+├── cli_build.go / _test.go
+├── cli_status.go / _test.go
+├── cli_clean.go / _test.go
+├── cli_query.go / _test.go
+├── cli_impact.go / _test.go
+├── cli_hubs.go / _test.go
+├── cli_context.go / _test.go
+├── cli_detect_changes.go / _test.go
+├── cli_preflight.go / _test.go
+├── e2e_test.go                  (//go:build e2e)
+└── envelope/
+    ├── envelope.go / _test.go
+    ├── validate.go / _test.go
+    └── schemas/
+        ├── embed.go             (//go:embed *.json)
+        ├── envelope.v1.json
+        ├── build.v1.json
+        ├── status.v1.json
+        ├── clean.v1.json
+        ├── query.v1.json
+        ├── impact.v1.json
+        ├── hubs.v1.json
+        ├── context.v1.json
+        ├── detect_changes.v1.json
+        └── preflight.v1.json
+```
+
+---
+
+## Envelope Shape
+
+```jsonc
+{
+  "schema_version": "1",
+  "command": "graph.preflight",
+  "ok": true,
+  "data": { /* payload */ },
+  "error": null,
+  "warnings": [],
+  "next_tool_suggestions": ["devpilot graph context --id ..."],
+  "elapsed_ms": 142
+}
+```
+
+On error: `ok=false`, `data=null`, `error={"code","message"}`, exit code 1.
+
+---
+
+## Task 4.1: Envelope type + helpers
+
+- [ ] Failing test in `envelope_test.go` covering `New`, `OK`, `Err`, `Suggest`, `Marshal`.
+- [ ] Implement `envelope.go` with `Envelope` struct (json tags: `schema_version`, `command`, `ok`, `data`, `error`, `warnings`, `next_tool_suggestions`, `elapsed_ms`), `New(cmd)`, `OK(data)`, `Err(code,msg)`, `Warn(msg)`, `Suggest(cmds...)`, `Marshal()`.
+- [ ] Run, expect PASS. Commit `feat(graph/envelope): canonical JSON envelope type`.
+
+## Task 4.2: JSON schemas + validator
+
+- [ ] `go get github.com/santhosh-tekuri/jsonschema/v5 && go mod tidy`
+- [ ] Failing test in `validate_test.go`.
+- [ ] Write `envelope.v1.json` (base) and `status.v1.json` (concrete example with `allOf $ref envelope.v1.json`).
+- [ ] Implement `schemas/embed.go` with `//go:embed *.json var FS embed.FS`.
+- [ ] Implement `validate.go` with `Validate(raw []byte, schemaID string) error` that lazily compiles all schemas from `schemas.FS`.
+- [ ] PASS. Commit `feat(graph/envelope): jsonschema-backed validator`.
+
+## Task 4.3: graph build + shared helpers + cobra wiring
+
+- [ ] Failing test for `resolveRepo` (abs path, missing → error).
+- [ ] Failing test for `runBuild(repo)` — temp DEVPILOT_HOME, fixture go file, assert envelope `ok=true`, command=`graph.build`.
+- [ ] Implement `cli_helpers.go`: `resolveRepo`, `openStore`, `emit(e, schemaID) int` (marshals, validates, prints, returns exit code).
+- [ ] Implement `cli_build.go` calling `cache.NewBuilder` + `b.Build()`, emit `{repo, mode, files_parsed, nodes, edges}`.
+- [ ] Write `build.v1.json`.
+- [ ] Implement `commands.go` with `RegisterCommands(parent)` adding `graph` parent + `buildCmd()`. Wire into `cmd/devpilot/main.go`.
+- [ ] PASS. Commit `feat(graph/cli): graph build subcommand`.
+
+## Task 4.4: graph status
+
+- [ ] Failing test seeding cache via builder, asserts `nodes>0`, `languages` includes `go`, validates against `status.v1.json`.
+- [ ] Implement `cli_status.go` reading `cache.ReadMeta` + `store.CountNodes/CountEdges` (add count helpers if missing).
+- [ ] Register `statusCmd()` with `--repo`. PASS. Commit.
+
+## Task 4.5: graph clean
+
+- [ ] Three failing tests: `--repo X`, `--all`, neither (→ `args_required`).
+- [ ] Implement `cli_clean.go` using `os.RemoveAll` on `cache.GraphDir(home, RepoKey(abs))` or `<home>/graphs`.
+- [ ] Register `cleanCmd()` with `--repo`, `--all`. PASS. Commit.
+
+## Task 4.6: graph query (6 v1 patterns)
+
+Patterns: `callers_of`, `callees_of`, `tests_for`, `implementors_of`, `hubs`, `context`.
+
+- [ ] Table-driven failing test seeding nodes/edges directly via `store.InsertNodes/Edges` for all six patterns.
+- [ ] Implement `cli_query.go` with `runQuery(opts)` switching on pattern → `query.CallersOf/CalleesOf/TestsFor/ImplementorsOf/Hubs/Context`. Emit `data={pattern_result:{<key>:<value>}}`.
+- [ ] Write `query.v1.json` with `oneOf` over six sub-shapes.
+- [ ] Register `queryCmd()` with positional args `<pattern> [target]` and flags `--repo`, `--depth`, `--threshold`.
+- [ ] PASS. Commit `feat(graph/cli): graph query with six v1 patterns`.
+
+## Task 4.7: thin wrappers — impact / hubs / context
+
+Per-command failing test → implement → schema → register → commit.
+
+- [ ] **4.7a** `graph impact --files a,b,c --depth N` → `query.ImpactRadius` → `data={changed_symbols,callers}`. Commit.
+- [ ] **4.7b** `graph hubs --threshold N` → `query.Hubs` → `data.hubs=[{id,caller_count}]`. Commit.
+- [ ] **4.7c** `graph context --id ID --depth N` → `query.Context` → `data.context={target,callers}`. Commit.
+
+## Task 4.8: detect-changes + preflight composites
+
+### 4.8a graph detect-changes
+
+- [ ] Failing test using a small temp git repo; assert `changed_symbols` non-empty, each `change_type ∈ {added,removed,modified,renamed}`.
+- [ ] Implement `cli_detect_changes.go` calling `query.DetectChanges(st, abs, base, head)`. Suggest follow-up `graph preflight`.
+- [ ] Write `detect_changes.v1.json`. Register. Commit.
+
+### 4.8b graph preflight
+
+- [ ] Failing test mirroring Phase 3 roundtrip: build graph for `internal/auth/`, run against two synthetic SHAs, assert top-level keys from design §6.
+- [ ] Implement `cli_preflight.go` calling `query.Preflight(st, query.PreflightInput{...})`. Add `Suggest` for top 3 risky symbols → `graph context --id …`.
+- [ ] Write `preflight.v1.json` mirroring `query.PreflightResult` struct tags.
+- [ ] Register `preflightCmd()` with `--base`, `--head`, `--repo`. PASS. Commit `feat(graph/cli): graph preflight subcommand emits §6 payload`.
+
+## Task 4.9: end-to-end test via compiled binary
+
+- [ ] Create `internal/graph/e2e_test.go` (`//go:build e2e`).
+- [ ] `TestE2EAllCommands` builds `cmd/devpilot` into `t.TempDir()`, sets `DEVPILOT_HOME`, runs each subcommand via `os/exec` against a fixture git repo, parses stdout, calls `envelope.Validate(stdout, "<verb>.v1.json")`, asserts `ok=true`.
+- [ ] Run `go test -tags=e2e ./internal/graph/ -v`. PASS. Commit `test(graph/cli): e2e suite for all graph subcommands`.
+
+---
+
+## Phase 4 acceptance
+
+- [ ] All nine subcommands + six `query` patterns have passing e2e tests.
+- [ ] Every JSON output validates against its v1 schema.
+- [ ] `devpilot graph preflight` against devpilot itself completes in < 10s on warm cache.
+- [ ] `make lint` clean.
+- [ ] `cmd/devpilot/main.go` adds exactly one new `RegisterCommands` call.
+- [ ] No subcommand owns a file under `cmd/devpilot/`; all CLI code lives under `internal/graph/`.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/gofrs/flock v0.13.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
 github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/internal/graph/cli_build.go
+++ b/internal/graph/cli_build.go
@@ -1,0 +1,30 @@
+package graph
+
+import (
+	"github.com/siyuqian/devpilot/internal/graph/cache"
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+)
+
+func runBuild(repo string) int {
+	e := envelope.New("graph.build")
+	abs, err := resolveRepo(repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "build.v1.json")
+	}
+	b, err := cache.NewBuilder(cache.Home(), abs)
+	if err != nil {
+		return emit(e.Err("builder_init", err.Error()), "build.v1.json")
+	}
+	res, err := b.Build()
+	if err != nil {
+		return emit(e.Err("build_failed", err.Error()), "build.v1.json")
+	}
+	e.Suggest("devpilot graph status --repo " + abs)
+	return emit(e.OK(map[string]any{
+		"repo":         abs,
+		"mode":         res.Mode,
+		"files_parsed": res.FilesParsed,
+		"nodes":        res.NodesInsert,
+		"edges":        res.EdgesInsert,
+	}), "build.v1.json")
+}

--- a/internal/graph/cli_build_test.go
+++ b/internal/graph/cli_build_test.go
@@ -1,0 +1,54 @@
+package graph
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunBuildEmitsValidEnvelope(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "main.go"),
+		[]byte("package main\nfunc main(){}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEVPILOT_HOME", t.TempDir())
+
+	buf := captureStdout(t, func() {
+		if code := runBuild(repo); code != 0 {
+			t.Fatalf("runBuild rc=%d (output: %s)", code, "")
+		}
+	})
+
+	if !bytes.Contains(buf, []byte(`"ok":true`)) {
+		t.Fatalf("not ok: %s", buf)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(buf, &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, buf)
+	}
+	if env["command"] != "graph.build" {
+		t.Errorf("command=%v", env["command"])
+	}
+	data, ok := env["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("data not object: %v", env["data"])
+	}
+	if data["mode"] != "full" {
+		t.Errorf("mode=%v", data["mode"])
+	}
+}
+
+func TestRunBuildBadRepo(t *testing.T) {
+	t.Setenv("DEVPILOT_HOME", t.TempDir())
+	buf := captureStdout(t, func() {
+		if code := runBuild("/definitely/not/here"); code != 1 {
+			t.Errorf("expected rc=1, got %d", code)
+		}
+	})
+	if !bytes.Contains(buf, []byte(`"code":"repo_invalid"`)) {
+		t.Errorf("missing repo_invalid: %s", buf)
+	}
+}

--- a/internal/graph/cli_clean.go
+++ b/internal/graph/cli_clean.go
@@ -1,0 +1,50 @@
+package graph
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siyuqian/devpilot/internal/graph/cache"
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+)
+
+func runClean(repo string, all bool) int {
+	e := envelope.New("graph.clean")
+	if !all && repo == "" {
+		return emit(e.Err("args_required", "pass --repo or --all"), "clean.v1.json")
+	}
+	home := cache.Home()
+	if all {
+		dir := filepath.Join(home, "graphs")
+		if err := os.RemoveAll(dir); err != nil {
+			return emit(e.Err("remove_failed", err.Error()), "clean.v1.json")
+		}
+		return emit(e.OK(map[string]any{"removed": dir, "all": true}), "clean.v1.json")
+	}
+	abs, err := resolveRepo(repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "clean.v1.json")
+	}
+	dir := cache.GraphDir(home, cache.RepoKey(abs))
+	if err := os.RemoveAll(dir); err != nil {
+		return emit(e.Err("remove_failed", err.Error()), "clean.v1.json")
+	}
+	return emit(e.OK(map[string]any{"removed": dir, "all": false}), "clean.v1.json")
+}
+
+func cleanCmd() *cobra.Command {
+	var repo string
+	var all bool
+	c := &cobra.Command{
+		Use:   "clean",
+		Short: "Delete graph cache for a repo (--repo) or every repo (--all)",
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(runClean(repo, all))
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "repo root")
+	c.Flags().BoolVar(&all, "all", false, "remove every cached graph")
+	return c
+}

--- a/internal/graph/cli_context.go
+++ b/internal/graph/cli_context.go
@@ -1,0 +1,47 @@
+package graph
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+	"github.com/siyuqian/devpilot/internal/graph/query"
+)
+
+func runContext(repo, id string, depth int) int {
+	e := envelope.New("graph.context")
+	abs, err := resolveRepo(repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "context.v1.json")
+	}
+	if id == "" {
+		return emit(e.Err("args_required", "--id is required"), "context.v1.json")
+	}
+	st, _, err := openStore(abs)
+	if err != nil {
+		return emit(e.Err("cache_missing", err.Error()).Suggest("devpilot graph build --repo "+abs), "context.v1.json")
+	}
+	defer func() { _ = st.Close() }()
+	ctx, err := query.Context(st, id, defaultInt(depth, 1), abs)
+	if err != nil {
+		return emit(e.Err("context_failed", err.Error()), "context.v1.json")
+	}
+	return emit(e.OK(map[string]any{"context": contextToMap(ctx)}), "context.v1.json")
+}
+
+func contextCmd() *cobra.Command {
+	var repo, id string
+	var depth int
+	c := &cobra.Command{
+		Use:   "context",
+		Short: "Return the source snippet for a symbol and (optionally) its callers",
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(runContext(repo, id, depth))
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "repo root")
+	c.Flags().StringVar(&id, "id", "", "symbol id")
+	c.Flags().IntVar(&depth, "depth", 0, "caller depth (0 = target only)")
+	return c
+}

--- a/internal/graph/cli_detect_changes.go
+++ b/internal/graph/cli_detect_changes.go
@@ -1,0 +1,57 @@
+package graph
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+	"github.com/siyuqian/devpilot/internal/graph/query"
+)
+
+func runDetectChanges(repo, base, head string) int {
+	e := envelope.New("graph.detect-changes")
+	abs, err := resolveRepo(repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "detect_changes.v1.json")
+	}
+	if base == "" || head == "" {
+		return emit(e.Err("args_required", "--base and --head are required"), "detect_changes.v1.json")
+	}
+	st, _, err := openStore(abs)
+	if err != nil {
+		return emit(e.Err("cache_missing", err.Error()).Suggest("devpilot graph build --repo "+abs), "detect_changes.v1.json")
+	}
+	defer func() { _ = st.Close() }()
+	ch, err := query.DetectChanges(st, abs, base, head)
+	if err != nil {
+		return emit(e.Err("detect_failed", err.Error()), "detect_changes.v1.json")
+	}
+	out := make([]map[string]any, 0, len(ch))
+	for _, c := range ch {
+		out = append(out, map[string]any{
+			"id":          c.ID,
+			"kind":        c.Kind,
+			"is_exported": c.IsExported,
+			"is_new":      c.IsNew,
+			"change_type": c.ChangeType,
+		})
+	}
+	e.Suggest("devpilot graph preflight --base " + base + " --head " + head + " --repo " + abs)
+	return emit(e.OK(map[string]any{"changed_symbols": out}), "detect_changes.v1.json")
+}
+
+func detectChangesCmd() *cobra.Command {
+	var repo, base, head string
+	c := &cobra.Command{
+		Use:   "detect-changes",
+		Short: "List symbols changed between two git refs",
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(runDetectChanges(repo, base, head))
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "repo root")
+	c.Flags().StringVar(&base, "base", "", "base git ref")
+	c.Flags().StringVar(&head, "head", "", "head git ref")
+	return c
+}

--- a/internal/graph/cli_helpers.go
+++ b/internal/graph/cli_helpers.go
@@ -1,0 +1,67 @@
+package graph
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siyuqian/devpilot/internal/graph/cache"
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+	"github.com/siyuqian/devpilot/internal/graph/store"
+)
+
+// resolveRepo normalises a user-provided repo path to an absolute existing dir.
+// An empty input falls back to the current working directory.
+func resolveRepo(repo string) (string, error) {
+	if repo == "" {
+		var err error
+		repo, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("getwd: %w", err)
+		}
+	}
+	abs, err := filepath.Abs(repo)
+	if err != nil {
+		return "", fmt.Errorf("abs %s: %w", repo, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("repo %s is not a directory", abs)
+	}
+	return abs, nil
+}
+
+// openStore opens the cached graph for the resolved repo, returning an error
+// when the cache is absent so callers can map it to a structured envelope code.
+func openStore(repoAbs string) (*store.Store, string, error) {
+	key := cache.RepoKey(repoAbs)
+	dbPath := cache.GraphDB(cache.Home(), key)
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil, key, fmt.Errorf("graph cache missing for %s — run `devpilot graph build`", repoAbs)
+	}
+	st, err := store.Open(dbPath)
+	if err != nil {
+		return nil, key, fmt.Errorf("open %s: %w", dbPath, err)
+	}
+	return st, key, nil
+}
+
+// emit writes the envelope as canonical JSON to stdout, validates it against
+// schemaID, and returns a process-exit code (0 ok, 1 otherwise).
+func emit(e *envelope.Envelope, schemaID string) int {
+	b, err := e.Marshal()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "envelope marshal:", err)
+		return 1
+	}
+	if err := envelope.Validate(b, schemaID); err != nil {
+		fmt.Fprintln(os.Stderr, "envelope schema violation:", err)
+		fmt.Fprintln(os.Stderr, string(b))
+		return 1
+	}
+	fmt.Println(string(b))
+	if !e.OKFlag {
+		return 1
+	}
+	return 0
+}

--- a/internal/graph/cli_helpers_test.go
+++ b/internal/graph/cli_helpers_test.go
@@ -1,0 +1,63 @@
+package graph
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+)
+
+func TestResolveRepoAbs(t *testing.T) {
+	got, err := resolveRepo(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("want absolute, got %q", got)
+	}
+}
+
+func TestResolveRepoMissing(t *testing.T) {
+	if _, err := resolveRepo("/definitely/not/here"); err == nil {
+		t.Fatal("want error")
+	}
+}
+
+// captureStdout returns whatever fn writes to os.Stdout.
+func captureStdout(t *testing.T, fn func()) []byte {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan []byte)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.Bytes()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	return <-done
+}
+
+func TestEmitValidates(t *testing.T) {
+	e := envelope.New("graph.status").OK(map[string]any{
+		"repo": "/x", "head_sha": "abc", "languages": []string{"go"},
+		"nodes": 1, "edges": 1, "built_at_unix": 1,
+	})
+	buf := captureStdout(t, func() {
+		if code := emit(e, "status.v1.json"); code != 0 {
+			t.Errorf("rc=%d", code)
+		}
+	})
+	if !bytes.Contains(buf, []byte(`"ok":true`)) {
+		t.Errorf("missing ok=true: %s", buf)
+	}
+}

--- a/internal/graph/cli_hubs.go
+++ b/internal/graph/cli_hubs.go
@@ -1,0 +1,43 @@
+package graph
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+	"github.com/siyuqian/devpilot/internal/graph/query"
+)
+
+func runHubs(repo string, threshold int) int {
+	e := envelope.New("graph.hubs")
+	abs, err := resolveRepo(repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "hubs.v1.json")
+	}
+	st, _, err := openStore(abs)
+	if err != nil {
+		return emit(e.Err("cache_missing", err.Error()).Suggest("devpilot graph build --repo "+abs), "hubs.v1.json")
+	}
+	defer func() { _ = st.Close() }()
+	hs, err := query.Hubs(st, defaultInt(threshold, 10))
+	if err != nil {
+		return emit(e.Err("hubs_failed", err.Error()), "hubs.v1.json")
+	}
+	return emit(e.OK(map[string]any{"hubs": hubsToMaps(hs)}), "hubs.v1.json")
+}
+
+func hubsCmd() *cobra.Command {
+	var repo string
+	var threshold int
+	c := &cobra.Command{
+		Use:   "hubs",
+		Short: "List high-fanin nodes (frequent call targets)",
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(runHubs(repo, threshold))
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "repo root")
+	c.Flags().IntVar(&threshold, "threshold", 0, "min inbound calls (default 10)")
+	return c
+}

--- a/internal/graph/cli_impact.go
+++ b/internal/graph/cli_impact.go
@@ -1,0 +1,56 @@
+package graph
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+	"github.com/siyuqian/devpilot/internal/graph/query"
+)
+
+func runImpact(repo, filesCSV string, depth int) int {
+	e := envelope.New("graph.impact")
+	abs, err := resolveRepo(repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "impact.v1.json")
+	}
+	if filesCSV == "" {
+		return emit(e.Err("args_required", "--files is required"), "impact.v1.json")
+	}
+	files := strings.Split(filesCSV, ",")
+	st, _, err := openStore(abs)
+	if err != nil {
+		return emit(e.Err("cache_missing", err.Error()).Suggest("devpilot graph build --repo "+abs), "impact.v1.json")
+	}
+	defer func() { _ = st.Close() }()
+	im, err := query.ImpactRadius(st, files, defaultInt(depth, 2))
+	if err != nil {
+		return emit(e.Err("impact_failed", err.Error()), "impact.v1.json")
+	}
+	changed := im.ChangedSymbols
+	if changed == nil {
+		changed = []string{}
+	}
+	return emit(e.OK(map[string]any{
+		"changed_symbols": changed,
+		"callers":         callersToMaps(im.Symbols),
+	}), "impact.v1.json")
+}
+
+func impactCmd() *cobra.Command {
+	var repo, files string
+	var depth int
+	c := &cobra.Command{
+		Use:   "impact",
+		Short: "Union of callers for symbols defined in the given files",
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(runImpact(repo, files, depth))
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "repo root")
+	c.Flags().StringVar(&files, "files", "", "comma-separated file paths")
+	c.Flags().IntVar(&depth, "depth", 0, "max caller hops")
+	return c
+}

--- a/internal/graph/cli_preflight.go
+++ b/internal/graph/cli_preflight.go
@@ -1,0 +1,54 @@
+package graph
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+	"github.com/siyuqian/devpilot/internal/graph/query"
+)
+
+func runPreflight(repo, base, head string) int {
+	e := envelope.New("graph.preflight")
+	abs, err := resolveRepo(repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "preflight.v1.json")
+	}
+	if base == "" || head == "" {
+		return emit(e.Err("args_required", "--base and --head are required"), "preflight.v1.json")
+	}
+	st, _, err := openStore(abs)
+	if err != nil {
+		return emit(e.Err("cache_missing", err.Error()).Suggest("devpilot graph build --repo "+abs), "preflight.v1.json")
+	}
+	defer func() { _ = st.Close() }()
+	res, err := query.Preflight(st, query.PreflightInput{
+		RepoRoot: abs, Base: base, Head: head,
+	})
+	if err != nil {
+		return emit(e.Err("preflight_failed", err.Error()), "preflight.v1.json")
+	}
+	for i, s := range res.ChangedSymbols {
+		if i >= 3 {
+			break
+		}
+		e.Suggest("devpilot graph context --id " + s.ID + " --depth 1 --repo " + abs)
+	}
+	return emit(e.OK(res), "preflight.v1.json")
+}
+
+func preflightCmd() *cobra.Command {
+	var repo, base, head string
+	c := &cobra.Command{
+		Use:   "preflight",
+		Short: "Emit the §6 preflight payload for a PR diff",
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(runPreflight(repo, base, head))
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "repo root")
+	c.Flags().StringVar(&base, "base", "", "base git ref")
+	c.Flags().StringVar(&head, "head", "", "head git ref")
+	return c
+}

--- a/internal/graph/cli_query.go
+++ b/internal/graph/cli_query.go
@@ -1,0 +1,146 @@
+package graph
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+	"github.com/siyuqian/devpilot/internal/graph/query"
+)
+
+type queryOpts struct {
+	repo      string
+	depth     int
+	threshold int
+}
+
+func runQuery(o queryOpts, pattern, target string) int {
+	e := envelope.New("graph.query")
+	abs, err := resolveRepo(o.repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "query.v1.json")
+	}
+	st, _, err := openStore(abs)
+	if err != nil {
+		return emit(e.Err("cache_missing", err.Error()).Suggest("devpilot graph build --repo "+abs), "query.v1.json")
+	}
+	defer func() { _ = st.Close() }()
+
+	switch pattern {
+	case "callers_of":
+		v, err := query.CallersOf(st, target, defaultInt(o.depth, 2))
+		return finishQuery(e, pattern, "callers", callersToMaps(v), err)
+	case "callees_of":
+		v, err := query.CalleesOf(st, target, defaultInt(o.depth, 2))
+		return finishQuery(e, pattern, "callees", calleesToMaps(v), err)
+	case "tests_for":
+		v, err := query.TestsFor(st, target)
+		return finishQuery(e, pattern, "tests", v, err)
+	case "implementors_of":
+		v, err := query.ImplementorsOf(st, target)
+		return finishQuery(e, pattern, "implementors", v, err)
+	case "hubs":
+		v, err := query.Hubs(st, defaultInt(o.threshold, 10))
+		return finishQuery(e, pattern, "hubs", hubsToMaps(v), err)
+	case "context":
+		v, err := query.Context(st, target, defaultInt(o.depth, 1), abs)
+		return finishQuery(e, pattern, "context", contextToMap(v), err)
+	default:
+		return emit(e.Err("unknown_pattern",
+			fmt.Sprintf("pattern %q not in {callers_of,callees_of,tests_for,implementors_of,hubs,context}", pattern)),
+			"query.v1.json")
+	}
+}
+
+func finishQuery(e *envelope.Envelope, pattern, key string, value any, err error) int {
+	if err != nil {
+		return emit(e.Err("query_failed", err.Error()), "query.v1.json")
+	}
+	if value == nil {
+		// Normalise nil slices to empty so schema oneOf branches work cleanly.
+		value = []any{}
+	}
+	return emit(e.OK(map[string]any{
+		"pattern":        pattern,
+		"pattern_result": map[string]any{key: value},
+	}), "query.v1.json")
+}
+
+func defaultInt(v, d int) int {
+	if v <= 0 {
+		return d
+	}
+	return v
+}
+
+func callersToMaps(in []query.Caller) []map[string]any {
+	out := make([]map[string]any, 0, len(in))
+	for _, c := range in {
+		out = append(out, map[string]any{"id": c.ID, "hop": c.Hop})
+	}
+	return out
+}
+
+func calleesToMaps(in []query.Callee) []map[string]any {
+	out := make([]map[string]any, 0, len(in))
+	for _, c := range in {
+		out = append(out, map[string]any{"id": c.ID, "hop": c.Hop})
+	}
+	return out
+}
+
+func hubsToMaps(in []query.Hub) []map[string]any {
+	out := make([]map[string]any, 0, len(in))
+	for _, h := range in {
+		out = append(out, map[string]any{"id": h.ID, "caller_count": h.CallerCount})
+	}
+	return out
+}
+
+func contextToMap(c query.ContextResult) map[string]any {
+	return map[string]any{
+		"target":  snippetToMap(c.Target),
+		"callers": snippetsToMaps(c.Callers),
+	}
+}
+
+func snippetToMap(s query.Snippet) map[string]any {
+	return map[string]any{
+		"id":         s.ID,
+		"path":       s.Path,
+		"start_line": s.StartLine,
+		"end_line":   s.EndLine,
+		"source":     s.Source,
+	}
+}
+
+func snippetsToMaps(in []query.Snippet) []map[string]any {
+	out := make([]map[string]any, 0, len(in))
+	for _, s := range in {
+		out = append(out, snippetToMap(s))
+	}
+	return out
+}
+
+func queryCmd() *cobra.Command {
+	var o queryOpts
+	c := &cobra.Command{
+		Use:   "query <pattern> [target]",
+		Short: "Run a saved query pattern against the graph",
+		Args:  cobra.RangeArgs(1, 2),
+		Run: func(cmd *cobra.Command, args []string) {
+			pattern := args[0]
+			target := ""
+			if len(args) > 1 {
+				target = args[1]
+			}
+			os.Exit(runQuery(o, pattern, target))
+		},
+	}
+	c.Flags().StringVar(&o.repo, "repo", "", "repo root (default: cwd)")
+	c.Flags().IntVar(&o.depth, "depth", 0, "max BFS depth (callers_of, callees_of, context)")
+	c.Flags().IntVar(&o.threshold, "threshold", 0, "min inbound calls (hubs)")
+	return c
+}

--- a/internal/graph/cli_status.go
+++ b/internal/graph/cli_status.go
@@ -1,0 +1,60 @@
+package graph
+
+import (
+	"github.com/spf13/cobra"
+	"os"
+
+	"github.com/siyuqian/devpilot/internal/graph/cache"
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+)
+
+func runStatus(repo string) int {
+	e := envelope.New("graph.status")
+	abs, err := resolveRepo(repo)
+	if err != nil {
+		return emit(e.Err("repo_invalid", err.Error()), "status.v1.json")
+	}
+	key := cache.RepoKey(abs)
+	meta, err := cache.ReadMeta(cache.MetaFile(cache.Home(), key))
+	if err != nil {
+		return emit(e.Err("meta_unreadable", err.Error()), "status.v1.json")
+	}
+	st, _, err := openStore(abs)
+	if err != nil {
+		return emit(e.Err("cache_missing", err.Error()).Suggest("devpilot graph build --repo "+abs), "status.v1.json")
+	}
+	defer func() { _ = st.Close() }()
+	nodes, err := st.CountNodes()
+	if err != nil {
+		return emit(e.Err("count_failed", err.Error()), "status.v1.json")
+	}
+	edges, err := st.CountEdges()
+	if err != nil {
+		return emit(e.Err("count_failed", err.Error()), "status.v1.json")
+	}
+	langs := meta.Languages
+	if langs == nil {
+		langs = []string{}
+	}
+	return emit(e.OK(map[string]any{
+		"repo":          abs,
+		"head_sha":      meta.HeadSHA,
+		"languages":     langs,
+		"nodes":         nodes,
+		"edges":         edges,
+		"built_at_unix": meta.BuiltAtUnix,
+	}), "status.v1.json")
+}
+
+func statusCmd() *cobra.Command {
+	var repo string
+	c := &cobra.Command{
+		Use:   "status",
+		Short: "Report graph-cache state for a repo",
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(runStatus(repo))
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "repo root (default: cwd)")
+	return c
+}

--- a/internal/graph/commands.go
+++ b/internal/graph/commands.go
@@ -1,0 +1,48 @@
+// Package graph hosts the `devpilot graph` Cobra surface. Subcommands live in
+// sibling files (cli_<verb>.go) but are registered here, matching the project
+// convention of one commands.go per domain.
+package graph
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// RegisterCommands installs the `graph` parent and all subcommands.
+func RegisterCommands(parent *cobra.Command) {
+	g := &cobra.Command{
+		Use:   "graph",
+		Short: "Code-graph build and query commands",
+	}
+	g.AddCommand(
+		buildCmd(),
+		statusCmd(),
+		cleanCmd(),
+		queryCmd(),
+		impactCmd(),
+		hubsCmd(),
+		contextCmd(),
+		detectChangesCmd(),
+		preflightCmd(),
+	)
+	parent.AddCommand(g)
+}
+
+func buildCmd() *cobra.Command {
+	var repo string
+	c := &cobra.Command{
+		Use:   "build [repo]",
+		Short: "Build or refresh the graph cache for a repo",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			r := repo
+			if r == "" && len(args) > 0 {
+				r = args[0]
+			}
+			os.Exit(runBuild(r))
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "repo root (default: cwd)")
+	return c
+}

--- a/internal/graph/e2e_test.go
+++ b/internal/graph/e2e_test.go
@@ -1,0 +1,151 @@
+//go:build e2e
+
+package graph
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope"
+)
+
+// TestE2EAllCommands builds the real devpilot binary and exercises every
+// `graph` subcommand against a small temp repo. Each invocation must:
+//   - exit 0
+//   - emit JSON that validates against its v1 schema
+//   - report ok=true
+//
+// Run with: go test -tags=e2e ./internal/graph/...
+func TestE2EAllCommands(t *testing.T) {
+	bindir := t.TempDir()
+	binPath := filepath.Join(bindir, "devpilot")
+	out, err := exec.Command("go", "build", "-o", binPath, "../../cmd/devpilot").CombinedOutput()
+	if err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	home := t.TempDir()
+	repo := makeE2EFixture(t)
+
+	run := func(args ...string) []byte {
+		cmd := exec.Command(binPath, args...)
+		cmd.Env = append(os.Environ(), "DEVPILOT_HOME="+home)
+		buf, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("%v: %v\nstdout=%s", args, err, buf)
+		}
+		return buf
+	}
+
+	// Build first so the cache exists for the read commands.
+	buildOut := run("graph", "build", "--repo", repo)
+	if err := envelope.Validate(buildOut, "build.v1.json"); err != nil {
+		t.Fatalf("build schema: %v\n%s", err, buildOut)
+	}
+
+	head, base := gitHeadAndPrev(t, repo)
+
+	cases := []struct {
+		name, schema string
+		args         []string
+	}{
+		{"status", "status.v1.json", []string{"graph", "status", "--repo", repo}},
+		{"query.callers_of", "query.v1.json", []string{"graph", "query", "callers_of", "main.go::Greet", "--repo", repo}},
+		{"query.callees_of", "query.v1.json", []string{"graph", "query", "callees_of", "main.go::main", "--repo", repo}},
+		{"query.tests_for", "query.v1.json", []string{"graph", "query", "tests_for", "main.go::Greet", "--repo", repo}},
+		{"query.implementors_of", "query.v1.json", []string{"graph", "query", "implementors_of", "main.go::Speaker", "--repo", repo}},
+		{"query.hubs", "query.v1.json", []string{"graph", "query", "hubs", "--repo", repo, "--threshold", "1"}},
+		{"query.context", "query.v1.json", []string{"graph", "query", "context", "main.go::Greet", "--repo", repo}},
+		{"impact", "impact.v1.json", []string{"graph", "impact", "--repo", repo, "--files", "main.go"}},
+		{"hubs", "hubs.v1.json", []string{"graph", "hubs", "--repo", repo, "--threshold", "1"}},
+		{"context", "context.v1.json", []string{"graph", "context", "--repo", repo, "--id", "main.go::Greet"}},
+		{"detect-changes", "detect_changes.v1.json", []string{"graph", "detect-changes", "--repo", repo, "--base", base, "--head", head}},
+		{"preflight", "preflight.v1.json", []string{"graph", "preflight", "--repo", repo, "--base", base, "--head", head}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw := run(c.args...)
+			if err := envelope.Validate(raw, c.schema); err != nil {
+				t.Fatalf("schema %s: %v\n%s", c.schema, err, raw)
+			}
+			var env map[string]any
+			if err := json.Unmarshal(raw, &env); err != nil {
+				t.Fatal(err)
+			}
+			if env["ok"] != true {
+				t.Errorf("not ok: %v", env)
+			}
+		})
+	}
+
+	// Cover the --all branch of clean separately so the earlier read commands
+	// keep their cache.
+	t.Run("clean", func(t *testing.T) {
+		raw := run("graph", "clean", "--all")
+		if err := envelope.Validate(raw, "clean.v1.json"); err != nil {
+			t.Fatalf("schema: %v\n%s", err, raw)
+		}
+	})
+}
+
+// makeE2EFixture creates a tiny git repo with two commits so detect-changes /
+// preflight have a base..head range to walk.
+func makeE2EFixture(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	mustGitE2E(t, repo, "init", "-q", "-b", "main")
+	mustGitE2E(t, repo, "config", "user.email", "e2e@example.com")
+	mustGitE2E(t, repo, "config", "user.name", "e2e")
+
+	first := `package main
+
+import "fmt"
+
+type Speaker interface{ Speak() string }
+
+func Greet(name string) string { return "hi " + name }
+
+func main() { fmt.Println(Greet("world")) }
+`
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte(first), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGitE2E(t, repo, "add", "main.go")
+	mustGitE2E(t, repo, "commit", "-q", "-m", "init")
+
+	second := strings.Replace(first, `"hi " + name`, `"hello " + name`, 1)
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte(second), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGitE2E(t, repo, "commit", "-q", "-am", "tweak")
+	return repo
+}
+
+func mustGitE2E(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func gitHeadAndPrev(t *testing.T, repo string) (head, base string) {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repo, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	head = strings.TrimSpace(string(out))
+	out, err = exec.Command("git", "-C", repo, "rev-parse", "HEAD~1").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	base = strings.TrimSpace(string(out))
+	return
+}

--- a/internal/graph/envelope/envelope.go
+++ b/internal/graph/envelope/envelope.go
@@ -1,0 +1,80 @@
+// Package envelope defines the uniform JSON output shape used by every
+// `devpilot graph <verb>` subcommand. Downstream skills depend on this exact
+// shape; changes must bump the schema_version constant and add a new schema
+// file under schemas/.
+package envelope
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// SchemaVersion is the wire-protocol version of the envelope.
+const SchemaVersion = "1"
+
+// Envelope is the canonical CLI output shape.
+type Envelope struct {
+	SchemaVersionField  string   `json:"schema_version"`
+	Command             string   `json:"command"`
+	OKFlag              bool     `json:"ok"`
+	Data                any      `json:"data"`
+	Error               *ErrInfo `json:"error"`
+	Warnings            []string `json:"warnings"`
+	NextToolSuggestions []string `json:"next_tool_suggestions"`
+	ElapsedMS           int64    `json:"elapsed_ms"`
+
+	startedAt time.Time
+}
+
+// ErrInfo carries a structured error payload.
+type ErrInfo struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// New starts a builder for the given fully-qualified command (e.g. "graph.preflight").
+func New(command string) *Envelope {
+	return &Envelope{
+		SchemaVersionField:  SchemaVersion,
+		Command:             command,
+		Warnings:            []string{},
+		NextToolSuggestions: []string{},
+		startedAt:           time.Now(),
+	}
+}
+
+// OK marks the envelope as successful and attaches the payload.
+func (e *Envelope) OK(data any) *Envelope {
+	e.OKFlag = true
+	e.Data = data
+	e.Error = nil
+	return e
+}
+
+// Err marks the envelope as failed and clears the payload.
+func (e *Envelope) Err(code, msg string) *Envelope {
+	e.OKFlag = false
+	e.Data = nil
+	e.Error = &ErrInfo{Code: code, Message: msg}
+	return e
+}
+
+// Warn appends a non-fatal warning.
+func (e *Envelope) Warn(msg string) *Envelope {
+	e.Warnings = append(e.Warnings, msg)
+	return e
+}
+
+// Suggest appends one or more next-tool hints.
+func (e *Envelope) Suggest(cmds ...string) *Envelope {
+	e.NextToolSuggestions = append(e.NextToolSuggestions, cmds...)
+	return e
+}
+
+// Marshal finalises elapsed_ms and returns canonical JSON bytes.
+func (e *Envelope) Marshal() ([]byte, error) {
+	if e.ElapsedMS == 0 && !e.startedAt.IsZero() {
+		e.ElapsedMS = time.Since(e.startedAt).Milliseconds()
+	}
+	return json.Marshal(e)
+}

--- a/internal/graph/envelope/envelope_test.go
+++ b/internal/graph/envelope/envelope_test.go
@@ -1,0 +1,70 @@
+package envelope
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewAndOK(t *testing.T) {
+	e := New("graph.status").OK(map[string]any{"foo": "bar"})
+	if !e.OKFlag {
+		t.Fatal("expected ok=true after OK")
+	}
+	if e.Command != "graph.status" {
+		t.Errorf("command=%q", e.Command)
+	}
+	if e.Error != nil {
+		t.Errorf("error should be nil, got %+v", e.Error)
+	}
+}
+
+func TestErr(t *testing.T) {
+	e := New("graph.build").Err("repo_not_found", "no such repo: /tmp/x")
+	if e.OKFlag {
+		t.Fatal("expected ok=false after Err")
+	}
+	if e.Error == nil || e.Error.Code != "repo_not_found" {
+		t.Fatalf("unexpected error: %+v", e.Error)
+	}
+	if e.Data != nil {
+		t.Errorf("data must be nil on error")
+	}
+}
+
+func TestSuggestAppends(t *testing.T) {
+	e := New("graph.detect-changes").OK(nil).Suggest("devpilot graph context --id foo", "devpilot graph preflight")
+	if len(e.NextToolSuggestions) != 2 {
+		t.Fatalf("want 2 suggestions, got %d", len(e.NextToolSuggestions))
+	}
+}
+
+func TestWarnAppends(t *testing.T) {
+	e := New("graph.build").OK(nil).Warn("slow disk")
+	if len(e.Warnings) != 1 || e.Warnings[0] != "slow disk" {
+		t.Fatalf("warnings=%+v", e.Warnings)
+	}
+}
+
+func TestMarshalShape(t *testing.T) {
+	e := New("graph.status").OK(map[string]any{"nodes": 12})
+	b, err := e.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{
+		`"schema_version":"1"`,
+		`"command":"graph.status"`,
+		`"ok":true`,
+		`"data":{"nodes":12}`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in %s", want, s)
+		}
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/graph/envelope/schemas/build.v1.json
+++ b/internal/graph/envelope/schemas/build.v1.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "build.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "properties": {
+    "command": { "const": "graph.build" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["repo", "mode", "files_parsed", "nodes", "edges"],
+          "properties": {
+            "repo": { "type": "string" },
+            "mode": { "enum": ["full", "incremental"] },
+            "files_parsed": { "type": "integer" },
+            "nodes": { "type": "integer" },
+            "edges": { "type": "integer" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/schemas/clean.v1.json
+++ b/internal/graph/envelope/schemas/clean.v1.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "clean.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "properties": {
+    "command": { "const": "graph.clean" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["removed", "all"],
+          "properties": {
+            "removed": { "type": "string" },
+            "all": { "type": "boolean" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/schemas/context.v1.json
+++ b/internal/graph/envelope/schemas/context.v1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "context.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "$defs": {
+    "snippet": {
+      "type": "object",
+      "required": ["id", "path", "start_line", "end_line", "source"],
+      "properties": {
+        "id": { "type": "string" },
+        "path": { "type": "string" },
+        "start_line": { "type": "integer" },
+        "end_line": { "type": "integer" },
+        "source": { "type": "string" }
+      }
+    }
+  },
+  "properties": {
+    "command": { "const": "graph.context" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["context"],
+          "properties": {
+            "context": {
+              "type": "object",
+              "required": ["target", "callers"],
+              "properties": {
+                "target": { "$ref": "#/$defs/snippet" },
+                "callers": { "type": "array", "items": { "$ref": "#/$defs/snippet" } }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/schemas/detect_changes.v1.json
+++ b/internal/graph/envelope/schemas/detect_changes.v1.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "detect_changes.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "properties": {
+    "command": { "const": "graph.detect-changes" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["changed_symbols"],
+          "properties": {
+            "changed_symbols": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["id", "kind", "is_exported", "is_new", "change_type"],
+                "properties": {
+                  "id": { "type": "string" },
+                  "kind": { "type": "string" },
+                  "is_exported": { "type": "boolean" },
+                  "is_new": { "type": "boolean" },
+                  "change_type": { "enum": ["added", "removed", "modified", "renamed"] }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/schemas/embed.go
+++ b/internal/graph/envelope/schemas/embed.go
@@ -1,0 +1,10 @@
+// Package schemas embeds the JSON-schema files that the envelope validator
+// consults. New schemas land in this directory and are picked up automatically.
+package schemas
+
+import "embed"
+
+// FS holds every *.json schema shipped with the envelope package.
+//
+//go:embed *.json
+var FS embed.FS

--- a/internal/graph/envelope/schemas/envelope.v1.json
+++ b/internal/graph/envelope/schemas/envelope.v1.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "envelope.v1.json",
+  "type": "object",
+  "required": ["schema_version", "command", "ok", "data", "error", "warnings", "next_tool_suggestions", "elapsed_ms"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "command": { "type": "string", "pattern": "^graph\\.[a-z_-]+$" },
+    "ok": { "type": "boolean" },
+    "data": {},
+    "error": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["code", "message"],
+          "properties": {
+            "code": { "type": "string" },
+            "message": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "warnings": { "type": "array", "items": { "type": "string" } },
+    "next_tool_suggestions": { "type": "array", "items": { "type": "string" } },
+    "elapsed_ms": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/internal/graph/envelope/schemas/hubs.v1.json
+++ b/internal/graph/envelope/schemas/hubs.v1.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "hubs.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "properties": {
+    "command": { "const": "graph.hubs" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["hubs"],
+          "properties": {
+            "hubs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["id", "caller_count"],
+                "properties": {
+                  "id": { "type": "string" },
+                  "caller_count": { "type": "integer" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/schemas/impact.v1.json
+++ b/internal/graph/envelope/schemas/impact.v1.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "impact.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "properties": {
+    "command": { "const": "graph.impact" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["changed_symbols", "callers"],
+          "properties": {
+            "changed_symbols": { "type": "array", "items": { "type": "string" } },
+            "callers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["id", "hop"],
+                "properties": {
+                  "id": { "type": "string" },
+                  "hop": { "type": "integer" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/schemas/preflight.v1.json
+++ b/internal/graph/envelope/schemas/preflight.v1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "preflight.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "properties": {
+    "command": { "const": "graph.preflight" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["mode", "graph", "changed_symbols", "cross_community_edges", "risk_summary", "truncated_symbols"],
+          "properties": {
+            "mode": { "type": "string" },
+            "graph": {
+              "type": "object",
+              "required": ["freshness", "languages", "skipped_files"],
+              "properties": {
+                "freshness": {
+                  "type": "object",
+                  "required": ["covers_base_sha", "stale_files"],
+                  "properties": {
+                    "covers_base_sha": { "type": "boolean" },
+                    "stale_files": { "type": "integer" }
+                  }
+                },
+                "languages": { "type": ["array", "null"], "items": { "type": "string" } },
+                "skipped_files": { "type": ["array", "null"], "items": { "type": "string" } }
+              }
+            },
+            "changed_symbols": { "type": ["array", "null"] },
+            "cross_community_edges": { "type": ["array", "null"] },
+            "risk_summary": { "type": "object" },
+            "truncated_symbols": { "type": ["array", "null"], "items": { "type": "string" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/schemas/query.v1.json
+++ b/internal/graph/envelope/schemas/query.v1.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "query.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "properties": {
+    "command": { "const": "graph.query" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["pattern", "pattern_result"],
+          "properties": {
+            "pattern": {
+              "enum": ["callers_of", "callees_of", "tests_for", "implementors_of", "hubs", "context"]
+            },
+            "pattern_result": { "type": "object" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/schemas/status.v1.json
+++ b/internal/graph/envelope/schemas/status.v1.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "status.v1.json",
+  "allOf": [{ "$ref": "envelope.v1.json" }],
+  "properties": {
+    "command": { "const": "graph.status" },
+    "data": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["repo", "head_sha", "languages", "nodes", "edges", "built_at_unix"],
+          "properties": {
+            "repo": { "type": "string" },
+            "head_sha": { "type": "string" },
+            "languages": { "type": "array", "items": { "type": "string" } },
+            "nodes": { "type": "integer" },
+            "edges": { "type": "integer" },
+            "built_at_unix": { "type": "integer" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/graph/envelope/validate.go
+++ b/internal/graph/envelope/validate.go
@@ -1,0 +1,66 @@
+package envelope
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+
+	"github.com/siyuqian/devpilot/internal/graph/envelope/schemas"
+)
+
+var (
+	compilerOnce sync.Once
+	compiler     *jsonschema.Compiler
+	compileErr   error
+)
+
+func loadCompiler() (*jsonschema.Compiler, error) {
+	compilerOnce.Do(func() {
+		c := jsonschema.NewCompiler()
+		entries, err := fs.ReadDir(schemas.FS, ".")
+		if err != nil {
+			compileErr = fmt.Errorf("read schemas dir: %w", err)
+			return
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			data, err := fs.ReadFile(schemas.FS, e.Name())
+			if err != nil {
+				compileErr = fmt.Errorf("read %s: %w", e.Name(), err)
+				return
+			}
+			if err := c.AddResource(e.Name(), bytes.NewReader(data)); err != nil {
+				compileErr = fmt.Errorf("add resource %s: %w", e.Name(), err)
+				return
+			}
+		}
+		compiler = c
+	})
+	return compiler, compileErr
+}
+
+// Validate parses raw JSON and asserts it conforms to the schema with the given $id.
+func Validate(raw []byte, schemaID string) error {
+	c, err := loadCompiler()
+	if err != nil {
+		return err
+	}
+	sch, err := c.Compile(schemaID)
+	if err != nil {
+		return fmt.Errorf("compile %s: %w", schemaID, err)
+	}
+	var doc any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	if err := sch.Validate(doc); err != nil {
+		return fmt.Errorf("validate %s: %w", schemaID, err)
+	}
+	return nil
+}

--- a/internal/graph/envelope/validate_test.go
+++ b/internal/graph/envelope/validate_test.go
@@ -1,0 +1,41 @@
+package envelope
+
+import (
+	"testing"
+)
+
+func TestValidateAcceptsValidStatus(t *testing.T) {
+	e := New("graph.status").OK(map[string]any{
+		"repo":          "/tmp/r",
+		"nodes":         10,
+		"edges":         20,
+		"built_at_unix": 1,
+		"head_sha":      "deadbeef",
+		"languages":     []string{"go"},
+	})
+	b, _ := e.Marshal()
+	if err := Validate(b, "status.v1.json"); err != nil {
+		t.Fatalf("want valid, got %v\n%s", err, b)
+	}
+}
+
+func TestValidateRejectsMissingCommand(t *testing.T) {
+	bad := []byte(`{"schema_version":"1","ok":true,"data":null,"error":null,"warnings":[],"next_tool_suggestions":[],"elapsed_ms":0}`)
+	if err := Validate(bad, "envelope.v1.json"); err == nil {
+		t.Fatal("want error for missing command field")
+	}
+}
+
+func TestValidateUnknownSchema(t *testing.T) {
+	if err := Validate([]byte(`{}`), "no_such.json"); err == nil {
+		t.Fatal("want error for unknown schema id")
+	}
+}
+
+func TestValidateRejectsBadCommandPattern(t *testing.T) {
+	e := New("not.graph").OK(nil)
+	b, _ := e.Marshal()
+	if err := Validate(b, "envelope.v1.json"); err == nil {
+		t.Fatal("want pattern violation")
+	}
+}

--- a/internal/graph/store/store.go
+++ b/internal/graph/store/store.go
@@ -277,6 +277,24 @@ func (s *Store) CountEdgesByKind(dst, kind string) (int, error) {
 	return n, nil
 }
 
+// CountNodes returns the total number of node rows.
+func (s *Store) CountNodes() (int, error) {
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("CountNodes: %w", err)
+	}
+	return n, nil
+}
+
+// CountEdges returns the total number of edge rows.
+func (s *Store) CountEdges() (int, error) {
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM edges`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("CountEdges: %w", err)
+	}
+	return n, nil
+}
+
 // HubsByCalls returns dst IDs with at least minCallers inbound `calls` edges,
 // ordered by caller count descending then id ascending for determinism.
 func (s *Store) HubsByCalls(minCallers int) ([]struct {


### PR DESCRIPTION
## Summary

Exposes the Phase 3 `internal/graph/query` package as `devpilot graph <verb>` subcommands. Every command emits one JSON document on stdout shaped by a uniform envelope, validated against a versioned schema embedded in the binary.

Continues the graph subsystem after #108 (parser/store), #109 (multi-language + cache), #110 (query layer). See [Phase 4 plan](docs/plans/2026-05-20-devpilot-graph-phase4-plan.md).

## What changed

- **`internal/graph/envelope/`** — `Envelope` builder (`New`, `OK`, `Err`, `Suggest`, `Warn`, `Marshal`) and a `jsonschema/v5`-backed `Validate(raw, schemaID)`. Schemas are embedded via `//go:embed *.json` and lazily compiled once.
- **9 subcommands** wired from `internal/graph/commands.go` per the CLAUDE.md convention (no central `cli/` router; one `commands.go` per domain):
  - `build [repo]`, `status`, `clean (--repo | --all)`
  - `query <pattern> [target]` — 6 v1 patterns: `callers_of`, `callees_of`, `tests_for`, `implementors_of`, `hubs`, `context`
  - `impact --files`, `hubs --threshold`, `context --id` (thin flag-driven wrappers)
  - `detect-changes --base --head`, `preflight --base --head` — composites with populated `next_tool_suggestions`
- **9 v1 schemas** under `internal/graph/envelope/schemas/`, each `allOf`-merging `envelope.v1.json` with a command-specific `data` shape.
- **`store.CountNodes` / `store.CountEdges`** — small helpers needed by `graph status`.
- **`cmd/devpilot/main.go`** — exactly one new line: `graph.RegisterCommands(rootCmd)`.
- **New dep**: `github.com/santhosh-tekuri/jsonschema/v5 v5.3.1`.

## Envelope shape

```jsonc
{
  "schema_version": "1",
  "command": "graph.preflight",
  "ok": true,
  "data": { /* command-specific */ },
  "error": null,
  "warnings": [],
  "next_tool_suggestions": ["devpilot graph context --id ..."],
  "elapsed_ms": 142
}
```

On error: `ok=false`, `data=null`, `error={code,message}`, exit code 1.

## Review Guide

Start with **`internal/graph/envelope/envelope.go`** (40 lines) and **`internal/graph/envelope/validate.go`** to see the contract — everything else feeds it. Then read **`internal/graph/commands.go`** for the cobra wiring (intentionally thin), and pick any one of the `cli_*.go` files to see the shape (they are all structurally identical: resolve repo → open store → call query func → emit envelope).

Things to watch:

- **PascalCase vs snake_case.** The existing `query.Caller/Callee/Hub/Snippet` types have no JSON tags, so I wrap them into `map[string]any` with explicit snake_case keys in `cli_query.go` (`callersToMaps`, `hubsToMaps`, `contextToMap`, etc.). `query.PreflightResult` already has json tags so `cli_preflight.go` passes it through directly.
- **Schema strictness.** Each command schema requires its `data` keys when `data` is non-null but allows `data: null` on errors so the same schema validates both the success and error envelopes. See the `oneOf` in any `*.v1.json`.
- **`emit()` (`cli_helpers.go`)** validates *before* printing; a schema violation goes to stderr and returns exit 1. This is the safety net — if anyone changes a payload shape without updating the schema, the e2e test fails loudly.
- **`graph clean --all`** wipes `\$DEVPILOT_HOME/graphs` for *every* repo. Only enter that branch when the explicit flag is set; otherwise require `--repo`.

## Test plan

- [x] `make test` — 125 unit tests across `internal/graph/...` (envelope builder, validator, build/helpers).
- [x] `go test -tags=e2e ./internal/graph/` — `e2e_test.go` builds the real binary, creates a temp git repo with two commits, then exercises every subcommand + every `query` pattern via `os/exec`, validating each stdout against its schema. 14 cases pass.
- [x] `make lint` — clean.
- [x] Live smoke against this repo:
  - `devpilot graph build --repo .` → ok, 756 nodes / 5866 edges in 62ms.
  - `devpilot graph status --repo .` → ok, languages `[go javascript rust typescript]`.
  - `devpilot graph hubs --repo . --threshold 3` → ok, returns the expected high-fanin externals.
  - `devpilot graph query callers_of <id>` → ok.

## For reviewers (human)

- [ ] Confirm the envelope shape is what downstream skills want (Phase 6 will call this).
- [ ] Sanity-check that the `oneOf null | object` pattern in every schema doesn't relax validation more than intended.
- [ ] `preflight.v1.json` is intentionally lenient on inner shapes (e.g. `changed_symbols: array`) because the §6 payload is large; tighten in a follow-up if you want stricter checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)