### PR TITLE
fix(release): native CGO matrix build for tree-sitter binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
             goarch: amd64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -40,7 +40,7 @@ jobs:
           OUT=devpilot-${{ matrix.goos }}-${{ matrix.goarch }}
           go build -ldflags "-X main.version=${VERSION}" -o "${OUT}" ./cmd/devpilot
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: devpilot-${{ matrix.goos }}-${{ matrix.goarch }}
           path: devpilot-${{ matrix.goos }}-${{ matrix.goarch }}
@@ -50,7 +50,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,20 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            goos: darwin
+            goarch: arm64
+          - runner: macos-13
+            goos: darwin
+            goarch: amd64
+          - runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
@@ -17,18 +30,37 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build binaries
+      - name: Build binary
+        env:
+          CGO_ENABLED: "1"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
         run: |
           VERSION=${{ github.event.release.tag_name }}
-          LDFLAGS="-X main.version=${VERSION}"
-          GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o devpilot-darwin-arm64 ./cmd/devpilot
-          GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o devpilot-darwin-amd64 ./cmd/devpilot
-          GOOS=linux  GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o devpilot-linux-amd64  ./cmd/devpilot
+          OUT=devpilot-${{ matrix.goos }}-${{ matrix.goarch }}
+          go build -ldflags "-X main.version=${VERSION}" -o "${OUT}" ./cmd/devpilot
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: devpilot-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: devpilot-${{ matrix.goos }}-${{ matrix.goarch }}
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
       - name: Generate checksums
+        working-directory: dist
         run: sha256sum devpilot-* > checksums.txt
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.event.release.tag_name }} devpilot-* checksums.txt
+        working-directory: dist
+        run: gh release upload ${{ github.event.release.tag_name }} devpilot-* checksums.txt --repo ${{ github.repository }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,23 +10,23 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.8.0
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -34,7 +34,7 @@ jobs:
         run: go test -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -4,7 +4,7 @@ Parked items not scheduled. Promote to an active exec-plan (`docs/exec-plans/act
 
 ## Open
 
-- _empty_
+- 2026-05-21 — TS/JS parser pinned to `smacker/go-tree-sitter` (CGO, upstream in maintenance mode), which forces the release pipeline to do a per-platform CGO matrix build. Migrate to official `tree-sitter/go-tree-sitter` v0.25+ (mechanical rename) when convenient; re-evaluate going CGO-free once `malivvan/tree-sitter` (wazero+WASM) tags v1 or `microsoft/typescript-go` exposes a stable AST. Not scheduled — matrix release unblocks shipping today.
 
 ## Closed
 


### PR DESCRIPTION
## Summary
- v0.18.1 release failed because release.yml cross-compiles with default `CGO_ENABLED=0`, but `internal/graph/parser/{typescript,javascript,rust}.go` still depend on `smacker/go-tree-sitter`, whose `iter.go` references CGO-only `Node` types (`undefined: Node`). Background: the Go parser was migrated to a native AST backend (#112, #113) but TS/JS/Rust still need tree-sitter.
- Switch release to a native build matrix: `macos-14` → darwin/arm64, `macos-13` → darwin/amd64, `ubuntu-latest` → linux/amd64. Each builds with `CGO_ENABLED=1`, uploads its artifact, and a `publish` job aggregates, checksums, and uploads to the release.
- Logged the tree-sitter CGO coupling in `docs/exec-plans/tech-debt-tracker.md` — revisit going CGO-free once a maintained wazero/WASM tree-sitter binding (e.g. `malivvan/tree-sitter`) ships v1, or `microsoft/typescript-go` exposes a stable AST.

## Test plan
- [ ] Cut a fresh draft release tag and confirm all three artifacts + `checksums.txt` upload.
- [ ] Sanity-check each downloaded binary runs (`devpilot --version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)