### PR TITLE
fix(graph/resolver): handle /* */ block comments in stripJSONComments

### DIFF
--- a/internal/graph/resolver/tsconfig.go
+++ b/internal/graph/resolver/tsconfig.go
@@ -131,10 +131,9 @@ func (r *TSConfigResolver) resolve(spec string) (string, bool) {
 	return "", false
 }
 
-// stripJSONComments removes JSONC `//` line comments while preserving
-// occurrences of `//` inside string literals (so URLs and path values
-// like "https://x" survive intact). Block comments are not handled —
-// add when a real tsconfig in the wild needs them.
+// stripJSONComments removes JSONC `//` line comments and `/* ... */` block
+// comments while preserving occurrences of `//` or `/*` inside string literals
+// (so URLs and path values like "https://x" or "http://x/*foo*/" survive intact).
 func stripJSONComments(b []byte) []byte {
 	out := make([]byte, 0, len(b))
 	inString := false
@@ -168,6 +167,22 @@ func stripJSONComments(b []byte) []byte {
 			}
 			if i < len(b) {
 				out = append(out, '\n')
+			}
+			continue
+		}
+		// Outside a string: drop `/* ... */` block comments. An unterminated
+		// block comment is treated as comment-to-end-of-input.
+		if c == '/' && i+1 < len(b) && b[i+1] == '*' {
+			i += 2
+			for i+1 < len(b) && (b[i] != '*' || b[i+1] != '/') {
+				i++
+			}
+			if i+1 < len(b) {
+				// Skip the closing `*/`. Loop's i++ handles the second byte.
+				i++
+			} else {
+				// Unterminated: consume the rest of the buffer.
+				i = len(b)
 			}
 			continue
 		}

--- a/internal/graph/resolver/tsconfig_test.go
+++ b/internal/graph/resolver/tsconfig_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -25,5 +26,79 @@ func TestTSConfigResolverRewritesAliasImports(t *testing.T) {
 	}
 	if got[0].Dst != "src/lib/b.ts" {
 		t.Errorf("dst=%q want src/lib/b.ts", got[0].Dst)
+	}
+}
+
+func TestStripJSONComments(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "line comment stripped",
+			in:   "{\n  // a comment\n  \"a\": 1\n}",
+			want: "{\n  \n  \"a\": 1\n}",
+		},
+		{
+			name: "simple block comment stripped",
+			in:   `{/* hi */"a":1}`,
+			want: `{"a":1}`,
+		},
+		{
+			name: "block comment containing // is fully stripped",
+			in:   `{/* see // not a line comment */"a":1}`,
+			want: `{"a":1}`,
+		},
+		{
+			name: "block comment spanning newlines",
+			in:   "{\n/* multi\nline // with slashes\n*/\n\"a\":1}",
+			want: "{\n\n\"a\":1}",
+		},
+		{
+			name: "block-comment marker inside string not stripped",
+			in:   `{"url":"http://x/*foo*/"}`,
+			want: `{"url":"http://x/*foo*/"}`,
+		},
+		{
+			name: "line-comment marker inside string survives",
+			in:   `{"url":"https://example.com"}`,
+			want: `{"url":"https://example.com"}`,
+		},
+		{
+			name: "unterminated block comment consumes to EOF",
+			in:   `{"a":1}/* unterminated`,
+			want: `{"a":1}`,
+		},
+		{
+			name: "escaped quote inside string with // does not split",
+			in:   `{"a":"he said \"hi\" //x"}`,
+			want: `{"a":"he said \"hi\" //x"}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(stripJSONComments([]byte(tc.in)))
+			if got != tc.want {
+				t.Errorf("stripJSONComments(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripJSONCommentsParsesRealisticTSConfig(t *testing.T) {
+	// Regression: /* ... // ... */ used to corrupt the JSON because the
+	// embedded `//` triggered the line-comment branch and consumed the
+	// `*/` terminator.
+	input := []byte(`{
+  /* paths config // see docs */
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  }
+}`)
+	var v map[string]any
+	if err := json.Unmarshal(stripJSONComments(input), &v); err != nil {
+		t.Fatalf("unmarshal failed: %v\nstripped=%s", err, stripJSONComments(input))
 	}
 }


### PR DESCRIPTION
## Summary
- `stripJSONComments` only handled `//` line comments. A `/* ... // ... */` block comment in a real tsconfig.json triggered the line-comment branch on the embedded `//`, eating through the next newline including `*/` and corrupting the JSON.
- Extends the state machine outside string literals to also strip `/* ... */` block comments (unterminated blocks consumed to EOF).
- Adds table-driven tests covering block comment with embedded `//`, block comment inside string literal (must survive), unterminated block, line comments, and the existing URL-in-string case.

Closes #125

## Test plan
- [x] `go test ./internal/graph/resolver/...` (16 pass incl. new cases)
- [x] `go build ./...`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)