### PR TITLE
fix(graph/parser): nil-guard TypesInfo in LoadModule TYPE-spec branch

### DIFF
--- a/internal/graph/parser/go_native.go
+++ b/internal/graph/parser/go_native.go
@@ -420,6 +420,12 @@ func (p *GoNativeParser) LoadModule(repoRoot string) (map[string]ParseResult, er
 				if !ok || gd.Tok != token.TYPE {
 					continue
 				}
+				// Mirror the func-decl branch's guard above: when packages.Load
+				// returns a package that failed to type-check, TypesInfo can be
+				// nil and dereferencing it panics. Skip the type-spec block.
+				if pk.TypesInfo == nil {
+					continue
+				}
 				for _, spec := range gd.Specs {
 					ts, ok := spec.(*ast.TypeSpec)
 					if !ok || ts.Name == nil {


### PR DESCRIPTION
## Summary
- The func-decl branch in `LoadModule` (line ~399) correctly guards `if pk.TypesInfo != nil`, but the TYPE-spec branch below did not, so `packages.Load` returning a package whose `TypesInfo` is nil (e.g. failed type-check) panics.
- Adds matching `if pk.TypesInfo == nil { continue }` guard with a comment cross-referencing the func-decl branch.

Closes #124

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/graph/parser/...` (37 pass)
- [x] `make lint`
- [ ] No targeted regression test added — constructing a `*packages.Package` with nil TypesInfo + TypeSpecs deterministically is brittle; guard mirrors an already-tested pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)