### PR TITLE
fix(trello): send credentials via Authorization header instead of URL query

### DIFF
--- a/internal/auth/trello_service.go
+++ b/internal/auth/trello_service.go
@@ -86,9 +86,14 @@ func (t *TrelloService) IsLoggedIn() bool {
 }
 
 func (t *TrelloService) verify(apiKey, token string) error {
-	url := fmt.Sprintf("%s/1/members/me?key=%s&token=%s", t.getBaseURL(), apiKey, token)
+	req, err := http.NewRequest(http.MethodGet, t.getBaseURL()+"/1/members/me", nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf(`OAuth oauth_consumer_key="%s", oauth_token="%s"`, apiKey, token))
+
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(url)
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Trello: %w", err)
 	}

--- a/internal/auth/trello_service_test.go
+++ b/internal/auth/trello_service_test.go
@@ -11,9 +11,11 @@ func TestTrelloVerify_Success(t *testing.T) {
 		if r.URL.Path != "/1/members/me" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		key := r.URL.Query().Get("key")
-		token := r.URL.Query().Get("token")
-		if key != "test-key" || token != "test-token" {
+		if r.URL.Query().Get("key") != "" || r.URL.Query().Get("token") != "" {
+			t.Fatalf("credentials must not be in query string: %s", r.URL.RawQuery)
+		}
+		wantAuth := `OAuth oauth_consumer_key="test-key", oauth_token="test-token"`
+		if got := r.Header.Get("Authorization"); got != wantAuth {
 			w.WriteHeader(401)
 			return
 		}

--- a/internal/trello/client.go
+++ b/internal/trello/client.go
@@ -42,65 +42,26 @@ func NewClient(apiKey, token string, opts ...ClientOption) *Client {
 	return c
 }
 
-func (c *Client) get(path string, params url.Values) ([]byte, error) {
-	if params == nil {
-		params = url.Values{}
-	}
-	params.Set("key", c.apiKey)
-	params.Set("token", c.token)
-	reqURL := fmt.Sprintf("%s%s?%s", c.baseURL, path, params.Encode())
-
-	resp, err := c.http.Get(reqURL)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read body failed: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-	return body, nil
+// authHeader returns the Trello OAuth-style Authorization header value
+// carrying the API key and token. Sending credentials via the header keeps
+// them out of access logs, proxy logs, and Referer headers.
+func (c *Client) authHeader() string {
+	return fmt.Sprintf(`OAuth oauth_consumer_key="%s", oauth_token="%s"`, c.apiKey, c.token)
 }
 
-func (c *Client) post(path string, params url.Values) ([]byte, error) {
-	if params == nil {
-		params = url.Values{}
+func (c *Client) do(method, path string, params url.Values, contentType string) ([]byte, error) {
+	reqURL := c.baseURL + path
+	if len(params) > 0 {
+		reqURL = reqURL + "?" + params.Encode()
 	}
-	params.Set("key", c.apiKey)
-	params.Set("token", c.token)
-	reqURL := fmt.Sprintf("%s%s?%s", c.baseURL, path, params.Encode())
 
-	resp, err := c.http.Post(reqURL, "application/json", nil)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read body failed: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-	return body, nil
-}
-
-func (c *Client) put(path string, params url.Values) ([]byte, error) {
-	if params == nil {
-		params = url.Values{}
-	}
-	params.Set("key", c.apiKey)
-	params.Set("token", c.token)
-	reqURL := fmt.Sprintf("%s%s?%s", c.baseURL, path, params.Encode())
-
-	req, err := http.NewRequest(http.MethodPut, reqURL, nil)
+	req, err := http.NewRequest(method, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request failed: %w", err)
+	}
+	req.Header.Set("Authorization", c.authHeader())
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
 	}
 
 	resp, err := c.http.Do(req)
@@ -117,6 +78,18 @@ func (c *Client) put(path string, params url.Values) ([]byte, error) {
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 	return body, nil
+}
+
+func (c *Client) get(path string, params url.Values) ([]byte, error) {
+	return c.do(http.MethodGet, path, params, "")
+}
+
+func (c *Client) post(path string, params url.Values) ([]byte, error) {
+	return c.do(http.MethodPost, path, params, "application/json")
+}
+
+func (c *Client) put(path string, params url.Values) ([]byte, error) {
+	return c.do(http.MethodPut, path, params, "")
 }
 
 // GetBoards returns the authenticated member's open boards.

--- a/internal/trello/client_test.go
+++ b/internal/trello/client_test.go
@@ -17,8 +17,12 @@ func TestGetBoards(t *testing.T) {
 		if r.URL.Query().Get("filter") != "open" {
 			t.Error("expected filter=open")
 		}
-		if r.URL.Query().Get("key") == "" || r.URL.Query().Get("token") == "" {
-			t.Error("missing auth params")
+		if r.URL.Query().Get("key") != "" || r.URL.Query().Get("token") != "" {
+			t.Error("credentials must not be in query string")
+		}
+		wantAuth := `OAuth oauth_consumer_key="testkey", oauth_token="testtoken"`
+		if got := r.Header.Get("Authorization"); got != wantAuth {
+			t.Errorf("unexpected Authorization header: %q", got)
 		}
 		_ = json.NewEncoder(w).Encode(boards)
 	}))


### PR DESCRIPTION
## Summary
- Switches Trello API key/token transport from URL query params (`?key=…&token=…`) to the documented `Authorization: OAuth oauth_consumer_key="…", oauth_token="…"` header in `internal/trello/client.go` and `internal/auth/trello_service.go`.
- Consolidates `get`/`post`/`put` in `internal/trello/client.go` into a shared `do` helper that sets the auth header on every outbound request.
- Updates `internal/trello/client_test.go` and `internal/auth/trello_service_test.go` to assert the new header value and the absence of `key=`/`token=` from the query string.

## Why
Credentials in URLs leak into access logs, proxy logs, and referer headers. Header auth is supported by Trello and avoids the leak.

Closes #123

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/trello/... ./internal/auth/...` (37 tests pass)
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)