### PR TITLE
docs: explain how to update installed skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ npx skills add siyuqian/devpilot
 
 This drops the skills into `.claude/skills/` so Claude Code can pick them up immediately. Use the devpilot CLI below if you also want the Gmail / Slack / Trello helpers.
 
+**Updating installed skills** — pull the latest versions from this catalog:
+
+```bash
+npx skills list                      # see what's installed
+npx skills update                    # update all installed skills
+npx skills update devpilot-pr-review # update a single skill by name
+npx skills update -g                 # update globally-installed skills only
+npx skills update -p                 # update project-installed skills only
+```
+
+Each skill installs under its own name (e.g. `devpilot-pr-review`, `devpilot-learn`) — there is no single `devpilot` bundle to update. Re-running `npx skills add siyuqian/devpilot` also works and will overwrite the existing install.
+
 **From release:**
 ```bash
 curl -sSL https://raw.githubusercontent.com/SiyuQian/devpilot/main/install.sh | sh


### PR DESCRIPTION
## Summary

Adds an **Updating installed skills** subsection to `README.md`, right under the `npx skills add siyuqian/devpilot` install instructions.

Motivates the change: a user tried `npx skills update devpilot` and got `No installed skills found matching: devpilot`, because skills install under their individual names (`devpilot-pr-review`, `devpilot-learn`, …) rather than as a single `devpilot` bundle. The new block documents:

- `npx skills list` to inspect what's installed
- `npx skills update` to update everything
- `npx skills update <skill-name>` for a single skill (with a per-skill example)
- `-g` / `-p` scope flags
- The note that re-running `npx skills add siyuqian/devpilot` also overwrites the existing install

Docs-only — no code, no behavior change.

## Review Guide

Just `README.md`, lines around the install section. Verify the commands match `npx skills --help`.

## Test plan
- [x] `npx skills --help` confirms `update [skills...]`, `-g`, `-p` flags exist
- [x] `npx skills list` confirms installed skills use per-skill names (e.g. `devpilot-pr-review`)
- [ ] Reviewer: skim the new block for tone/voice consistency with the rest of the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)