### PR TITLE
fix(release): drop macos-13 (darwin/amd64) from matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ jobs:
           - runner: macos-14
             goos: darwin
             goarch: arm64
-          - runner: macos-13
-            goos: darwin
-            goarch: amd64
           - runner: ubuntu-latest
             goos: linux
             goarch: amd64


### PR DESCRIPTION
## Summary
- v0.18.2 release hung on the `build (macos-13, darwin, amd64)` job — no log was produced, indicating GitHub couldn't schedule the runner (macos-13 has been deprecated since late 2024/2025 and is effectively retired in 2026).
- Drop darwin/amd64 from the release matrix. Apple has only shipped Apple Silicon Macs since November 2020 — modern user base is arm64. Intel users can build from source until demand justifies adding cross-compile.
- Future option: if Intel coverage matters again, cross-compile amd64 on the macos-14 ARM runner with `CC="clang -arch x86_64" CGO_ENABLED=1 GOARCH=amd64`.

## Test plan
- [x] Cut a fresh release tag; confirm `build (macos-14)` + `build (ubuntu-latest)` both succeed and `publish` uploads two binaries + checksums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)