### PR TITLE
feat(pr-review): dependency reality + security/perf coverage + missing-test injection

### DIFF
--- a/skills/devpilot-pr-review/SKILL.md
+++ b/skills/devpilot-pr-review/SKILL.md
@@ -12,7 +12,7 @@ A PR review the author can act on: every concrete finding is posted as an **inli
 Three structural ideas drive this skill:
 
 1. **Eligibility gate** — decide the PR is worth a full review before spending tokens on it. Dependabot, drafts, generated-file PRs, "already reviewed" all stop here.
-2. **Parallel fanout** — five subagents look at the change from five independent angles in parallel. Coverage comes from diversity of angle, not depth of a single pass. The main session dispatches and merges; subagents read code.
+2. **Parallel fanout** — five to six subagents look at the change from independent angles in parallel. Coverage comes from diversity of angle, not depth of a single pass. The main session dispatches and merges; subagents read code. Agent F (Dependency Reality Check) is dispatched only when the diff adds new dependencies — it verifies imports/packages resolve on their public registry, catching hallucinated names that pass every text-based agent.
 3. **Confidence filtering** — every finding carries `Confidence: 0–100`. Findings below 70 are dropped by default. Coverage at collection, filtering at posting.
 
 ## When NOT to Use
@@ -72,19 +72,20 @@ Run `devpilot graph preflight --base <base-sha> --head <head-sha>` once. Cache t
 
 If the graph cache is missing, the language is unsupported, or preflight fails, **fall back** to the grep-only path and note `Behavior trace: grep-only (graph unavailable: <reason>)` in the body's sweep summary. Do not auto-run `devpilot graph build`. See `references/graph.md` for the full payload schema, fallback triggers, and confidence-weighting rules.
 
-### 2. Parallel fanout (5 subagents)
+### 2. Parallel fanout (5–6 subagents)
 
-Dispatch all five in a single message so they run in parallel. Each receives the PR metadata, the diff, and one focused brief. Each returns findings with `Confidence: 0–100` and `Severity`. See `references/fanout.md` for the prompts.
+Dispatch all in a single message so they run in parallel. Each receives the PR metadata, the diff, and one focused brief. Each returns findings with `Confidence: 0–100` and `Severity`. See `references/fanout.md` for the prompts. Agent F is conditional: dispatch only if the diff adds entries to `go.mod` / `package.json` / `requirements*.txt` / `pyproject.toml` / `Cargo.toml`, or adds an import for a module not already in the base-ref manifest.
 
 In **incremental mode**, the diff passed to subagents is the range diff (`last_reviewed_sha..head_sha`), not the full PR diff — agents should look at the new commits only. Agent A still grounds its blast-radius checks in the full repo, but findings must be anchored to lines changed in the new commits.
 
 | Agent | Angle |
 |---|---|
 | A | Behavior sweep (5 blind-spot questions + behavior trace) |
-| B | Shallow bug scan on the diff |
+| B | Shallow bug scan on the diff + Security/Performance [REQUIRED CHECKS] coverage |
 | C | CLAUDE.md / AGENTS.md compliance |
 | D | Git blame & history + comments on prior PRs touching these files |
 | E | Code comments & in-file conventions in modified files |
+| F | Dependency reality check — verifies added imports/packages resolve on public registry (conditional: only dispatched when the diff adds dependencies) |
 
 The main session does NOT also do these passes itself. Subagent context savings are the point.
 
@@ -120,7 +121,8 @@ Before posting, walk `references/rationalizations.md` self-check.
 |---|---|
 | `references/eligibility.md` | Gate rules + false-positive list (when to skip review entirely, what to never flag). |
 | `references/graph.md` | `devpilot graph preflight` payload schema, fallback triggers, confidence-weighting rules consumed by step 3. |
-| `references/fanout.md` | Five subagent prompts (Behavior, Bug scan, CLAUDE.md, Git history, In-file comments) — all receive the graph payload. |
+| `references/fanout.md` | Six subagent prompts (Behavior, Bug scan + sec/perf coverage, CLAUDE.md, Git history, In-file comments, Dependency reality) — A–E receive the graph payload; F receives the pre-extracted dependency manifest. |
+| `references/import-verifier.md` | Agent F spec: per-ecosystem registry-check commands (Go / npm / Python / Rust), finding shape, typosquat heuristic, fallback rules. |
 | `references/confidence.md` | 0–100 rubric, threshold 70, severity vs. confidence axes, dedupe rules, graph reconciliation. |
 | `references/unknown-unknowns.md` | Behavior sweep details — Agent A's playbook. |
 | `references/checklist.md` | Quality dimensions referenced by Agent B's bug scan and Agent A's checklist tail. |

--- a/skills/devpilot-pr-review/references/checklist.md
+++ b/skills/devpilot-pr-review/references/checklist.md
@@ -17,9 +17,70 @@ Every category produces zero or more findings. Each finding becomes an inline co
 
 - **Public surface** — matches the change's purpose; no leaked internals; new exported symbols have a clear caller story.
 - **Scalability** — cost grows reasonably with input size; no accidental O(n²) over user-controlled input; no unbounded slices, maps, or goroutines.
-- **Performance** — no chatty I/O on hot paths; no synchronous calls inside loops where batching applies; no unnecessary allocations in inner loops.
-- **Security** — input validated at trust boundaries; secrets not logged; auth/authz not bypassed by the new path; no SSRF / SQLi / XSS / template injection / path-traversal surface.
 - **Observability hooks** — new code paths have logs / metrics / errors a human can find when paged.
+
+## Security [REQUIRED CHECKS]
+
+Agent B MUST walk every item below for code in the diff. For each item, produce a finding OR return an entry in the `coverage` block (`{item}: checked, no_evidence`). "Risk is low because the input isn't attacker-controlled today" is the canonical silent-skip rationalization — write it as a Consider-level finding with the assumption made explicit, not as a silent pass.
+
+- **Hardcoded secrets** — API keys, tokens, passwords, private keys, OAuth client secrets, signing keys, JWT secrets in source/config/test fixtures added by the diff.
+- **Credential placement** — secrets transported via URL query / referer-leaking surface / GET requests / debug logs; should be header / body / encrypted store.
+- **String interpolation into structured contexts** — values from variables/inputs interpolated into:
+  - Auth/HTTP headers (CRLF injection, quote escaping in `OAuth ...="%s"` style templates).
+  - SQL / NoSQL queries (injection).
+  - Shell commands / `exec` / process spawn.
+  - HTML / template engines (XSS).
+  - File paths (traversal).
+  - Log format strings.
+- **AuthN ≠ AuthZ** — every endpoint / handler / RPC method touched: both authentication AND object-level authorization checks present? A user being logged in is not authorization.
+- **Error response leakage** — error strings echo internal state (DB errors verbatim, stack traces, response bodies that may contain auth tokens, secrets, PII).
+- **Sensitive data in logs** — log statements added or modified include credential fields, full request bodies, PII, session IDs.
+- **Cross-host credential propagation** — HTTP clients that follow redirects: does Authorization / Cookie get re-sent to a different host? (Go's default behavior changed across versions; verify explicitly for the version in `go.mod`.)
+- **TLS / transport** — new outbound calls use HTTPS; certificate verification not disabled; no `InsecureSkipVerify` introduced.
+
+## Performance [REQUIRED CHECKS]
+
+Same protocol as Security: every item produces a finding OR a `coverage` entry. "Looks fine" is not a coverage entry.
+
+- **N+1 / loop-bound I/O** — DB / HTTP / fs / RPC call inside a loop where batching applies.
+- **Unbounded list / find_all on request paths** — pagination / `LIMIT` / max-results missing.
+- **Index coverage** — new query filter / sort / join columns when DB schema is visible in the repo; flag if no index covers them.
+- **Serial independent awaits** — sequential `await` / blocking calls that are mutually independent and should run concurrently (`Promise.all`, `errgroup.Go`).
+- **Blocking calls on hot paths** — `time.Sleep`, synchronous fs/net, large `io.ReadAll` of externally-controlled bodies in request handlers / RPC paths.
+- **Connection reuse** — new `http.Client{}` or DB connection per call instead of sharing; missing `Transport` tuning where the call pattern justifies it.
+- **Inner-loop allocation in hot code** — `fmt.Sprintf` / repeated map allocation / string concatenation in tight loops on changed lines (skip if the loop is bounded by a small constant).
+
+## Coverage block (Agent B return shape)
+
+Agent B's response MUST include a `coverage` block alongside `findings`:
+
+```yaml
+findings:
+  - ... (as before)
+
+coverage:
+  security:
+    hardcoded_secrets: checked, no_evidence
+    credential_placement: finding_raised
+    string_interpolation: finding_raised
+    authn_vs_authz: not_applicable (no endpoint touched)
+    error_response_leakage: checked, no_evidence
+    sensitive_data_in_logs: checked, no_evidence
+    cross_host_credential_propagation: checked, no_evidence
+    tls_transport: not_applicable
+  performance:
+    n_plus_one: checked, no_evidence
+    unbounded_list: not_applicable
+    index_coverage: not_applicable (no schema visible)
+    serial_independent_awaits: checked, no_evidence
+    blocking_hot_path: finding_raised
+    connection_reuse: checked, no_evidence
+    inner_loop_allocation: checked, no_evidence
+```
+
+**Allowed values per item:** `checked, no_evidence` | `finding_raised` | `not_applicable (<one-line reason>)`. Anything else, including missing keys, is invalid — main session re-dispatches once (see `confidence.md` → coverage assertion).
+
+**`not_applicable` is not a free pass.** Use it only when the diff genuinely cannot match the item (e.g. no DB code touched → `index_coverage: not_applicable`). "I looked and it was fine" is `checked, no_evidence`, not `not_applicable`.
 
 ## Testing
 

--- a/skills/devpilot-pr-review/references/confidence.md
+++ b/skills/devpilot-pr-review/references/confidence.md
@@ -63,7 +63,9 @@ A finding both corroborated on one dimension and contradicted on another takes t
 
 ## Merge procedure (after the fanout returns)
 
+0. **Coverage assertion (Agent B).** Verify Agent B returned a `coverage` block covering every [REQUIRED CHECK] item in `references/checklist.md` §Security AND §Performance, with allowed values (`checked, no_evidence` | `finding_raised` | `not_applicable (<reason>)`). Missing keys, blank reasons, or items returned with unrecognized values trigger a single re-dispatch of Agent B with the exact missing items spelled out in the brief. If the second return is still incomplete, record `Security/Perf scan: partial (n/m items covered, missing: <list>)` in the body's Unknown-Unknowns Sweep block and downgrade the review event to at most `COMMENT` (never `APPROVE`) — an incomplete safety scan is not an approval.
 1. **Collect** all findings from agents A–E into one list.
+1.5. **Inject graph-derived findings** for missing tests on changed public surface. See "Graph-injected findings" below. Skip if graph fell back.
 2. **Reconcile** against `GRAPH_PREFLIGHT` per the section above (skip if graph fell back).
 3. **Filter:**
    - Drop `confidence < 70` (or the user-overridden threshold).
@@ -75,6 +77,54 @@ A finding both corroborated on one dimension and contradicted on another takes t
    - Every surviving finding needs `(path, line, side)`. Cross-cutting findings (e.g. "this PR has no tests") anchor to the most representative line — the new function's signature, the first new line of the changed file. The comment body MUST say so.
 6. **Count** by severity. The counts go in the body.
 7. **Derive the review event** (`REQUEST_CHANGES` / `COMMENT` / `APPROVE`) from the highest-severity surviving finding. See `posting.md` → "Event mapping".
+
+## Graph-injected findings (step 1.5)
+
+The fanout relies on Agent A's judgment to surface missing tests on changed public surface. In practice agents rationalize this away (`"too defensive to need a test"`, `"author justified skipping it"`, `"would be a nag"`). The graph already knows which changed public symbols lack a direct test; the main session injects findings unconditionally from the payload so judgment can only *upgrade* the finding, not silence it.
+
+**Inject one finding for every `changed_symbols[]` entry that satisfies ALL of:**
+
+- `is_exported == true`
+- `change_type` ∈ {`"modified"`, `"added"`}
+- `tests.has_tests == false`
+- `kind` ∈ {`"function"`, `"method"`}
+- The symbol's diff is **not trivial** (see "Trivial diff" below).
+
+**Default shape:**
+
+```
+title: Missing test for changed public surface — <symbol_id>
+severity: Should-fix
+confidence: 85           # graph corroborated; floor in graph.md
+anchor: <path>:<signature line of the symbol at head SHA>
+agent: "graph"
+behavior: "<symbol> is exported, modified by this PR, and has no direct test symbol in the graph."
+why: "Untested public surface changes are how silent regressions ship. Author may have justified skipping a test in the PR body — surface the gap explicitly so the decision is reviewable."
+fix: "Add a direct test for <symbol> covering the changed behavior, or reply with the reason a test is impractical (then resolve)."
+```
+
+**Severity escalation:**
+
+- `risk_factors` contains `hub` → `Severity: Blocking` (a hub semantic change without a test pages everyone downstream).
+- `risk_factors` contains `interface_change` → `Severity: Blocking`.
+
+**Trivial diff** (skip injection — these would be pure noise):
+
+- The symbol's hunk is ≤ 3 lines AND every line is a comment or whitespace.
+- The symbol's hunk is a pure rename / signature relocation (name change, no body change).
+- The symbol's body becomes a single-line forward (`return Other(args...)` and nothing else).
+
+**Not trivial — DO inject even though it feels minor:**
+
+- Defensive nil-guard / error-guard mirroring an existing pattern (5-line `if x == nil { continue }` blocks). The author asserting "this is too defensive to test" is exactly the case the injection is designed to overcome. Author can resolve the inline with "untestable, see PR body" — that's healthy. Silently dropping the finding is not.
+- Refactors that change control flow even by one branch.
+- Anything the author flagged in the PR description as "no test added because ___" — the justification belongs in the resolution thread, not in the reviewer's head.
+
+**Sibling-test transitivity is not coverage.** "The mirror branch / sibling function has a test, so this one is covered by analogy" is a rationalization, not a fact. Each symbol's `tests.has_tests` is independent. If two branches share a contract, the right answer is usually to factor out a helper and test the helper — that refactor *is* the fix.
+
+**Dedupe with Agent A:** if Agent A returned a finding for the same `(symbol, "missing test")` defect, drop the graph-injected one and keep Agent A's (Agent A's `fix` is concrete; the injected default is generic).
+
+**Anchor:** the symbol's declaration line at head SHA. For Go methods, the line of `func (recv T) Name(...)`. The main session resolves the line by reading the file at head SHA — do not guess.
 
 ## What to do when the fanout returns nothing
 

--- a/skills/devpilot-pr-review/references/fanout.md
+++ b/skills/devpilot-pr-review/references/fanout.md
@@ -1,6 +1,6 @@
-# Parallel Fanout: Five Subagent Briefs
+# Parallel Fanout: Six Subagent Briefs
 
-Dispatch all five subagents in a **single message with five parallel Task calls** so they run concurrently. Each subagent gets the same PR header (URL, title, head SHA, base SHA, files changed list, full diff) **plus the graph preflight payload** (or the `graph_unavailable: <reason>` marker if step 1.5 fell back) and one focused brief from this file.
+Dispatch all six subagents in a **single message with six parallel Task calls** so they run concurrently. Each subagent gets the same PR header (URL, title, head SHA, base SHA, files changed list, full diff) **plus the graph preflight payload** (or the `graph_unavailable: <reason>` marker if step 1.5 fell back) and one focused brief from this file. Agent F additionally receives the dispatcher's pre-extracted dependency manifest (see `references/import-verifier.md`); if the manifest is empty (no new dependencies), skip dispatching F entirely.
 
 ## Shared graph header (injected into every brief)
 
@@ -53,6 +53,8 @@ You are reviewing a pull request for behavior-level defects. Your job is the fiv
    4. Stale-training check (verify versions in `go.mod`/`package.json`)
    5. Hand-rolled vs. off-the-shelf (search repo + deps for existing utilities)
 3. Trace at least one golden-path input and one edge-case input through the change. Record the observable behavior delta. Use `GRAPH_PREFLIGHT.cross_community_edges` to spot whether this PR newly widens a package boundary — a Consider-level finding when unexpected.
+
+   **Untested public surface — write the finding, do not rationalize it.** For every symbol with `risk_factors` containing `untested_public`, write an inline finding with a *concrete* suggested test (test function name, package, the specific path it should cover). If you skip it, the main session injects a generic default in step 1.5 of `confidence.md` — your only lever is to *upgrade* with a better fix suggestion, not to suppress. Do not argue that a defensive guard / mirror of a tested pattern / author-justified-in-PR-body is "too minor for a test" — the author's justification belongs in the resolution thread, not in your decision to silence the finding.
 4. Produce a one-line summary per question for the body (`### Unknown-Unknowns Sweep` section). Concrete defects discovered during the sweep ALSO become individual findings anchored to lines. The blast-radius line MUST cite the caller count from the graph payload (or say `grep-only fallback` with the reason).
 
 **Output:** Findings list (one per concrete defect) + a `sweep_summary` block with five lines (one per question).
@@ -73,7 +75,10 @@ You are looking for **obvious bugs in the diff itself**. Read the changes, do no
 **Process:**
 1. Read the diff.
 2. For each changed function, look for: swapped conditions, off-by-one, nil/zero handling, error swallowing, panic in library code, defer/Close leaks, resource leaks, missing cancellation, dead branches, copy-paste bugs, wrong format specifier, wrong unit (seconds vs. ms).
-3. Apply the false-positive filter in `references/eligibility.md` to your own output before returning.
+3. **Walk the [REQUIRED CHECKS] in `references/checklist.md` §Security AND §Performance.** For every item, either produce a finding OR record `checked, no_evidence` / `not_applicable (<reason>)` in the `coverage` block. Silent skip is forbidden. The canonical rationalization "low risk because input isn't attacker-controlled today" is itself a Consider-level finding ("assumption recorded: <input> is currently trusted; if that ever changes, this becomes ___") — write it; do not swallow it.
+4. Apply the false-positive filter in `references/eligibility.md` to your own output before returning.
+
+**Return shape:** `{findings: [...], coverage: { security: {...}, performance: {...} }}`. Missing or partial coverage block = invalid return. See `references/checklist.md` → "Coverage block" for the exact key set and allowed values.
 
 **Hard rules:**
 - Do not flag pre-existing code that the PR didn't touch.
@@ -136,6 +141,36 @@ You read the history of the files this PR touches to surface context the diff al
 
 ---
 
+## Agent F — Dependency Reality Check
+
+You are the **mechanical** member of the fanout. No judgment. You verify that every dependency / import / package name **added** by this PR resolves to a real artifact on its public registry. This catches hallucinated packages ("slopsquatting") that pass every other text-based review.
+
+**Inputs:**
+- A pre-extracted JSON list of candidate artifacts produced by the dispatcher (Go modules, npm packages, Python packages, Rust crates) with their manifest lines and versions. See `references/import-verifier.md` → "What the dispatcher pre-extracts".
+- If the list is empty, return immediately with `coverage.dependencies.skipped: true (no new dependencies)` and no findings.
+
+**Process:**
+1. For each artifact, run the per-ecosystem verification command in `references/import-verifier.md` ("Per-ecosystem verification commands"). Cache by `(ecosystem, name, version)`.
+2. Classify each as: `ok` | `unresolved` | `version-missing` | `typo-suspect`.
+3. Emit findings per the severity rules in `import-verifier.md` → "Finding shape" (Blocking 100 for not-on-registry, Should-fix 95 for missing version, Should-fix 80 for typo neighbors).
+4. Return the `coverage.dependencies` block.
+
+**Hard rules:**
+- Do NOT judge whether a real dependency is a *good* dependency. License / popularity / CVEs are out of scope.
+- Do NOT chase transitive dependencies.
+- Network failure ≠ registry says no. Distinguish `skipped (no network)` from `unresolved (404)`.
+- Findings are independent of `GRAPH_PREFLIGHT` — graph reconciliation does NOT apply (these are not blast-radius claims).
+
+**Confidence calibration:**
+- 100: registry definitively says no (404 / `module ... not found`).
+- 95: registry has the package, not this version.
+- 80: registry has the package; name is within Levenshtein 2 of a top-1000 same-ecosystem package and the diff was AI-authored (typo-squat suspicion).
+- < 70: never. Either the registry has it or it doesn't — there is no "probably exists".
+
+**Output:** Findings list + `coverage.dependencies` block. See `references/import-verifier.md` for exact shape.
+
+---
+
 ## Agent E — In-File Comments & Conventions
 
 You read the comments inside the modified files and check the diff against them.
@@ -163,12 +198,15 @@ You read the comments inside the modified files and check the diff against them.
 ```python
 # Pseudocode — actually invoked as 5 parallel Task tool calls in one message.
 parallel_tasks = []
-for agent in ["A", "B", "C", "D", "E"]:
+agents = ["A", "B", "C", "D", "E"]
+if dependency_manifest_has_new_entries(diff):
+    agents.append("F")
+for agent in agents:
     parallel_tasks.append(
         Task(
             description=f"PR review fanout agent {agent}",
             subagent_type="general-purpose",
-            prompt=BRIEF[agent] + SHARED_PR_HEADER,
+            prompt=BRIEF[agent] + SHARED_PR_HEADER + (DEPENDENCY_MANIFEST if agent == "F" else ""),
         )
     )
 ```

--- a/skills/devpilot-pr-review/references/import-verifier.md
+++ b/skills/devpilot-pr-review/references/import-verifier.md
@@ -1,0 +1,141 @@
+# Import / Dependency Reality Check (Agent F)
+
+Agent F is the **mechanical** member of the fanout. It does no judgment — it checks that the artifacts the diff *names* (added imports, added dependencies, new package references) actually exist on their public registry. This is the cheapest, highest-signal class of finding in AI-authored code: hallucinated APIs / fake packages / "slopsquatting" survive every other agent's text-based review because they are syntactically perfect Go / TypeScript / Rust / Python.
+
+The dispatcher pre-extracts the candidate identifiers from the diff and hands them to Agent F as a structured list. Agent F runs the per-ecosystem verification command and returns one finding per *unresolved* artifact.
+
+## What the dispatcher pre-extracts (input to Agent F)
+
+Before dispatching Agent F, the main session walks the diff and assembles:
+
+```json
+{
+  "go": [
+    {"manifest_line": "go.mod:12", "module": "github.com/anthropics/agent-utils-v2", "version": "v0.4.1"},
+    {"import_line": "internal/scoring/score.go:4", "module": "github.com/anthropics/agent-utils-v2/ranking", "version": ""}
+  ],
+  "npm": [
+    {"manifest_line": "package.json:18", "package": "react-llm-toolkit", "version": "^3.2.1"}
+  ],
+  "python": [
+    {"manifest_line": "requirements.txt:7", "package": "anthropic-codetools", "version": "==0.9.0"}
+  ],
+  "rust": [
+    {"manifest_line": "Cargo.toml:14", "crate": "claude-tool-bridge", "version": "0.2"}
+  ]
+}
+```
+
+**Extraction rules:**
+
+- **Go** — every NEW line in `go.mod`'s `require` block; every NEW or MODIFIED `import "..."` line in `.go` files whose module path is not already present in the base-ref `go.mod`.
+- **npm** — every NEW key under `dependencies` / `devDependencies` / `peerDependencies` in `package.json`; every NEW `import ... from "<pkg>"` / `require("<pkg>")` whose package is not already in base-ref `package.json` (scoped packages count).
+- **Python** — every NEW line in `requirements*.txt` / `pyproject.toml [tool.poetry.dependencies]` / `setup.py install_requires`.
+- **Rust** — every NEW key under `[dependencies]` / `[dev-dependencies]` in `Cargo.toml`.
+
+Skip standard library imports (`fmt`, `os`, `sort` for Go; `react`, `node:fs` for npm; `os`, `sys`, `typing` for Python). The dispatcher's extractor maintains a small allowlist per language; everything else goes through Agent F.
+
+If the diff touches no manifest and no new third-party imports, **skip Agent F dispatch entirely** — there's nothing to check. Record `agent_f: skipped (no new dependencies)` in the body sweep summary.
+
+## Per-ecosystem verification commands
+
+Each must complete in < 5 s per artifact; cache the result by `(ecosystem, name, version)` within the review session to avoid duplicate calls when the same package appears in multiple lines.
+
+### Go
+
+```bash
+# Module-level existence (works without checkout):
+go list -m -json <module>@<version>          # version="" → use "latest"
+# Exit code 0 + JSON with Path field → exists.
+# Exit code != 0 + stderr containing "module ... not found" / "unknown revision" → does not exist.
+```
+
+Fallback if `go list` is unavailable in the sandbox:
+
+```bash
+curl -fsSI "https://proxy.golang.org/<module>/@v/list"     # 404 → does not exist
+```
+
+For sub-packages (`github.com/foo/bar/sub`), trim the path to the module root by matching against `go.mod`'s `require` block — registries are module-rooted, not path-rooted.
+
+### npm
+
+```bash
+npm view "<package>@<version>" name --json   # exits 0 + JSON → exists
+# Exit code != 0 → does not exist; stderr "404 Not Found" is definitive.
+```
+
+Fallback:
+
+```bash
+curl -fsS "https://registry.npmjs.org/<package>"   # 404 → not on registry
+```
+
+For scoped packages (`@org/pkg`), URL-encode the `/` (`%2F`) only in the curl form.
+
+### Python
+
+```bash
+curl -fsS "https://pypi.org/pypi/<package>/json" | jq -e '.info.name'
+# 404 → not on PyPI; check version exists in .releases keys.
+```
+
+### Rust
+
+```bash
+curl -fsS "https://crates.io/api/v1/crates/<crate>"   # 404 → not on crates.io
+```
+
+## Finding shape
+
+For each unresolved or suspicious artifact:
+
+```yaml
+- agent: F
+  path: <manifest_line.path>
+  line: <manifest_line.line>
+  side: RIGHT
+  title: "Dependency does not exist on registry — <name>@<version>"
+  severity: Blocking
+  confidence: 100
+  behavior: "`<name>@<version>` is referenced by this PR (manifest at <path>:<line>, import at <import_line.path>:<line>). The package was queried against <registry> and returned 404 / not-found."
+  why: "Hallucinated dependencies fail builds, expose the project to supply-chain compromise if a malicious actor later registers the typo'd name (slopsquatting), and indicate the change was written without execution. This must be resolved before merge."
+  fix: "Verify the intended package name. Candidates: <typo_candidates if generated>. If the package legitimately exists on a private registry, document the private-registry config in the PR description and `not_applicable` this check explicitly."
+```
+
+**Severity rules:**
+
+- Package not on registry at all → `Blocking, 100`.
+- Package exists but exact version not published → `Should-fix, 95`.
+- Package exists; name is within Levenshtein distance ≤ 2 of a top-1000 download package on the same registry (potential typosquat) → `Should-fix, 80`.
+- Package exists, version exists, no typo neighbors → no finding; record `<name>@<version>: ok` in coverage block.
+
+## Coverage block
+
+Agent F returns alongside findings:
+
+```yaml
+coverage:
+  dependencies:
+    artifacts_checked: <int>
+    artifacts_unresolved: <int>
+    artifacts_typo_flagged: <int>
+    skipped: false     # or true with reason
+```
+
+The dispatcher uses `artifacts_checked` to populate the body's "Dependency reality: N/N artifacts verified" line in the Unknown-Unknowns Sweep section.
+
+## What Agent F does NOT do
+
+- Does not judge whether a *real* dependency is a good choice. License, maintainership, popularity, security advisories — out of scope. License-and-CVE auditing is a separate skill we'd plug in later.
+- Does not chase transitive dependencies. Only directly-added artifacts in this PR's diff.
+- Does not run the package. Existence on registry, not behavior, is the contract.
+- Does not interact with private registries. If a name resolves locally via a private mirror but 404s on the public registry, Agent F reports `unresolved` and the author must explicitly mark `not_applicable (private registry: <reason>)`.
+
+## Failure modes & fallback
+
+- Network unavailable in the review sandbox → Agent F returns `coverage.dependencies.skipped: true (reason: no network)`. The body sweep shows `Dependency reality: not verified (no network)`; review event is downgraded to at most `COMMENT` if any new third-party dependency was added.
+- Registry rate-limit → wait 2 s, retry once; on second 429 record `skipped (rate-limited)`.
+- Ambiguous response (registry returns 200 with redirect to a deprecated/squatted package) → emit a `Should-fix, 70` finding and let the author confirm.
+
+Never block a review on Agent F infra failure — distinguish "network said no" from "registry said no" in the finding text.

--- a/skills/devpilot-pr-review/references/template.md
+++ b/skills/devpilot-pr-review/references/template.md
@@ -15,6 +15,8 @@ Every finding tied to a specific line uses this template. Posted as a single Git
 
 **Suggested change:** <concrete direction>
 
+**Suggested test:** <test function name + package + the path it should cover>  <!-- include ONLY for missing-test findings (graph-injected or Agent A); omit otherwise -->
+
 **Confidence:** <high | medium | low> — <one-line reason if not high>
 ```
 
@@ -57,6 +59,10 @@ The body holds only what doesn't belong on a single line: Verdict, TL;DR, Streng
 - Known pitfalls (incl. security/data/reversibility): <finding>
 - Stale-training check: <finding>
 - Hand-rolled vs. off-the-shelf: <finding>
+
+### Security / Performance coverage
+<n>/<total_security> security required-checks completed · <n>/<total_perf> performance required-checks completed
+<one line per `not_applicable` item with the reason; omit the line entirely if all checks were `checked, no_evidence` or `finding_raised`>
 
 ### Inline findings (count by severity)
 - Blocking: <n>


### PR DESCRIPTION
## Summary

Three coverage gaps in `devpilot-pr-review`, surfaced by running TDD-for-skills baselines (`superpowers:writing-skills`) on real merged PRs as fixtures and watching what the current skill missed. Each gap was closed with the smallest rule change that made the baseline subagent flip behavior; rationalizations the baseline used were captured verbatim and explicitly forbidden in the new rules.

### ① Graph-injected missing-test findings

**Fixture:** PR #132 — exported `LoadModule` modified, author explicitly skipped a test ("brittle to construct nil `TypesInfo`").

**RED:** baseline subagent returned `FINDINGS: none`, reasoning *"Raising it here would be a confidence-<70 nag against a pure mirror of an already-tested pattern."*

**GREEN:** main session now injects a Should-fix finding unconditionally for `is_exported && change_type ∈ {modified,added} && !has_tests && !trivial(diff)`. Agent A's only lever is to upgrade with a concrete test name; suppression is forbidden. Severity escalates to Blocking on `hub` / `interface_change` risk factors. After edits, GREEN subagent produced a Should-fix/85 finding with a concrete test name and a refactor suggestion.

**REFACTOR:** added "sibling-test transitivity is not coverage" clause to close a rationalization the GREEN run surfaced.

Files: `references/confidence.md` (+ step 1.5 + full Graph-injected findings section), `references/fanout.md` (Agent A escape-hatch text), `references/template.md` (optional `Suggested test:` line).

### ② Security / Performance [REQUIRED CHECKS]

**Fixture:** PR #131 — trello credentials moved from URL query to Authorization header (`fmt.Sprintf` interpolating apiKey into a backtick-quoted OAuth template).

**RED:** baseline Agent B returned `FINDINGS: none`, self-reporting: *"I scanned-and-judged based on what caught my eye against the bullet list... There is no audit trail in my process beyond this meta-note you explicitly asked for."* Five+ dimensions silently skipped including header injection, redirect cross-host propagation, credential echo in error bodies.

**GREEN:** `checklist.md` §Security and §Performance promoted to top-level `[REQUIRED CHECKS]` (8 + 7 items). Agent B must return a `coverage` block with `checked, no_evidence | finding_raised | not_applicable (<reason>)` for every item. Missing keys trigger one re-dispatch; second incomplete return downgrades the review event from APPROVE. After edits, GREEN subagent produced **5 findings + complete coverage block**, and listed three rationalizations it noticed resisting (verbatim phrases from the RED run).

Files: `references/checklist.md` (Security/Performance promoted + Coverage block spec), `references/fanout.md` (Agent B step 3 + return shape), `references/confidence.md` (Merge step 0 — Coverage assertion), `references/template.md` (body shows coverage counts).

### ③ Agent F — Dependency Reality Check

**Fixture:** synthetic Go diff adding `github.com/anthropics/agent-utils-v2@v0.4.1` (a hallucinated package).

**RED:** all 5 existing agents would miss it — A/B/C/D/E each cited their brief and confirmed dependency provenance is outside their scope. Fake import would reach APPROVE.

**GREEN:** added Agent F as a conditional sixth fanout slot (dispatched only when the diff touches dependency manifests or adds third-party imports). Pre-extracted artifact list per ecosystem; per-ecosystem registry-check commands (Go: `go list -m -json` or `proxy.golang.org`; npm: `npm view` or `registry.npmjs.org`; Python: PyPI JSON; Rust: crates.io API). Findings independent of graph reconciliation. GREEN subagent actually ran `curl` against `proxy.golang.org` and `api.github.com` — both 404 — and returned **2 Blocking/100 findings**, downgrading the review to REQUEST_CHANGES.

Files: `references/import-verifier.md` (new), `references/fanout.md` (Agent F brief + conditional dispatch), `SKILL.md` (fanout table 5→6, reference index).

## Why

External AI-code-review tools (Greptile v3, CodeRabbit, Graphite — see web comparison in conversation that produced this PR) outperform a single-pass review on three axes we were under-covering: explicit safety-dimension audit trails, missing-test enforcement on changed public surface, and supply-chain reality checks for AI-authored dependencies. These three changes close those gaps without adding fanout cost on PRs that don't need it (Agent F is conditional; the missing-test rule is graph-driven and free; the coverage block is a serialization tweak to Agent B's existing pass).

## Review Guide

Start with `references/confidence.md` — it's the merge orchestration and the new step 0 (coverage assertion) + step 1.5 (graph-injected findings) are the load-bearing rules. Then `references/checklist.md` for the [REQUIRED CHECKS] item lists. Then `references/import-verifier.md` for Agent F. `references/fanout.md` and `SKILL.md` are mostly stitching the above together.

Tricky bits to scrutinize:
- The `trivial` predicate in `confidence.md` Graph-injected findings — narrow on purpose, with explicit "Not trivial — DO inject" examples to forbid common rationalizations. PR #132 was exactly the borderline case.
- Coverage block allowed values: `checked, no_evidence` vs `not_applicable (<reason>)` — the rule that `not_applicable` requires a one-line reason is critical to prevent silent skipping.
- Agent F's distinction between `unresolved (404)` and `skipped (no network)` — never block on infra failure.

## Test Plan

- [x] RED → GREEN → REFACTOR cycles run for all three improvements with subagent baselines on real fixtures (PR #131, PR #132, synthetic fake-import diff). Evidence captured in conversation that produced this PR.
- [x] GREEN subagent for ② resisted three RED-phase rationalizations by name in its output.
- [x] GREEN subagent for ③ actually ran `curl proxy.golang.org` and confirmed 404 for the hallucinated module.
- [ ] Replay on a future real PR after merge — looking for cases where the coverage assertion triggers a re-dispatch.
- [ ] Watch first 5 real-world reviews for Agent F false positives on private-registry deps; expand the `not_applicable (private registry: ...)` guidance if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)