### PR TITLE
feat: add devpilot-e2e-tests skill for Playwright generation

### DIFF
--- a/.claude/skills/devpilot-e2e-tests/SKILL.md
+++ b/.claude/skills/devpilot-e2e-tests/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: devpilot-e2e-tests
+description: Use when the user wants to generate, scaffold, or auto-write end-to-end / browser tests for a web app — "generate e2e tests", "write Playwright tests", "auto-generate browser tests", "/e2e-tests", "test the login/checkout flow end to end". Playwright-first; drives the running app to capture real selectors and verifies each spec to green. Do NOT use for unit/integration tests, API-only tests, CLI tests, or non-Playwright e2e frameworks already present (it will stop).
+---
+
+# Auto-Generate E2E Tests (Playwright)
+
+## Overview
+
+Generated e2e tests that were never executed are usually wrong — selectors mismatch, timing is off, auth is missing. This skill is **live-primary**: it drives the *running* app to capture real selectors and assert against the real DOM, then **verifies every spec to green** before reporting. A flow that can't be made green honestly is left as `test.fixme` with a diagnostic note — never faked by weakening an assertion or pasting blanket waits.
+
+## When to Use
+
+- "Generate e2e tests for this app" / "write Playwright tests"
+- "Test the login (or checkout, signup, …) flow end to end"
+- "Auto-generate browser tests for my web app"
+
+**Don't use for:** unit or integration tests, API-only tests (no browser), CLI tests, or a repo that already uses a **different** e2e framework (Cypress/Selenium/WebdriverIO) — this skill is Playwright-first and will stop rather than add a second harness.
+
+## Workflow
+
+```dot
+digraph e2e {
+    "Detect harness & framework" [shape=box];
+    "Other e2e framework present?" [shape=diamond];
+    "STOP — ask before adding Playwright" [shape=box];
+    "Playwright present?" [shape=diamond];
+    "Bootstrap minimal Playwright" [shape=box];
+    "Infer + confirm launch / auth / env" [shape=box];
+    "Set up storageState auth" [shape=box];
+    "Discover flows (MCP or source seed)" [shape=box];
+    "Propose prioritized batch, confirm" [shape=box];
+    "Generate one spec (semantic locators)" [shape=box];
+    "Run spec" [shape=box];
+    "Green?" [shape=diamond];
+    "Fix selector/assertion/wait (≤3 tries)" [shape=box];
+    "Mark test.fixme + note" [shape=box];
+    "More flows?" [shape=diamond];
+    "Report" [shape=doublecircle];
+
+    "Detect harness & framework" -> "Other e2e framework present?";
+    "Other e2e framework present?" -> "STOP — ask before adding Playwright" [label="yes"];
+    "Other e2e framework present?" -> "Playwright present?" [label="no"];
+    "Playwright present?" -> "Bootstrap minimal Playwright" [label="no"];
+    "Playwright present?" -> "Infer + confirm launch / auth / env" [label="yes"];
+    "Bootstrap minimal Playwright" -> "Infer + confirm launch / auth / env";
+    "Infer + confirm launch / auth / env" -> "Set up storageState auth";
+    "Set up storageState auth" -> "Discover flows (MCP or source seed)";
+    "Discover flows (MCP or source seed)" -> "Propose prioritized batch, confirm";
+    "Propose prioritized batch, confirm" -> "Generate one spec (semantic locators)";
+    "Generate one spec (semantic locators)" -> "Run spec" -> "Green?";
+    "Green?" -> "More flows?" [label="yes"];
+    "Green?" -> "Fix selector/assertion/wait (≤3 tries)" [label="no"];
+    "Fix selector/assertion/wait (≤3 tries)" -> "Run spec" [label="retry"];
+    "Fix selector/assertion/wait (≤3 tries)" -> "Mark test.fixme + note" [label="exhausted"];
+    "Mark test.fixme + note" -> "More flows?";
+    "More flows?" -> "Generate one spec (semantic locators)" [label="yes"];
+    "More flows?" -> "Report" [label="no"];
+}
+```
+
+## Step 1 — Detect & Gate
+
+Before writing anything, probe the project (inline `cat`/`ls`/grep — no scripts needed):
+
+- **Competing framework?** Look for `cypress/`, `cypress.config.*`, `wdio.conf.*`, Selenium deps. If found → **STOP.** Tell the user this skill is Playwright-first and a second harness is a maintenance smell; proceed only if they explicitly say "add Playwright anyway."
+- **Existing Playwright?** Check `@playwright/test` in `package.json`, a `playwright.config.*`, and any existing e2e dir (`e2e/`, `tests/e2e/`, `playwright/`). If present, conform to it — never clobber config.
+- **Discovery mode?** Check whether a Playwright MCP server is available. Announce which mode you'll use: **MCP** (preferred — read the real accessibility tree) or **runner fallback** (spec-and-run + `--trace`/`show-report` convergence).
+- **Launch / auth / env (infer → confirm):** read `package.json` scripts, README, and `.env.example` to guess the dev command, base URL, whether auth exists, and the target environment. Present your guesses in **one** confirmation and ask only for what you genuinely can't find (test credentials). Ask once: **"Is the app I'll drive a throwaway/test environment?"** — this gates destructive flows in Step 6.
+
+## Step 2 — Bootstrap Minimal (only if no Playwright)
+
+If and only if no Playwright setup exists, scaffold the bare minimum and nothing more:
+
+- Install `@playwright/test` (match the project's package manager) and browsers (`npx playwright install`).
+- Write a minimal `playwright.config.ts`: `baseURL` → the confirmed dev server, a `webServer` block to start it, the test dir, and the `storageState` setup project from Step 3.
+- Create one test dir (default `e2e/`). No reporters, sharding, or device matrices — that's not this skill's job.
+
+## Step 3 — Auth via `storageState`
+
+For any authenticated flow, use Playwright's standard pattern: a **`global.setup`** project that logs in once through the UI and saves `storageState` to disk; authenticated specs declare `storageState` so they start logged in. This keeps specs fast and isolated. Never hardcode credentials in specs — read them from env/config.
+
+## Step 4 — Discover & Propose Flows
+
+Seed candidate flows from the frontend **source** (routes, pages, forms, nav links), then refine against the **live** app (MCP snapshot, or a quick navigation pass). Prioritize **critical paths first**: auth → core CRUD → primary value flows (checkout/submit) → secondary navigation. Present the prioritized candidate list and let the user confirm or narrow the batch. If the user named a single flow, just do that one.
+
+## Step 5 — Generate (Strict Semantic Locators)
+
+Write one spec per flow. **Locators are semantic-only:**
+
+| Prefer | Avoid |
+|--------|-------|
+| `getByRole(name=…)`, `getByLabel`, `getByText`, `getByTestId` | `getByRole` ✗ CSS selectors, XPath, `nth-child`, class chains |
+
+There is **no CSS/XPath fallback.** When a control has no accessible name and no `data-testid`, do **not** invent a brittle selector — record a **recommendation** to add a `data-testid` (control description + suggested id) and, if it blocks the flow, mark that spec `test.fixme`. **Never edit the app's source** to add test hooks; only recommend.
+
+Keep specs flat and readable. Suggest a Page Object Model only if the suite grows large — don't impose it.
+
+## Step 6 — Verify Loop (Bounded, Honest)
+
+Run each generated spec (`npx playwright test <file>`). On failure, inspect the **real** evidence — error message, `--trace`, `npx playwright show-report`, or the live MCP DOM — and fix the selector, assertion, or wait. Retry up to **~3 times**.
+
+- **Green** → keep the spec.
+- **Still red after the bound** → mark `test.fixme` with a one-line note explaining what blocked it (e.g. "no accessible name on submit button; needs data-testid").
+- **Never** force green: don't relax an assertion to `toBeTruthy`, don't add blanket `waitForTimeout`, don't comment out the failing check.
+
+**Destructive flows:** if the user confirmed a throwaway/test env (Step 1), verify mutation flows (create/delete/update) live. If the env is real or unknown, generate them but leave them `test.fixme` with a note. **Irreversible actions (payments, real emails) default to `test.fixme` regardless of environment** unless the user explicitly green-lights them.
+
+## Common Mistakes & Red Flags — STOP
+
+- Falling back to CSS/XPath/`nth-child` when no semantic locator exists. → Recommend a `data-testid` instead.
+- Faking green: weakening an assertion, adding blanket waits, or commenting out a check to make a flaky spec pass.
+- Clobbering an existing `playwright.config.*` or e2e dir layout.
+- Adding Playwright next to an existing Cypress/Selenium suite without explicit user opt-in.
+- Running mutation/payment flows against an environment whose disposability you didn't confirm.
+- Editing the app's component source to add test hooks (only recommend).
+- Reporting specs as done without actually running them.
+
+If any apply, **stop and correct course** before continuing.
+
+## Reporting
+
+When done, report: discovery mode used (MCP vs runner); flows discovered and which were generated; per-spec status (green vs `test.fixme` + why); `data-testid` recommendations grouped by component; and any flows skipped for environment-safety reasons.

--- a/.claude/skills/devpilot-e2e-tests/evals/evals.json
+++ b/.claude/skills/devpilot-e2e-tests/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "e2e-tests",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "Generate end-to-end tests for our web app. We don't have any e2e setup yet.",
+      "expected_output": "Detects no Playwright present, bootstraps a minimal Playwright setup (install + minimal config + e2e dir), infers/confirms the dev command, base URL and auth, then discovers flows and generates+verifies specs to green.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "prompt": "Auto-generate Playwright tests for the main user flows. We already have Playwright configured in tests/e2e.",
+      "expected_output": "Detects the existing Playwright setup and conforms to the tests/e2e layout without clobbering config, proposes a prioritized batch of flows (auth/core CRUD first), and verifies each generated spec to green or leaves test.fixme with a note.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Write an e2e test for the checkout flow end to end.",
+      "expected_output": "Generates a single spec for the named checkout flow using strict semantic locators, drives the running app to capture real selectors, and runs it in a bounded verify loop. Treats payment/irreversible steps as test.fixme unless the user green-lights a test environment.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Can you generate browser e2e tests? Our repo already uses Cypress.",
+      "expected_output": "Detects the existing Cypress suite and STOPS rather than adding a second framework, explaining the maintenance smell and asking whether the user explicitly wants to add Playwright alongside it.",
+      "files": []
+    }
+  ]
+}

--- a/skills/devpilot-e2e-tests/SKILL.md
+++ b/skills/devpilot-e2e-tests/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: devpilot-e2e-tests
+description: Use when the user wants to generate, scaffold, or auto-write end-to-end / browser tests for a web app — "generate e2e tests", "write Playwright tests", "auto-generate browser tests", "/e2e-tests", "test the login/checkout flow end to end". Playwright-first; drives the running app to capture real selectors and verifies each spec to green. Do NOT use for unit/integration tests, API-only tests, CLI tests, or non-Playwright e2e frameworks already present (it will stop).
+---
+
+# Auto-Generate E2E Tests (Playwright)
+
+## Overview
+
+Generated e2e tests that were never executed are usually wrong — selectors mismatch, timing is off, auth is missing. This skill is **live-primary**: it drives the *running* app to capture real selectors and assert against the real DOM, then **verifies every spec to green** before reporting. A flow that can't be made green honestly is left as `test.fixme` with a diagnostic note — never faked by weakening an assertion or pasting blanket waits.
+
+## When to Use
+
+- "Generate e2e tests for this app" / "write Playwright tests"
+- "Test the login (or checkout, signup, …) flow end to end"
+- "Auto-generate browser tests for my web app"
+
+**Don't use for:** unit or integration tests, API-only tests (no browser), CLI tests, or a repo that already uses a **different** e2e framework (Cypress/Selenium/WebdriverIO) — this skill is Playwright-first and will stop rather than add a second harness.
+
+## Workflow
+
+```dot
+digraph e2e {
+    "Detect harness & framework" [shape=box];
+    "Other e2e framework present?" [shape=diamond];
+    "STOP — ask before adding Playwright" [shape=box];
+    "Playwright present?" [shape=diamond];
+    "Bootstrap minimal Playwright" [shape=box];
+    "Infer + confirm launch / auth / env" [shape=box];
+    "Set up storageState auth" [shape=box];
+    "Discover flows (MCP or source seed)" [shape=box];
+    "Propose prioritized batch, confirm" [shape=box];
+    "Generate one spec (semantic locators)" [shape=box];
+    "Run spec" [shape=box];
+    "Green?" [shape=diamond];
+    "Fix selector/assertion/wait (≤3 tries)" [shape=box];
+    "Mark test.fixme + note" [shape=box];
+    "More flows?" [shape=diamond];
+    "Report" [shape=doublecircle];
+
+    "Detect harness & framework" -> "Other e2e framework present?";
+    "Other e2e framework present?" -> "STOP — ask before adding Playwright" [label="yes"];
+    "Other e2e framework present?" -> "Playwright present?" [label="no"];
+    "Playwright present?" -> "Bootstrap minimal Playwright" [label="no"];
+    "Playwright present?" -> "Infer + confirm launch / auth / env" [label="yes"];
+    "Bootstrap minimal Playwright" -> "Infer + confirm launch / auth / env";
+    "Infer + confirm launch / auth / env" -> "Set up storageState auth";
+    "Set up storageState auth" -> "Discover flows (MCP or source seed)";
+    "Discover flows (MCP or source seed)" -> "Propose prioritized batch, confirm";
+    "Propose prioritized batch, confirm" -> "Generate one spec (semantic locators)";
+    "Generate one spec (semantic locators)" -> "Run spec" -> "Green?";
+    "Green?" -> "More flows?" [label="yes"];
+    "Green?" -> "Fix selector/assertion/wait (≤3 tries)" [label="no"];
+    "Fix selector/assertion/wait (≤3 tries)" -> "Run spec" [label="retry"];
+    "Fix selector/assertion/wait (≤3 tries)" -> "Mark test.fixme + note" [label="exhausted"];
+    "Mark test.fixme + note" -> "More flows?";
+    "More flows?" -> "Generate one spec (semantic locators)" [label="yes"];
+    "More flows?" -> "Report" [label="no"];
+}
+```
+
+## Step 1 — Detect & Gate
+
+Before writing anything, probe the project (inline `cat`/`ls`/grep — no scripts needed):
+
+- **Competing framework?** Look for `cypress/`, `cypress.config.*`, `wdio.conf.*`, Selenium deps. If found → **STOP.** Tell the user this skill is Playwright-first and a second harness is a maintenance smell; proceed only if they explicitly say "add Playwright anyway."
+- **Existing Playwright?** Check `@playwright/test` in `package.json`, a `playwright.config.*`, and any existing e2e dir (`e2e/`, `tests/e2e/`, `playwright/`). If present, conform to it — never clobber config.
+- **Discovery mode?** Check whether a Playwright MCP server is available. Announce which mode you'll use: **MCP** (preferred — read the real accessibility tree) or **runner fallback** (spec-and-run + `--trace`/`show-report` convergence).
+- **Launch / auth / env (infer → confirm):** read `package.json` scripts, README, and `.env.example` to guess the dev command, base URL, whether auth exists, and the target environment. Present your guesses in **one** confirmation and ask only for what you genuinely can't find (test credentials). Ask once: **"Is the app I'll drive a throwaway/test environment?"** — this gates destructive flows in Step 6.
+
+## Step 2 — Bootstrap Minimal (only if no Playwright)
+
+If and only if no Playwright setup exists, scaffold the bare minimum and nothing more:
+
+- Install `@playwright/test` (match the project's package manager) and browsers (`npx playwright install`).
+- Write a minimal `playwright.config.ts`: `baseURL` → the confirmed dev server, a `webServer` block to start it, the test dir, and the `storageState` setup project from Step 3.
+- Create one test dir (default `e2e/`). No reporters, sharding, or device matrices — that's not this skill's job.
+
+## Step 3 — Auth via `storageState`
+
+For any authenticated flow, use Playwright's standard pattern: a **`global.setup`** project that logs in once through the UI and saves `storageState` to disk; authenticated specs declare `storageState` so they start logged in. This keeps specs fast and isolated. Never hardcode credentials in specs — read them from env/config.
+
+## Step 4 — Discover & Propose Flows
+
+Seed candidate flows from the frontend **source** (routes, pages, forms, nav links), then refine against the **live** app (MCP snapshot, or a quick navigation pass). Prioritize **critical paths first**: auth → core CRUD → primary value flows (checkout/submit) → secondary navigation. Present the prioritized candidate list and let the user confirm or narrow the batch. If the user named a single flow, just do that one.
+
+## Step 5 — Generate (Strict Semantic Locators)
+
+Write one spec per flow. **Locators are semantic-only:**
+
+| Prefer | Avoid |
+|--------|-------|
+| `getByRole(name=…)`, `getByLabel`, `getByText`, `getByTestId` | `getByRole` ✗ CSS selectors, XPath, `nth-child`, class chains |
+
+There is **no CSS/XPath fallback.** When a control has no accessible name and no `data-testid`, do **not** invent a brittle selector — record a **recommendation** to add a `data-testid` (control description + suggested id) and, if it blocks the flow, mark that spec `test.fixme`. **Never edit the app's source** to add test hooks; only recommend.
+
+Keep specs flat and readable. Suggest a Page Object Model only if the suite grows large — don't impose it.
+
+## Step 6 — Verify Loop (Bounded, Honest)
+
+Run each generated spec (`npx playwright test <file>`). On failure, inspect the **real** evidence — error message, `--trace`, `npx playwright show-report`, or the live MCP DOM — and fix the selector, assertion, or wait. Retry up to **~3 times**.
+
+- **Green** → keep the spec.
+- **Still red after the bound** → mark `test.fixme` with a one-line note explaining what blocked it (e.g. "no accessible name on submit button; needs data-testid").
+- **Never** force green: don't relax an assertion to `toBeTruthy`, don't add blanket `waitForTimeout`, don't comment out the failing check.
+
+**Destructive flows:** if the user confirmed a throwaway/test env (Step 1), verify mutation flows (create/delete/update) live. If the env is real or unknown, generate them but leave them `test.fixme` with a note. **Irreversible actions (payments, real emails) default to `test.fixme` regardless of environment** unless the user explicitly green-lights them.
+
+## Common Mistakes & Red Flags — STOP
+
+- Falling back to CSS/XPath/`nth-child` when no semantic locator exists. → Recommend a `data-testid` instead.
+- Faking green: weakening an assertion, adding blanket waits, or commenting out a check to make a flaky spec pass.
+- Clobbering an existing `playwright.config.*` or e2e dir layout.
+- Adding Playwright next to an existing Cypress/Selenium suite without explicit user opt-in.
+- Running mutation/payment flows against an environment whose disposability you didn't confirm.
+- Editing the app's component source to add test hooks (only recommend).
+- Reporting specs as done without actually running them.
+
+If any apply, **stop and correct course** before continuing.
+
+## Reporting
+
+When done, report: discovery mode used (MCP vs runner); flows discovered and which were generated; per-spec status (green vs `test.fixme` + why); `data-testid` recommendations grouped by component; and any flows skipped for environment-safety reasons.

--- a/skills/devpilot-e2e-tests/evals/evals.json
+++ b/skills/devpilot-e2e-tests/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "e2e-tests",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "Generate end-to-end tests for our web app. We don't have any e2e setup yet.",
+      "expected_output": "Detects no Playwright present, bootstraps a minimal Playwright setup (install + minimal config + e2e dir), infers/confirms the dev command, base URL and auth, then discovers flows and generates+verifies specs to green.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "prompt": "Auto-generate Playwright tests for the main user flows. We already have Playwright configured in tests/e2e.",
+      "expected_output": "Detects the existing Playwright setup and conforms to the tests/e2e layout without clobbering config, proposes a prioritized batch of flows (auth/core CRUD first), and verifies each generated spec to green or leaves test.fixme with a note.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Write an e2e test for the checkout flow end to end.",
+      "expected_output": "Generates a single spec for the named checkout flow using strict semantic locators, drives the running app to capture real selectors, and runs it in a bounded verify loop. Treats payment/irreversible steps as test.fixme unless the user green-lights a test environment.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Can you generate browser e2e tests? Our repo already uses Cypress.",
+      "expected_output": "Detects the existing Cypress suite and STOPS rather than adding a second framework, explaining the maintenance smell and asking whether the user explicitly wants to add Playwright alongside it.",
+      "files": []
+    }
+  ]
+}

--- a/skills/index.json
+++ b/skills/index.json
@@ -73,6 +73,14 @@
       ]
     },
     {
+      "name": "devpilot-e2e-tests",
+      "description": "Use when the user wants to generate, scaffold, or auto-write end-to-end / browser tests for a web app. Playwright-first; drives the running app to capture real selectors and verifies each spec to green. Do NOT use for unit/integration tests, API-only tests, CLI tests, or non-Playwright e2e frameworks already present (it will stop).",
+      "files": [
+        "evals/evals.json",
+        "SKILL.md"
+      ]
+    },
+    {
       "name": "devpilot-google-go-style",
       "description": "ALWAYS use when working in a Go project — writing new Go code, modifying .go files, reviewing Go PRs, or discussing Go design decisions.",
       "files": [


### PR DESCRIPTION
## Summary

Adds **`devpilot-e2e-tests`** — a Playwright-first catalog skill that auto-generates browser end-to-end tests by driving the *running* app and verifying every spec to green before reporting.

The skill is pure-prose workflow guidance (no helper scripts), matching the style of `devpilot-dead-code-cleanup` / `devpilot-scanning-repos`. It leans on Playwright MCP when available, falling back to the `npx playwright test --trace` / `show-report` convergence loop when not.

Key behaviors encoded in `SKILL.md`:

- **Detect & gate first.** If a competing e2e framework (Cypress / Selenium / WebdriverIO) is present, the skill **stops** rather than introduce a second harness.
- **Detect-don't-clobber.** Conforms to any existing Playwright config and e2e dir layout; bootstraps a minimal setup only when none exists.
- **Infer-then-confirm** launch command / base URL / auth / environment; one-shot confirmation, asks only for the genuinely-unknown (test creds).
- **`storageState` auth** via a `global.setup` project, reused across authenticated specs.
- **Critical-path-first flow discovery**, propose a prioritized batch, user confirms scope.
- **Strict semantic locators** (`getByRole` / `getByLabel` / `getByText` / `getByTestId`) — no CSS/XPath fallback. Missing accessible name → *recommend* a `data-testid`; never edits app source.
- **Bounded verify-until-green** (~3 attempts). On exhaustion, mark `test.fixme` with a diagnostic note — never weaken an assertion or paste blanket waits.
- **Destructive-flow safety**: one up-front question about the target environment; payments / irreversible actions default to `test.fixme` regardless.

## Files

- `skills/devpilot-e2e-tests/SKILL.md` — workflow + `dot` graph + selector rules + STOP red flags + reporting section.
- `skills/devpilot-e2e-tests/evals/evals.json` — 4 evals: greenfield no-Playwright, existing Playwright suite, single named flow, Cypress-already-present.
- `skills/index.json` — registration entry inserted between `devpilot-daily-toolkit` and `devpilot-google-go-style`.
- `.claude/skills/devpilot-e2e-tests/` — install mirror.

Design captured at `~/.claude/plans/d-crispy-tarjan.md` during brainstorming (13 design questions resolved before any file was touched).

## Review Guide

Start with **`skills/devpilot-e2e-tests/SKILL.md`** — that's where the design lives. Read it top-to-bottom; the `dot` workflow graph on top is the spine and every numbered step maps to a node in it.

Suggested reading order for the rest:
1. `skills/devpilot-e2e-tests/SKILL.md` frontmatter — confirm the trigger description is specific enough (Playwright-first; lists positive triggers and the explicit "Do NOT use for" exclusions including the Cypress-already-present case).
2. `skills/devpilot-e2e-tests/SKILL.md` Steps 1, 6, and Common Mistakes — the riskiest parts: the gate logic, the verify loop's `test.fixme` discipline, and the explicit no-CSS-fallback / no-faking-green rules.
3. `skills/devpilot-e2e-tests/evals/evals.json` — the 4 evals should each map clearly to a Step-1 branch (greenfield → Step 2 bootstrap; existing setup → conform; single flow → degraded scope mode; Cypress → STOP).
4. `skills/index.json` diff — alphabetical insertion, files list matches what's on disk.

Things to look at critically:
- **Description triggers** — does it cleanly distinguish from `devpilot-pr-review` and the superpowers `test-driven-development` skill? (It's scoped to e2e/browser/Playwright specifically.)
- **The "never edit app source" stance** — would you rather it offered to add `data-testid`s with confirmation? The brainstorm picked recommend-only for blast-radius reasons; reasonable to revisit.
- **The destructive-env confirmation question** — phrased as one up-front question; check the wording in Step 1 doesn't read as paranoid for typical local-dev usage.

Out of scope for this PR (intentionally): the pre-existing `skills/` ↔ `.claude/skills/` drift in other skills (pr-review/scanning-repos references, untracked `devpilot-cv-writer` etc.) — `make sync-skills` surfaced it, but it predates this branch and is unrelated. Worth a separate cleanup PR.

## Test plan

- [x] `python3 -m json.tool skills/index.json` — valid JSON
- [x] `python3 -m json.tool skills/devpilot-e2e-tests/evals/evals.json` — valid JSON
- [x] `make lint` — `golangci-lint run ./...` → 0 issues
- [x] `make test` — all packages pass
- [x] Skill appears in the live Claude Code skill catalog under `devpilot-e2e-tests`
- [x] `skills/` and `.claude/skills/` copies of `devpilot-e2e-tests/` are byte-identical
- [x] Manual smoke: invoke the skill against a small Playwright project (greenfield) and against an existing-suite project; confirm both discovery modes (MCP and runner-fallback) and the verify-until-green loop behave as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)