### PR TITLE
docs(claude): list all current internal/ domains in repo map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Skill catalog for Claude Code plus a small set of Go-native helpers (Gmail OAuth
 
 ## Repo map
 - `cmd/devpilot/` — entry point
-- `internal/<domain>/` — self-contained domains (`auth`, `trello`, `gmail`, `slack`, `initcmd`, `project`); each owns its Cobra commands in `commands.go`
+- `internal/<domain>/` — self-contained domains (`auth`, `generate`, `gmail`, `graph`, `initcmd`, `project`, `slack`, `trello`); each owns its Cobra commands in `commands.go`
 - `skills/` — distributable skill catalog (register each in `skills/index.json`)
 - `.claude/skills/` — installed skills for this project
 - `.github/workflows/` — CI (test + release)


### PR DESCRIPTION
## Summary
CLAUDE.md's repo map enumerated only 6 of 8 internal domains, missing `generate` (owns `devpilot commit`) and `graph` (owns `devpilot graph ...`). Updated to list all current domains alphabetically.

Closes #128

## Test plan
- [x] `ls internal/` matches the new list (auth, generate, gmail, graph, initcmd, project, slack, trello).

🤖 Generated with [Claude Code](https://claude.com/claude-code)