### PR TITLE
fix(graph): count native Go files in FullBuild files_parsed

### DIFF
--- a/internal/graph/cache/builder.go
+++ b/internal/graph/cache/builder.go
@@ -220,7 +220,7 @@ func (b *Builder) FullBuild() (BuildResult, error) {
 	}
 
 	return BuildResult{
-		FilesParsed: len(files),
+		FilesParsed: len(files) + len(nativeResults),
 		NodesInsert: len(allNodes),
 		EdgesInsert: len(allEdges),
 		Mode:        "full",


### PR DESCRIPTION
## Summary

`FullBuild` in `internal/graph/cache/builder.go` strips `.go` files out of the per-file fanout (they get parsed in bulk via `loadGoModule` into `nativeResults`), but the returned `BuildResult.FilesParsed` only counted `len(files)` — the non-Go remainder. The `graph.build` envelope therefore underreported `files_parsed` for any repo containing Go.

On this repo the symptom was:

```
$ devpilot graph build --repo .
{"files_parsed":8, "nodes":761, "edges":1991, ...}
```

…despite 120+ `.go` files. After the fix the same repo reports `files_parsed: 128` with `nodes`/`edges` unchanged — confirming the graph was always correct and only the counter was wrong.

## Change

One-liner in `FullBuild`:

```go
- FilesParsed: len(files),
+ FilesParsed: len(files) + len(nativeResults),
```

## Review Guide

- Start at `internal/graph/cache/builder.go:222-227` — the only changed lines.
- Context for *why* `files` doesn't already contain Go: lines 122-130 strip them after `loadGoModule` populates `nativeResults`.
- Out of scope (not changed in this PR): the same accounting question for `BuildIncremental` at `incremental.go:201-206`. `newResults` semantics there are different (it's the slice that was actually re-parsed this run); worth a separate look but not touched here.

## Test plan

- [x] `go test ./internal/graph/...` — 138 passed
- [x] Manual: `devpilot graph clean --repo . && devpilot graph build --repo .` reports `files_parsed: 128` (was `8`); `nodes`/`edges` unchanged at `761` / `1991`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)