### PR TITLE
feat(pr-review): integrate devpilot graph preflight as review fact-bed

### DIFF
--- a/skills/devpilot-pr-review/SKILL.md
+++ b/skills/devpilot-pr-review/SKILL.md
@@ -40,8 +40,9 @@ Every finding tied to a specific line goes in as an inline review comment, never
 ```
 0. Eligibility gate         → references/eligibility.md
 1. Load PR                  → gh / git / pasted patch
+1.5 Graph enrichment        → references/graph.md (preflight once; fallback OK)
 2. Parallel fanout          → references/fanout.md (5 subagents, parallel)
-3. Filter + merge           → references/confidence.md (threshold 70, dedupe)
+3. Filter + merge + reconcile against graph → references/confidence.md
 4. Draft review             → references/template.md + style.md
 5. Post one combined POST   → references/posting.md
 Self-check before post      → references/rationalizations.md
@@ -65,6 +66,12 @@ gh pr diff <url>
 
 Or `git diff <base>...HEAD` for a local branch, or read a pasted patch directly. Capture the **head SHA** — link rendering depends on it (see `references/posting.md`). A PR with no stated intent is itself a finding.
 
+### 1.5. Graph enrichment
+
+Run `devpilot graph preflight --base <base-sha> --head <head-sha>` once. Cache the JSON to `/tmp/pr_review_graph.json` and inject it into the shared header that every fanout brief sees. The payload tells subagents — before they read any code — which symbols changed, who calls each, which are hubs, which lack tests, and which cross-community edges this PR adds. Agent A's blast-radius answer comes from this payload, not from grep.
+
+If the graph cache is missing, the language is unsupported, or preflight fails, **fall back** to the grep-only path and note `Behavior trace: grep-only (graph unavailable: <reason>)` in the body's sweep summary. Do not auto-run `devpilot graph build`. See `references/graph.md` for the full payload schema, fallback triggers, and confidence-weighting rules.
+
 ### 2. Parallel fanout (5 subagents)
 
 Dispatch all five in a single message so they run in parallel. Each receives the PR metadata, the diff, and one focused brief. Each returns findings with `Confidence: 0–100` and `Severity`. See `references/fanout.md` for the prompts.
@@ -85,6 +92,7 @@ The main session does NOT also do these passes itself. Subagent context savings 
 
 Apply the rubric in `references/confidence.md`:
 
+- **Reconcile against the graph payload** (see `references/graph.md` → "Confidence weighting"): findings whose blast-radius claim is corroborated by `changed_symbols[].callers` have their confidence floor raised to 85; findings contradicted by the graph (claimed caller doesn't exist; "hub" claim when `in_hub:false`) are capped at 50 — which drops them under the threshold.
 - Drop findings with `Confidence < 70`.
 - Drop findings that match the false-positive list in `references/eligibility.md` (pre-existing issues, lines the PR did not modify, linter/typechecker-catchable, ignored-by-comment, **already raised by an existing review comment at the same anchor**, etc.). The existing-comments file from step 0 is the source of truth for the duplicate check.
 - Dedupe across agents (same line, same defect → one inline comment, take the higher confidence).
@@ -111,8 +119,9 @@ Before posting, walk `references/rationalizations.md` self-check.
 | File | What's in it |
 |---|---|
 | `references/eligibility.md` | Gate rules + false-positive list (when to skip review entirely, what to never flag). |
-| `references/fanout.md` | Five subagent prompts (Behavior, Bug scan, CLAUDE.md, Git history, In-file comments). |
-| `references/confidence.md` | 0–100 rubric, threshold 70, severity vs. confidence axes, dedupe rules. |
+| `references/graph.md` | `devpilot graph preflight` payload schema, fallback triggers, confidence-weighting rules consumed by step 3. |
+| `references/fanout.md` | Five subagent prompts (Behavior, Bug scan, CLAUDE.md, Git history, In-file comments) — all receive the graph payload. |
+| `references/confidence.md` | 0–100 rubric, threshold 70, severity vs. confidence axes, dedupe rules, graph reconciliation. |
 | `references/unknown-unknowns.md` | Behavior sweep details — Agent A's playbook. |
 | `references/checklist.md` | Quality dimensions referenced by Agent B's bug scan and Agent A's checklist tail. |
 | `references/template.md` | Inline comment template + review body template (Verdict, Strengths, sweep, counts). |

--- a/skills/devpilot-pr-review/references/confidence.md
+++ b/skills/devpilot-pr-review/references/confidence.md
@@ -51,19 +51,30 @@ The inline comment template (`template.md`) shows `Confidence: high | medium | l
 
 The numeric score is internal to the fanout pipeline. The label is what the PR author sees.
 
+## Graph reconciliation (before filtering)
+
+When `references/graph.md` produced a preflight payload (mode=`built`), each finding is reconciled against it before the threshold filter runs:
+
+- **Corroborated** — the finding cites a symbol whose `changed_symbols[].callers` / `risk_factors` match the defect (e.g. "this exported function's caller in package X doesn't update for the new contract" and the named caller is in `callers.sample`). Confidence floor raised to 85, cap stays at 95 unless the diff itself shows literal-string evidence.
+- **Contradicted** — the finding asserts a caller relationship or hub status the graph denies (named caller absent from `callers.sample`; "this is a hub" with `in_hub:false`; "no tests" with `tests.has_tests:true`). Confidence capped at 50.
+- **Unsupported** — finding sits outside graph coverage (no symbol match, or `mode != "built"`). Original score stands; do not boost or penalize.
+
+A finding both corroborated on one dimension and contradicted on another takes the more conservative outcome (cap at 50).
+
 ## Merge procedure (after the fanout returns)
 
 1. **Collect** all findings from agents A–E into one list.
-2. **Filter:**
+2. **Reconcile** against `GRAPH_PREFLIGHT` per the section above (skip if graph fell back).
+3. **Filter:**
    - Drop `confidence < 70` (or the user-overridden threshold).
    - Drop anything matching the false-positive list in `eligibility.md`.
-3. **Dedupe:**
+4. **Dedupe:**
    - Same `(path, line)` and same defect class from multiple agents → one finding. Keep the highest confidence; merge the fixes if they differ.
    - **Same defect across multiple lines or files** (e.g. four files all log the same secret) → **one consolidated inline comment** anchored to the worst/most-representative occurrence. List the other `path:line` locations inside the comment body as a short bullet list (`Same defect also at: a.go:42, b.go:91, c.go:30`). Also note the recurrence count in the body sweep summary under "Blast radius". Do NOT post one near-identical comment per file — that is the noise inline-first is meant to avoid.
-4. **Anchor:**
+5. **Anchor:**
    - Every surviving finding needs `(path, line, side)`. Cross-cutting findings (e.g. "this PR has no tests") anchor to the most representative line — the new function's signature, the first new line of the changed file. The comment body MUST say so.
-5. **Count** by severity. The counts go in the body.
-6. **Derive the review event** (`REQUEST_CHANGES` / `COMMENT` / `APPROVE`) from the highest-severity surviving finding. See `posting.md` → "Event mapping".
+6. **Count** by severity. The counts go in the body.
+7. **Derive the review event** (`REQUEST_CHANGES` / `COMMENT` / `APPROVE`) from the highest-severity surviving finding. See `posting.md` → "Event mapping".
 
 ## What to do when the fanout returns nothing
 

--- a/skills/devpilot-pr-review/references/fanout.md
+++ b/skills/devpilot-pr-review/references/fanout.md
@@ -1,6 +1,20 @@
 # Parallel Fanout: Five Subagent Briefs
 
-Dispatch all five subagents in a **single message with five parallel Task calls** so they run concurrently. Each subagent gets the same PR header (URL, title, head SHA, base SHA, files changed list, full diff) and one focused brief from this file.
+Dispatch all five subagents in a **single message with five parallel Task calls** so they run concurrently. Each subagent gets the same PR header (URL, title, head SHA, base SHA, files changed list, full diff) **plus the graph preflight payload** (or the `graph_unavailable: <reason>` marker if step 1.5 fell back) and one focused brief from this file.
+
+## Shared graph header (injected into every brief)
+
+When graph is available, the dispatch prepends this block to every Agent's prompt:
+
+```
+GRAPH_PREFLIGHT (authoritative for callers, hubs, untested public surface):
+- changed_symbols: <id, kind, is_exported, callers.count, callers.sample[], in_hub, tests.has_tests, risk_factors[]>
+- cross_community_edges: <from → to, count_added, samples[]>
+- risk_summary: <hub_nodes_modified, untested_public_changes, interface_changes, new_cross_community_edges>
+Source of truth for "who calls X" and "is X a hub". Do NOT re-derive these via grep.
+```
+
+When graph fell back, the block instead reads `graph_unavailable: <reason>; use grep, expect lower confidence on blast-radius claims`. See `references/graph.md` for the full payload schema and fallback rules.
 
 Each subagent returns a JSON-ish list of findings:
 
@@ -28,23 +42,24 @@ You are reviewing a pull request for behavior-level defects. Your job is the fiv
 **Inputs:**
 - PR URL, title, body, head SHA, base SHA, files changed.
 - Full diff (`gh pr diff <url>`).
+- The shared graph preflight payload (above) — authoritative for callers / hubs / untested surface.
 
 **Process:**
 1. Read the diff end-to-end. Then read the full files touched (not just the hunks).
 2. Run the five blind-spot questions from `references/unknown-unknowns.md`:
    1. Local pattern fit
-   2. Blast radius (grep callers of every exported symbol changed)
+   2. **Blast radius — consume `GRAPH_PREFLIGHT.changed_symbols[].callers` directly.** For each exported / behaviorally-modified symbol, list every caller from the payload, check each in turn against the change, and ask: does this caller still satisfy its contract after the change? Only fall back to grep if the shared header says `graph_unavailable`, or if the change involves reflection / codegen / string-keyed dispatch the static graph cannot see — name the reason explicitly. A symbol with `risk_factors: ["untested_public"]` is a Should-fix finding by itself. A symbol with `callers.in_hub: true` escalates severity for any behavior change.
    3. Known pitfalls for this change class (auth, concurrency, migration, DB query, retry, cache, LLM, input boundary, data write, reversibility)
    4. Stale-training check (verify versions in `go.mod`/`package.json`)
    5. Hand-rolled vs. off-the-shelf (search repo + deps for existing utilities)
-3. Trace at least one golden-path input and one edge-case input through the change. Record the observable behavior delta.
-4. Produce a one-line summary per question for the body (`### Unknown-Unknowns Sweep` section). Concrete defects discovered during the sweep ALSO become individual findings anchored to lines.
+3. Trace at least one golden-path input and one edge-case input through the change. Record the observable behavior delta. Use `GRAPH_PREFLIGHT.cross_community_edges` to spot whether this PR newly widens a package boundary — a Consider-level finding when unexpected.
+4. Produce a one-line summary per question for the body (`### Unknown-Unknowns Sweep` section). Concrete defects discovered during the sweep ALSO become individual findings anchored to lines. The blast-radius line MUST cite the caller count from the graph payload (or say `grep-only fallback` with the reason).
 
 **Output:** Findings list (one per concrete defect) + a `sweep_summary` block with five lines (one per question).
 
 **Confidence calibration:**
 - 100: literal-string evidence in the diff (e.g. "log statement leaks the token").
-- 85–95: traced through code on this branch; you opened the relevant files.
+- 85–95: traced through code on this branch; you opened the relevant files. Findings whose caller chain is corroborated by `GRAPH_PREFLIGHT` start at this floor.
 - 70–84: defect inferred from a clear pattern, but you didn't trace every path.
 - 50–69: plausible but you couldn't open the caller/test that would confirm.
 - < 50: speculation. Drop unless you can raise confidence.

--- a/skills/devpilot-pr-review/references/graph.md
+++ b/skills/devpilot-pr-review/references/graph.md
@@ -1,0 +1,108 @@
+# Graph Enrichment (`devpilot graph preflight`)
+
+Graph is the **fact bed** under the fanout. It does not produce findings on its own. It tells every subagent, before they read code, exactly which symbols this PR changed, who calls them, whether any of them are hubs, and which public surface lacks tests. Subagents stop guessing about blast radius; the main session can corroborate or contradict findings against ground truth.
+
+Pre-fanout, run the preflight once. Inject the result into the shared header that every Agent A–E brief sees. Subagents do **not** call `devpilot graph` themselves — they consume the structured payload.
+
+## When to use
+
+Run preflight whenever the PR touches code in a language the graph supports (Go, TypeScript/JavaScript, Rust at time of writing). Skip the optional follow-ups (`graph context`, `graph impact`) unless a specific finding requires deeper trace.
+
+## Command
+
+```bash
+bin/devpilot graph preflight --base <base-sha> --head <head-sha>
+```
+
+For an incremental re-review (see eligibility.md), pass `--base <last_reviewed_sha> --head <head_sha>` instead of PR base.
+
+Cache the JSON to `/tmp/pr_review_graph.json`.
+
+## Fallback triggers (skip graph, fall through to grep)
+
+Skip preflight and tell the body why if **any** of:
+
+- `data.mode != "built"` in the payload (graph cache missing, build failed, language unsupported).
+- Repo has no graph cache and `devpilot graph status` returns `ok:false`.
+- Preflight exits non-zero or takes > 30 s.
+- PR touches only unsupported languages (e.g. Python-only, shell-only, docs-only).
+
+Do **not** auto-run `devpilot graph build` — the build can be slow and the user may not want it triggered by a review. Note the fallback in the body's sweep summary: `Behavior trace: grep-only (graph unavailable: <reason>)`.
+
+## Payload — what each field means for the review
+
+```jsonc
+{
+  "data": {
+    "mode": "built",                       // or "fallback" → skip graph; see above
+    "graph": { "freshness": { "covers_base_sha": true, "stale_files": 0 } },
+    "changed_symbols": [
+      {
+        "id": "internal/auth/oauth.go::StartFlow",
+        "kind": "function",
+        "is_exported": true,
+        "change_type": "modified",
+        "callers": { "count": 2, "in_hub": false,
+                     "sample": ["internal/gmail/service.go::Service.Login", ...] },
+        "tests": { "has_tests": false, "test_symbols": [] },
+        "community": "internal/auth",
+        "risk_factors": ["untested_public"]
+      }
+    ],
+    "cross_community_edges": [
+      { "from": "internal/gmail", "to": "internal/auth",
+        "count_added": 7, "samples": ["..."] }
+    ],
+    "risk_summary": {
+      "hub_nodes_modified": 0,
+      "untested_public_changes": 15,
+      "interface_changes": 0,
+      "new_cross_community_edges": 8
+    }
+  }
+}
+```
+
+| Field | What Agent A–E does with it |
+|---|---|
+| `changed_symbols[].callers` | Agent A's blast-radius answer. Authoritative. Skip the grep step. |
+| `changed_symbols[].callers.in_hub` | If `true`, Agent A escalates that symbol's review and notes it in `sweep_summary.blast_radius`. |
+| `changed_symbols[].tests` | Agent A and Agent B both consult. `has_tests:false` on an exported behavior change is a Should-fix finding. |
+| `changed_symbols[].risk_factors` | `untested_public`, `hub`, `interface_change` — each gates a specific finding pattern. |
+| `cross_community_edges` | Agent A's "is this PR widening the contract between two packages?" question. New cross-community edges in an internal-only PR are a Consider-level finding. |
+| `risk_summary.untested_public_changes` | Aggregate count for the body's sweep summary. |
+| `risk_summary.interface_changes` | If > 0, Agent A traces implementors via `graph context --id <iface>`. |
+
+## Confidence weighting (consumed by `confidence.md` merge step)
+
+After the fanout returns, the main session reconciles each finding against the graph payload:
+
+- **Corroborated** — the finding names a symbol whose callers/risk_factors match the defect. Confidence floor raised to 85. (Cap stays at 95 unless literal-string evidence pushes it to 100.)
+- **Contradicted** — the finding asserts "X calls Y" but graph shows Y has zero callers, or asserts "this is a hub" but `in_hub:false`. Confidence capped at 50, which drops it under the default threshold.
+- **Unsupported** — finding sits outside the graph's coverage (no symbol match, or graph in fallback mode). No adjustment. Original score stands.
+
+A finding can be both corroborated on one dimension and contradicted on another — take the more conservative outcome.
+
+## Optional follow-ups
+
+Used only when a specific surviving finding needs a deeper trace; not run by default.
+
+```bash
+bin/devpilot graph context --id <symbol-id> --depth 1   # source + immediate callers/callees
+bin/devpilot graph impact  --files <path,path>          # caller union for symbols defined in files
+```
+
+Output is appended to the inline comment as evidence, not posted as a separate finding.
+
+## Known noise patterns
+
+- `change_type: "modified"` is line-overlap based. A struct or function can be marked modified when only neighboring lines shifted; its body may not have changed. Confirm against the diff before treating as a behavior change.
+- `callers.count: 0` means "no static caller in indexed languages". Reflection, codegen, RPC, CLI dispatch tables, and test main files are invisible. Spot-check with one grep before calling something dead code.
+- `risk_factors: ["untested_public"]` is a useful trigger but does not by itself constitute a finding — combine with a concrete contract change in the diff.
+
+## What graph does NOT do
+
+- It does not judge style, naming, comments, or CLAUDE.md compliance — those stay with Agents C and E.
+- It does not catch logic bugs inside a function body — that is Agent B.
+- It does not know dynamic dispatch beyond what the static graph records. Reflection, codegen, RPC, and string-keyed dispatch are invisible. Cross-reference Agent A's grep sweep when the change involves any of those.
+- It does not replace reading the code. It removes the "did I miss a caller?" anxiety so subagents spend their tokens on judgment, not enumeration.

--- a/skills/devpilot-pr-review/references/rationalizations.md
+++ b/skills/devpilot-pr-review/references/rationalizations.md
@@ -37,6 +37,10 @@ Common shortcuts the reviewer may reach for, and what to do instead. The "Realit
 | "Disclaimer feels defensive, I'll skip or shorten it." | Keep the disclaimer. It protects authors from treating AI findings as authoritative. |
 | "I'll ask 'what happens when X?' so the author clarifies." | If the code can answer it, state the answer. Author questions live in Open Questions only. |
 | "I have a better approach but I'll stay neutral." | Name it, one sentence on why, ask the author to confirm. |
+| "Graph says this symbol has 0 callers — must be dead code, skip it." | `callers.count: 0` means *no static caller in the indexed languages*. Reflection, codegen, RPC, CLI dispatch tables, and test main files are invisible to the graph. Confirm with one grep before claiming dead code. |
+| "Graph says change_type=modified, so the symbol's behavior changed." | `change_type` is line-overlap based; neighboring edits can mark a struct/function "modified" without changing its shape. Diff the symbol body before treating it as a behavior change. |
+| "Graph is unavailable, so I'll skip the blast-radius question." | Fall back to grep and note `grep-only fallback` in the sweep summary. The question still has to be answered; only the source of the answer changes. |
+| "Graph corroborated my finding, so I'll skip reading the caller file." | Graph confirms the edge exists; it does not confirm the caller still satisfies the new contract. Open the caller. |
 
 ## Self-check before posting
 


### PR DESCRIPTION
## Summary

Integrates `devpilot graph preflight` into the `devpilot-pr-review` skill as a **fact bed** for the parallel fanout. The five subagents now consume authoritative caller / hub / untested-public-surface data from the graph instead of grepping, while still reading code to verify contracts. Graph does not produce findings — it removes "did I miss a caller?" anxiety so subagents spend tokens on judgment.

Validated via RED-GREEN-REFACTOR on the existing PR #87 (`fix(auth): make OAuth callback sends non-blocking`):

| Dimension | Baseline (grep) | With graph payload |
|---|---|---|
| `StartFlow` callers | conf 95, hedged "cross-pkg not checked" | exact 2 cited, both opened and contract-verified |
| Untested public surface | not mentioned | `StartFlow` flagged, conf 90, graph-corroborated |
| Graph noise (`OAuthConfig` "modified") | n/a | correctly identified as line-shift artifact |
| Method note | "would be more confident with LSP" | "skipped 3 greps, focused on judgment" |

## Changes

- **New `references/graph.md`** — payload schema, fallback triggers (mode != built, language unsupported, >30s, etc.), confidence weighting rules, known noise patterns.
- **`SKILL.md`** — workflow gains Step 1.5 (Graph enrichment); step 3 reconciles findings against graph; Reference Index updated.
- **`references/fanout.md`** — prepends shared `GRAPH_PREFLIGHT` block to every Agent A–E brief; Agent A's blast-radius step rewritten to consume the payload directly and only grep when `graph_unavailable`; confidence calibration mentions graph corroboration.
- **`references/confidence.md`** — new "Graph reconciliation" section (corroborated → floor 85; contradicted → cap 50; unsupported → unchanged); merge procedure gains a reconcile step.
- **`references/rationalizations.md`** — four new graph-specific traps:
  - "0 callers means dead code" → reflection/codegen invisible
  - "change_type=modified means behavior changed" → line-shift artifact
  - "graph unavailable, skip blast-radius" → fall back to grep, still answer
  - "corroborated, skip reading the caller" → graph confirms edge, not contract

No code changes — skill catalog only.

## Review Guide

Start with `skills/devpilot-pr-review/references/graph.md` — it defines the contract everything else consumes. Then read:

1. `SKILL.md` — see the new Step 1.5 and the reconcile in step 3.
2. `references/fanout.md` — the "Shared graph header" block and the rewritten Agent A blast-radius step are the load-bearing changes.
3. `references/confidence.md` — verify the reconcile step is ordered before threshold filtering.
4. `references/rationalizations.md` — quick scan of the four new rows.

Watch for: the fallback contract. Non-Go repos and missing caches must gracefully degrade to grep without breaking the skill — see `graph.md` → "Fallback triggers" and the matching `graph_unavailable` handling in `fanout.md`.

## Test Plan

- [x] Run the skill against a Go PR with graph built — Step 1.5 fires, fanout receives payload, Agent A's sweep summary cites caller counts from the payload.
- [x] Run against a non-Go repo (e.g. a Python-only PR) — Step 1.5 falls back, body sweep notes `Behavior trace: grep-only (graph unavailable: <reason>)`, no errors.
- [x] Run against a PR where graph payload disagrees with a finding (claims caller that graph doesn't list) — finding is capped at 50 and dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)