### PR TITLE
fix(skills): require reply before resolving review threads

### DIFF
--- a/skills/devpilot-resolving-review-threads/SKILL.md
+++ b/skills/devpilot-resolving-review-threads/SKILL.md
@@ -9,7 +9,9 @@ description: Use when responding to inline review comments after pushing fixes t
 
 After pushing fixes for a code review, every inline thread falls into one of three buckets. This skill is the decision matrix and the exact API calls for each bucket on GitHub and GitLab.
 
-**Core principle:** Resolve only what you can prove is fixed at HEAD. Reply with technical reasoning, never with gratitude or hedging. Never resolve a thread you pushed back on — the reviewer does that.
+**Core principle:** Resolve only what you can prove is fixed at HEAD. **Every thread gets a reply before it is resolved — no silent resolves, ever.** Reply with technical reasoning, never with gratitude or hedging. Never resolve a thread you pushed back on — the reviewer does that.
+
+**The Reply-Before-Resolve Rule:** A resolve with no reply leaves the reviewer guessing whether you read the comment, agreed with it, or fixed something else. The reply is the receipt. Even for a one-character typo fix, post the commit SHA. No exceptions.
 
 **REQUIRED BACKGROUND:** superpowers:receiving-code-review — the no-gratitude and technical-rigor rules apply here verbatim.
 
@@ -60,13 +62,21 @@ If the change is in your local branch but not pushed, push first. A resolved thr
 
 ## Reply Templates
 
-### Bucket A — fixed (reply optional, often empty)
+### Bucket A — fixed (reply REQUIRED, then resolve)
 
-Only reply when the fix is non-obvious from the diff:
+Every Bucket A thread gets a reply naming the fix and the commit SHA. Then resolve. Order matters: reply first, resolve second — if the resolve call fails, the reply still landed.
 
-> Pre-allocated with `make([]Refund, 0, len(items))` in <sha>.
+Non-obvious fix:
 
-For typos and trivial fixes: resolve with no reply.
+> Pre-allocated with `make([]Refund, 0, len(items))` in `<sha>`.
+
+Trivial fix (typo, rename, one-liner) — still reply, just shorter:
+
+> Fixed in `<sha>`.
+
+> Gated on `canEditLines` in `<sha>`.
+
+Never resolve a Bucket A thread with zero replies from you. If the only comment on the thread is the reviewer's original, you have not closed the loop.
 
 ### Bucket B — pushback
 
@@ -136,8 +146,9 @@ glab api "/projects/<id>/merge_requests/<iid>/discussions" \
 1. **List unresolved threads** with the listing command above. Dump to `/tmp/threads.json`.
 2. **Classify each into A/B/C** using the decision tree. Write the classification to a scratch file before executing anything.
 3. **Verify bucket A items** are on HEAD. Drop to bucket C ("can't verify, need to repush") if not.
-4. **Execute** in order: bucket A resolves first (clears noise), then B/C replies. One API call per thread; if a call fails, stop and investigate — don't continue.
-5. **Print a summary** for the user: `N resolved, M replied-and-left-open, K need their input`.
+4. **Execute** in order, per thread: **reply first, then resolve** (Bucket A) or **reply only** (B/C). Never call `resolveReviewThread` without a preceding reply on the same thread in this run. One API call at a time; if any call fails, stop and investigate.
+5. **Verify before finishing:** re-list threads and assert every resolved thread has ≥2 comments (reviewer + your reply). If any resolved thread has only the reviewer's comment, post the missing reply now.
+6. **Print a summary** for the user: `N resolved (all with replies), M replied-and-left-open, K need their input`.
 
 ## Rationalization Table
 
@@ -149,6 +160,9 @@ glab api "/projects/<id>/merge_requests/<iid>/discussions" \
 | "I'll resolve this stale comment myself" | If the reviewer was looking at old code, reply with HEAD evidence and let THEM resolve. |
 | "The fix is in my branch, close enough" | The PR runs on the pushed head. Resolve only what's on HEAD. |
 | "I'll batch all replies into one PR comment" | Inline thread replies stay anchored to the line. Top-level comments lose context. Reply in-thread. |
+| "The fix is obvious from the diff, no reply needed" | The reviewer can't tell from a resolved+silent thread whether you read the comment or resolved by accident. Post the SHA. One line. |
+| "It's a one-character typo, replying is noise" | A `Fixed in <sha>.` reply is less noise than the reviewer re-reading the diff to confirm. Reply anyway. |
+| "I already replied to a sibling thread covering the same fix" | Each thread is its own conversation. Reply per thread, even if it's the same SHA. |
 
 ## Red Flags — Stop
 
@@ -156,6 +170,8 @@ glab api "/projects/<id>/merge_requests/<iid>/discussions" \
 - About to type "I think" or "Happy to" on a technical reply → state the fact instead
 - About to resolve a thread you didn't change code for → only if you replied with verified evidence AND it's a stale-diff case AND the reviewer is clearly looking at old code; otherwise leave open
 - About to resolve before pushing → push first
+- About to call `resolveReviewThread` without having posted a reply on that thread this run → STOP. Post the reply (even just `Fixed in <sha>.`), then resolve.
+- Finishing the run and a resolved thread has only one comment (the reviewer's) → you skipped the reply. Post it now and re-check.
 
 ## Bottom Line
 


### PR DESCRIPTION
## Summary

The `devpilot-resolving-review-threads` skill previously allowed Bucket A (verified fixes) to be resolved with **no reply** — "reply optional, often empty" and explicitly "For typos and trivial fixes: resolve with no reply." That loophole produced [Jinzor/jinzor-wms#581](https://github.com/Jinzor/jinzor-wms/pull/581), where all 4 review threads were resolved with zero author replies, leaving the reviewer unable to tell whether each comment was read, agreed with, or fixed.

This PR closes the loophole. Every thread now requires a reply before resolve — even a one-line `Fixed in <sha>.` — and the workflow ends with a verification pass that re-lists threads and asserts every resolved thread has ≥2 comments.

## Changes

All edits are inside `skills/devpilot-resolving-review-threads/SKILL.md`:

- **Core principle** — added "Every thread gets a reply before it is resolved — no silent resolves, ever" and a new `Reply-Before-Resolve Rule` paragraph explaining why.
- **Bucket A template** — renamed "reply optional, often empty" → "reply REQUIRED, then resolve"; added a trivial-fix template (`Fixed in <sha>.`) so there is no excuse for skipping.
- **Workflow** — step 4 enforces reply-first-then-resolve per thread; step 5 adds an end-of-run verification (every resolved thread must have ≥2 comments); step 6 updates the summary line.
- **Rationalization table** — three new entries: "obvious from the diff", "one-char typo", "covered in a sibling thread".
- **Red flags** — two new stop conditions: about to `resolveReviewThread` without a reply this run, and finishing with a resolved thread that has only the reviewer's comment.

## Review Guide

- Start with `skills/devpilot-resolving-review-threads/SKILL.md` — it's the only file changed.
- Read top-to-bottom: Core principle → Bucket A section → Workflow → Rationalization table → Red flags. The edits reinforce each other, so the consistency check matters more than any single hunk.
- Watch for: does the wording leave any wiggle room? The whole point of this PR is to remove "reply is optional" as a thought the agent can have.

## Test plan

- [x] `git diff origin/main...HEAD` reviewed — docs-only, no code paths touched.
- [x] Next time this skill runs against a real PR, every resolved thread carries an author reply (the failure mode from Jinzor/jinzor-wms#581 should not recur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)