### PR TITLE
chore(scanning-repos): drop bin/ prefix from devpilot graph commands

### DIFF
--- a/skills/devpilot-scanning-repos/SKILL.md
+++ b/skills/devpilot-scanning-repos/SKILL.md
@@ -49,8 +49,8 @@ A whole-repo sweep that dispatches **four parallel specialist sub-agents** (secu
 2.4. **Build (or refresh) the codegraph — MANDATORY.** The security, edge-case, and coverage scanners all use `devpilot graph` queries (`callers_of`, `tests_for`, hubs) to verify findings before emitting them; without the graph their output is grep-only noise.
 
    ```bash
-   bin/devpilot graph build --repo .
-   bin/devpilot graph hubs --threshold 5 > /tmp/devpilot-graph-hubs.json
+   devpilot graph build --repo .
+   devpilot graph hubs --threshold 5 > /tmp/devpilot-graph-hubs.json
    ```
 
    - Build is incremental on re-runs (~1–2s on devpilot-sized repos, <30s on most monorepos).
@@ -64,7 +64,7 @@ A whole-repo sweep that dispatches **four parallel specialist sub-agents** (secu
      1. Find every entry-point file, case-insensitive, anywhere in the repo: `fd -HI -t f -i '^(claude|agents|readme)\.md$'` (fallback: `find . -type f -iregex '.*/\(claude\|agents\|readme\)\.md'`).
      2. Parse markdown links from each — both inline `[text](path)` and reference `[text]: path` forms — keep only relative targets that resolve to existing files with doc-ish extensions (`.md`, `.mdx`, `.txt`, `.rst`) or living under a `docs/`-style directory. Strip `#anchor` for resolution but keep it for the scanner's reporting.
      3. Recurse one hop at a time, dedupe by absolute path, cap at depth 3 and at 200 doc files total. Write the resulting list to `/tmp/devpilot-doc-manifest.txt`. Print to the user: total entry points found, total docs in the manifest, and a tree showing which entry point pulled in which linked doc.
-3. **Dispatch scanners in parallel.** In ONE message, launch four sub-agents using the prompts in `agents/`. Pass each of the first three the manifest path AND `/tmp/devpilot-graph-hubs.json`; they will run `bin/devpilot graph query …` as their reachability oracle.
+3. **Dispatch scanners in parallel.** In ONE message, launch four sub-agents using the prompts in `agents/`. Pass each of the first three the manifest path AND `/tmp/devpilot-graph-hubs.json`; they will run `devpilot graph query …` as their reachability oracle.
    - `agents/security-scanner.md` — pass `/tmp/devpilot-scan-manifest.txt` + hubs file
    - `agents/edge-case-hunter.md` — pass `/tmp/devpilot-scan-manifest.txt` + hubs file
    - `agents/coverage-auditor.md` — pass `/tmp/devpilot-scan-manifest.txt` + hubs file

--- a/skills/devpilot-scanning-repos/agents/coverage-auditor.md
+++ b/skills/devpilot-scanning-repos/agents/coverage-auditor.md
@@ -29,7 +29,7 @@ You will receive a path to a manifest file (default `/tmp/devpilot-scan-manifest
 1. **Use codegraph as the authoritative test-coverage oracle (MANDATORY).** The same-package filename heuristic (`foo.go → foo_test.go`) misses cross-file and cross-package coverage. For each exported symbol in each manifest file:
 
    ```bash
-   bin/devpilot graph query tests_for '<file>::<symbol>'
+   devpilot graph query tests_for '<file>::<symbol>'
    ```
 
    - **Empty test set** → real `cov:no-test-file` candidate. Proceed to step 2's "is it worth a test?" filter.
@@ -45,8 +45,8 @@ You will receive a path to a manifest file (default `/tmp/devpilot-scan-manifest
    - Python: `foo.py` → `test_foo.py` or `tests/test_foo.py`.
 
 2. For each production file whose exported symbols all returned empty `tests_for` sets: decide if any of them deserve a test under the rules above. If yes, emit **one finding per file** (not per symbol — group them); list the uncovered symbols in `evidence`.
-3. For each production file that **has** at least one symbol with a non-empty test set: spot-check whether the error branches are asserted. Use `grep -n "if err != nil\\|return.*err" <file>` and compare to the bodies of the named tests (`bin/devpilot graph query context --id '<test-id>' --depth 0` to read each quickly). If the happy path has many assertions and every error path is untouched, that's one `cov:error-paths` finding.
-4. For recently-churny production files (`bin/devpilot graph detect-changes --base 'HEAD~50' --head HEAD` is the precise check; or fall back to `git log --oneline --since=90.days.ago -- <file> | wc -l > 5`) where `tests_for` returns empty OR a test file whose mtime is older than the production file's last meaningful change, emit `cov:stale-test`.
+3. For each production file that **has** at least one symbol with a non-empty test set: spot-check whether the error branches are asserted. Use `grep -n "if err != nil\\|return.*err" <file>` and compare to the bodies of the named tests (`devpilot graph query context --id '<test-id>' --depth 0` to read each quickly). If the happy path has many assertions and every error path is untouched, that's one `cov:error-paths` finding.
+4. For recently-churny production files (`devpilot graph detect-changes --base 'HEAD~50' --head HEAD` is the precise check; or fall back to `git log --oneline --since=90.days.ago -- <file> | wc -l > 5`) where `tests_for` returns empty OR a test file whose mtime is older than the production file's last meaningful change, emit `cov:stale-test`.
 
 ## Output format
 

--- a/skills/devpilot-scanning-repos/agents/edge-case-hunter.md
+++ b/skills/devpilot-scanning-repos/agents/edge-case-hunter.md
@@ -54,10 +54,10 @@ You will receive a path to a manifest file (default `/tmp/devpilot-scan-manifest
 6. **Codegraph verification (MANDATORY for `edge:nil-deref`, `edge:bounds-overflow`, `edge:input-validation`, and any finding marked "reachability unclear").** Before emitting:
 
    ```bash
-   bin/devpilot graph query callers_of '<file>::<symbol>' --depth 3
+   devpilot graph query callers_of '<file>::<symbol>' --depth 3
    ```
 
-   For each caller listed, read enough of it (`bin/devpilot graph query context --id '<caller-id>' --depth 0` is the fastest path) to answer the specific question that decides the finding:
+   For each caller listed, read enough of it (`devpilot graph query context --id '<caller-id>' --depth 0` is the fastest path) to answer the specific question that decides the finding:
    - **Nil-deref of a parameter** — does any caller visibly pass nil (or pass a value that could be nil after an unchecked error path)? If **yes**, severity is at least `medium`. If **no caller could pass nil**, drop.
    - **Bounds / overflow on a parameter** — does any caller pass user-controlled / unbounded data? If yes, confirmed.
    - **Empty caller set** — symbol is exported library API or registered entry point: treat as "any caller could pass anything", keep finding. If unexported with zero callers, it's dead code — drop the edge finding (or surface as `cov:no-callers` if your sibling skill cares).

--- a/skills/devpilot-scanning-repos/agents/security-scanner.md
+++ b/skills/devpilot-scanning-repos/agents/security-scanner.md
@@ -39,7 +39,7 @@ You will receive a path to a manifest file (default `/tmp/devpilot-scan-manifest
 4. **Verify reachability via codegraph (MANDATORY for `sec:injection`, `sec:path-traversal`, `sec:ssrf-csrf`, `sec:tls-misconfig`, `sec:deserialization`, and any finding whose claim is "untrusted input reaches X").** Before emitting the finding:
 
    ```bash
-   bin/devpilot graph query callers_of '<file>::<symbol>' --depth 4
+   devpilot graph query callers_of '<file>::<symbol>' --depth 4
    ```
 
    - **Caller set traces back to an entry point that accepts untrusted input** (CLI flag handler, HTTP/RPC route, env-var read, file read from a user-supplied path) → finding **confirmed**. Append the proven chain to `evidence` as a trailing `graph:` block: list 1–3 callers + the entry point + which input field flows in.


### PR DESCRIPTION
## Summary

`devpilot-scanning-repos` instructs the orchestrator and three scanner sub-agents to invoke the codegraph via `bin/devpilot graph …`. That path only resolves inside this repo's dev tree — end users running the skill have `devpilot` on `PATH` from their global install, so the `bin/` prefix breaks every reachability query.

Drops the prefix in 8 places:

- `SKILL.md` step 2.4 (`graph build`, `graph hubs`) and step 3 dispatch note (`graph query …`).
- `agents/security-scanner.md` — `graph query callers_of` invocation.
- `agents/edge-case-hunter.md` — `graph query callers_of` and `graph query context`.
- `agents/coverage-auditor.md` — `graph query tests_for`, `graph query context`, `graph detect-changes`.

No behavioural change to the workflow; only the command string the agents emit.

## Review Guide

Start with `skills/devpilot-scanning-repos/SKILL.md` (lines 52–53, 67) to confirm step 2.4 still reads as MANDATORY and the dispatch note still ties hubs file to the first three scanners. Then skim the three agent prompts — each `bin/devpilot ` → `devpilot ` substitution should be the only diff.

Worth double-checking: there is no shell script or eval assertion that pins the literal `bin/devpilot` string. Grepping the skill dir for `bin/devpilot` should return nothing.

## Test plan

- [x] `grep -rn 'bin/devpilot' skills/devpilot-scanning-repos/` returns empty.
- [ ] Reviewer confirms no eval in `evals/evals.json` greps for the `bin/` prefix (visual scan — no such assertion exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)