### PR TITLE
docs(devpilot-learn): sync SKILL/workflow/contract to single close-reading mode

### DIFF
--- a/skills/devpilot-learn/SKILL.md
+++ b/skills/devpilot-learn/SKILL.md
@@ -14,32 +14,36 @@ description: >
 
 # Learn
 
-Generate a standalone HTML learning artifact from a single source.
+Generate a standalone HTML **close-reading study artifact** from a single source.
 
-The skill supports two valid output modes:
+This skill has one job and one output shape. It does **not** summarize. It produces a
+single-column, reading-oriented document that keeps the source's **actual words** and
+helps the reader study them:
 
-- **Bilingual digest mode** — a fixed `English | 中文` comparison document for general
-  summaries
-- **Study-guide mode** — a Chinese-first, chaptered learning handout for long or
-  educational sources, with explicit `原文摘要 / Source Summary` blocks to help review
+- **Verbatim original** — the source's substantive text, copied faithfully, is the
+  primary prose and dominates the page.
+- **Chinese translation** — a faithful translation sits directly *below* each original
+  passage (never in a side-by-side column).
+- **Quizzes** — a short `节后小测` after each section and a `总测` at the end, with every
+  answer collapsed inside a `<details>` element.
 
-When the user asks for 学习资料 / notes / review material, or the source is chaptered,
-legal, academic, technical, doctrinal, or exam-prep oriented, prefer **study-guide mode**.
+The recurring failure mode this skill guards against is **over-compression**: turning the
+source into a short digest and losing its substance. The artifact is normally *larger*
+than the source, because it adds a translation and quizzes beneath text it has kept.
 
 ## Files in this skill
 
 | File | When to load |
 |---|---|
-| `references/output-contract.md` | First — mode selection, output guarantees, and the hard constraints that must never drift. |
-| `references/workflow.md` | During execution — source handling, mode selection, generation flow, save rules, and edge cases. |
-| `references/html-skeleton.md` | Use for bilingual digest mode — the responsive comparison-layout baseline. |
-| `references/study-guide-skeleton.md` | Use for study-guide mode — the chaptered learning-material layout with `原文摘要`. |
+| `references/output-contract.md` | First — the output guarantees and hard constraints, especially the rule against over-compression. |
+| `references/workflow.md` | During execution — source fetching, segmentation, generation flow, save rules, and edge cases. |
+| `references/skeleton.md` | When ready to emit the HTML — the single-column verbatim-original → translation → quiz layout. |
 
 ## How to use this skill
 
 1. Read `references/output-contract.md` before writing anything.
-2. Follow `references/workflow.md` to choose the correct mode and generate the right structure.
-3. Load only the skeleton file for the chosen mode when you are ready to emit the final HTML file.
+2. Follow `references/workflow.md` to fetch the source, segment it, and generate the artifact.
+3. Load `references/skeleton.md` for the layout when you are ready to emit the final HTML file.
 
 Keep `SKILL.md` as the entry point. Put detailed layout, workflow, and output spec
 in the reference files above rather than re-expanding them inline.

--- a/skills/devpilot-learn/references/output-contract.md
+++ b/skills/devpilot-learn/references/output-contract.md
@@ -1,60 +1,55 @@
 # Output Contract
 
-The final artifact must always be a single self-contained `.html` file with inline
-CSS only.
+The final artifact is always a single self-contained `.html` file with inline CSS
+only — no external stylesheets, no JavaScript, no network dependencies. It must open
+correctly by double-clicking the file.
 
-The skill supports two output modes.
+## The one mode: close-reading study artifact
 
-## Mode 1: Bilingual digest mode
+This skill produces **one** kind of artifact: a single-column, Chinese-annotated
+*close reading* of the source. It is not a digest and not a summary. The whole point
+is that the reader can study the source's **actual words**, with help, rather than
+read your compressed retelling of them.
 
-Use this for general article/document summarization when the user wants a concise
-digest rather than study material.
+Three pillars, in this rhythm, repeated section by section:
 
-Required shape:
+1. **Verbatim original** (`.orig`) — the source's real wording, copied faithfully.
+   This is the primary prose and should dominate the page by volume.
+2. **Chinese translation** (`.zh`) — a faithful translation sitting directly *below*
+   each original passage (never in a second column). This is where interpretation
+   lives; keep it accurate to the passage above it.
+3. **Quizzes** — short `节后小测` after each section and a `总测` at the end, every
+   answer hidden inside a `<details>` element so it stays collapsed until opened.
 
-- A fixed bilingual digest with `English | 中文` content blocks
-- Desktop: side-by-side columns
-- Mobile: stacked blocks, `English` first and `中文` second
-- A document with the sections below, in this exact order:
-  1. Bilingual Title
-  2. Metadata
-  3. `At a Glance / 一眼速览`
-  4. `Summary / 摘要`
-  5. `Key Points / 要点`
-  6. `Evidence & Data / 证据与数据`
-  7. `Visuals / 图表与视觉要素`
-  8. `Terminology Glossary / 术语对照表`
+Optional, used sparingly: `.note` glosses for individual terms or hard phrases that
+genuinely need explanation.
 
-## Mode 2: Study-guide mode
+## What "don't over-compress" means concretely
 
-Use this when the user asks for 学习资料 / notes / review material, or the source is
-chaptered, legal, academic, technical, doctrinal, or exam-prep oriented.
+The previous version of this skill summarized the source and lost its substance. That
+is the failure mode this contract exists to prevent.
 
-Required shape:
-
-- A Chinese-first, single-column study guide
-- A visible source metadata block near the top
-- A table of contents for major sections
-- Major sections should follow the source's chapter or section order
-- Every major section must begin with an explicit `原文摘要 / Source Summary` block
-  that faithfully summarizes that source section
-- Study-oriented callouts such as `重点`, `术语`, `法条/案例`, examples, or review notes
-  should be used when the source supports them
-- A closing `总结复习` section is required
-- Short review questions are recommended when the source is substantial enough to support
-  them, but they are not mandatory for every source
-- The artifact should help the user study the original source, not merely skim a digest
+- **Keep the original text.** Reproduce the source's substantive paragraphs verbatim
+  in `.orig` blocks. Do not paraphrase them, do not reduce a multi-sentence paragraph
+  to a single quoted line, and do not replace a section with a summary of it.
+- **Coverage over brevity.** Walk the source front to back. A reader should be able to
+  follow the source's full argument from your `.orig` blocks alone, in the source's
+  own order. Skipping whole sections to save space defeats the purpose.
+- **The artifact is normally larger than the source**, because it adds a translation
+  and quizzes beneath text it has kept. If your output is dramatically shorter than the
+  source, you have summarized instead of close-read — go back and restore the original
+  passages.
+- The only text you may safely drop is genuine non-content: running headers/footers,
+  page numbers, copyright boilerplate, navigation, and pure repetition.
 
 ## Non-negotiable rules
 
-- Pick one mode deliberately; do not blend them into an incoherent hybrid
-- Stay within what the source explicitly states or directly supports; do not add speculative
-  interpretation
-- If the source quality is poor or incomplete, degrade honestly while preserving the
-  chosen mode's overall structure
-- Preserve important source terminology faithfully; prefer common Chinese renderings
-  when they preserve meaning
-- For proper nouns such as company names, product names, model names, and organizations,
-  keep the original term and add a common Chinese rendering only when useful
-- In study-guide mode, `原文摘要 / Source Summary` must summarize the source section itself,
-  not your downstream study advice
+- Single-column flow only. Never a side-by-side / two-column comparison layout — that
+  framing pushes generation toward digest behavior.
+- `.zh` must faithfully translate the `.orig` directly above it; do not add claims that
+  aren't in that passage and do not editorialize.
+- Preserve source terminology. For statutes, cases, proper nouns, product/model/org
+  names, keep the original term and add a common Chinese rendering only when it helps.
+- Quizzes must be answerable from the source alone — never test outside knowledge.
+- If the source is thin, paywalled, or partly inaccessible, degrade honestly: keep the
+  close-reading structure over whatever text you actually have, and say so. Don't pad.

--- a/skills/devpilot-learn/references/workflow.md
+++ b/skills/devpilot-learn/references/workflow.md
@@ -1,223 +1,94 @@
 # Workflow
 
-## 1. Identify the source type
+Read `output-contract.md` first. This file is the step-by-step execution flow for
+producing the close-reading artifact.
 
-The user will provide one of:
+## 1. Identify and fetch the source
 
-- **URL** — web page or online article
-- **PDF** — local `.pdf`
-- **Word doc** — local `.docx`
-- **Text file** — local `.txt`, `.md`, or similar
-- **Pasted text** — content directly in the message
+The user provides one of:
 
-## 2. Fetch the content
+- **URL** — use `WebFetch`. If the page is paywalled, mostly navigation, or too thin,
+  tell the user the source is weak and continue only with what is actually accessible.
+- **PDF** (`.pdf`) — use the `Read` tool with the file path. **Read the whole document**,
+  not just the first pages. You cannot close-read text you never loaded, so cover every
+  section before writing.
+- **Word doc** (`.docx`) — convert with `textutil -convert txt <file> -stdout` (macOS) or
+  `pandoc <file> -t plain` as fallback.
+- **Text / Markdown** (`.txt`, `.md`) or **pasted text** — read directly.
 
-**For URLs:**
-Use `WebFetch` to retrieve the page. If the page is too short, obviously paywalled,
-or mostly navigation/login content, tell the user the source is weak and continue
-only if enough content remains to build a constrained digest.
+For long sources, read in passes if needed, but do not start writing until you have seen
+the full source end to end.
 
-**For PDFs:**
-Use the `Read` tool with the file path. For long PDFs, read enough to cover the whole
-argument before summarizing.
+## 2. Normalize metadata
 
-**For Word docs (.docx):**
-Use `Bash` to convert with `textutil -convert txt <file> -stdout` on macOS or use
-`pandoc <file> -t plain` as fallback.
+Identify, from the source itself:
 
-**For text files / pasted text:**
-Read directly.
+- **Title** — the source's real title.
+- **Content Type / 内容类型** — pick from: `Article / 文章`, `Report / 报告`,
+  `Paper / 论文`, `PDF Document / PDF 文档`, `Web Page / 网页`,
+  `Transcript / 访谈实录`, or `Document / 文档` when uncertain.
+- **Source / 来源** — URL or filename (clickable in the meta block).
+- **Author / 作者** and **Published / 发布时间** — only if the source states them.
 
-## 3. Choose the output mode
+## 3. Segment the source
 
-Select the mode before outlining the artifact.
+Split the source into its natural sections, following its own chapter/heading/section
+order. Each section becomes one `<h2>` block in the artifact. For an unstructured source,
+segment by topic shift into a handful of coherent chunks. Do not flatten everything into
+one undifferentiated block, and do not reorder the source.
 
-Choose **study-guide mode** when one or more of these are true:
+Within each section, note:
 
-- The user asks for 学习资料, notes, revision material, exam prep, or chapter-by-chapter learning help
-- The source is long and structurally organized, such as a textbook chapter, legal reading,
-  policy manual, course packet, academic paper, or technical explainer
-- The user wants help studying the original source rather than only skimming it
+- which paragraphs are substantive (these become `.orig` blocks — keep them verbatim)
+- which terms or phrases genuinely need a `.note` gloss
+- what a fair `节后小测` question would test, answerable from that section alone
 
-Choose **bilingual digest mode** when:
+## 4. Build the artifact
 
-- The user wants a concise digest, high-level summary, or quick bilingual comparison
-- The source is article-shaped and not naturally chaptered
+Load `skeleton.md` and follow its layout. For each section, in source order:
 
-If in doubt, prefer **study-guide mode** for educational sources and **digest mode**
-for general articles.
+1. Reproduce the section's substantive paragraphs **verbatim** in `.orig` blocks. Keep
+   large portions of the original — this is the heart of the artifact. Do not paraphrase
+   or compress them into a single line.
+2. Put a faithful Chinese translation in a `.zh` block directly below each `.orig`.
+3. Add `.note` glosses sparingly, only where a term or phrase needs explanation.
+4. End the section with a `节后小测` containing 1–3 questions, each answer hidden in a
+   `<details>` element.
 
-## 4. Normalize the source
+Then close with a `总测 / Final Test` spanning the whole source, same `<details>` answer
+pattern.
 
-Before writing the artifact:
+Keep the meta block at the top and a `目录` table of contents when the source has several
+sections (drop it for short single-section sources).
 
-- Determine the title
-- Determine `Content Type / 内容类型` from this fixed set when possible:
-  - `Article / 文章`
-  - `Report / 报告`
-  - `Paper / 论文`
-  - `PDF Document / PDF 文档`
-  - `Web Page / 网页`
-  - `Transcript / 访谈/实录`
-  - `Document / 文档` when uncertain
-- Extract `Source / 来源`
-- Extract `Author / 作者` if available
-- Extract `Published / 发布时间` if available
-- Identify the source's core thesis, supporting evidence, visuals, and important terms
+### Guard against over-compression
 
-For study-guide mode, also identify:
+The recurring failure mode is summarizing instead of close-reading. Before saving, sanity
+-check: a reader should be able to follow the source's full argument from your `.orig`
+blocks alone, in order. If whole sections of the source are missing, or your `.orig`
+blocks are one-line snippets where the source had full paragraphs, you have summarized —
+go back and restore the original text. The artifact is normally **larger** than the source,
+not smaller.
 
-- The source's chapter or section boundaries
-- Important statutes, cases, formulas, frameworks, or examples
-- Terms that should remain in English inline with Chinese explanation
-- Which sections are rich enough to support short review questions
+## 5. Save and present
 
-## 5. Build the artifact
-
-### If using bilingual digest mode
-
-Write the English side first. Treat it as the canonical source for the Chinese side.
-Do not draft English and Chinese independently.
-
-Required structure:
-
-- **Bilingual Title**
-  - Produce an English title and a Chinese title as a paired title block
-- **Metadata**
-  - Include `Source / 来源`
-  - Include `Author / 作者` if available
-  - Include `Published / 发布时间` if available
-  - Include `Content Type / 内容类型`
-  - Show a clickable original URL or filename, and include a human-readable site/source
-    label when possible
-- **At a Glance / 一眼速览**
-  - Exactly 2 sentences
-  - High-signal overview only
-- **Summary / 摘要**
-  - Exactly 1 short paragraph
-  - Explain the main argument and conclusion without repeating the full key points
-- **Key Points / 要点**
-  - At least 6 items
-  - Usually aim for 6-8 items; use up to 10 only when the source is unusually dense
-  - Each item must be a single sentence containing one complete, concrete point
-- **Evidence & Data / 证据与数据**
-  - Always present
-  - At least 3 items
-  - Use list cards, not tables
-  - Prefer concrete numbers, percentages, dates, findings, and direct factual support
-  - Include short source anchors when possible, such as section names, dates, figure
-    labels, or other traceable cues
-  - If the source has limited quantitative evidence, say so explicitly while still
-    giving the strongest available support
-- **Visuals / 图表与视觉要素**
-  - Always present
-  - Include up to 3 essential visuals
-  - If an image URL is available and stable, embed it and add bilingual caption/description
-  - If the image cannot be embedded, include a bilingual textual description
-  - If there are no essential visuals, include one bilingual item stating that and
-    briefly explain why
-- **Terminology Glossary / 术语对照表**
-  - Always the final section
-  - Use a four-column table:
-    `English Term | 中文对照 | English Explanation | 中文解释`
-  - Target 8-15 terms
-  - Do not force the count upward if the source truly has fewer valid terms
-  - Terms must come from the source or its directly necessary core concepts
-  - Sort terms by first appearance in the digest, not alphabetically
-
-Then translate each English block into Chinese only after the English block is finalized.
-
-Requirements:
-
-- Preserve the same meaning and scope
-- Preserve the same ordering
-- Preserve the same number of items in each paired list
-- Do not add or remove claims on one side only
-- Keep terminology aligned across the entire document, especially in the glossary
-
-### If using study-guide mode
-
-Build a Chinese-first learning handout that follows the source structure.
-
-Required structure:
-
-- **Title + metadata**
-  - Show source, author, date if available
-  - Add a short note that the material is organized for study from the original source
-- **Table of contents**
-  - Link to each major chapter or section
-- **Per major section**
-  - Start with `原文摘要 / Source Summary`
-    - 2-5 sentences
-    - Faithful summary of that source section's original content
-    - Do not replace this with only your own explanation
-  - Add `重点` callout for the highest-signal takeaway
-  - Add `术语` blocks for terms that matter in this section
-  - Add `法条/案例` or equivalent source-grounded authority/examples when applicable
-  - Add short study notes or comparisons when they help retention and remain source-grounded
-  - Add short review questions only if the section is substantial enough
-- **总结复习**
-  - End with a concise cross-section recap for revision
-
-Study-guide mode rules:
-
-- Preserve the source's chapter order instead of flattening everything into one digest
-- Use Chinese as the main explanatory language unless the user asks otherwise
-- Keep important English source terms inline where they aid recall
-- Review questions must be grounded in the source, not invented from external knowledge
-
-## 6. Generate the HTML artifact
-
-Create one self-contained HTML file with inline styles only. The visual design should
-match the chosen mode instead of falling back to a generic article page.
-
-Design requirements for bilingual digest mode:
-
-- Clear `English` and `中文` labels in every bilingual content block
-- Single bilingual section headings such as `Key Points / 要点`
-- Reader-friendly spacing and typography
-- Distinct section cards or blocks that make left/right comparison obvious
-- Responsive layout: two columns on desktop, stacked on narrow screens
-- Glossary rendered as a compact four-column table at the end
-- Footer uses a bilingual product label, such as:
-  `Generated by Bilingual Article Digest / 双语文章摘要生成`
-
-Design requirements for study-guide mode:
-
-- Single-column, Chinese-first learning layout
-- Strong section hierarchy and visible table of contents
-- Distinct visual treatments for `原文摘要`, `重点`, `术语`, and `法条/案例`
-- Better suited for reading, revising, and chapter-by-chapter recall than for bilingual comparison
-- Do not remove the original-source fidelity cues
-
-## 7. Save and present
-
-Save the HTML file using the `Write` tool.
+Save with the `Write` tool to the current working directory unless the user says otherwise.
 
 Naming convention:
 
-- For URLs: `digest-bilingual-[slugified-domain-or-title].html`
-- For files: `digest-bilingual-[original-filename].html`
-
-For study-guide mode, prefer:
-
-- For URLs: `study-guide-[slugified-domain-or-title].html`
 - For files: `study-guide-[original-filename].html`
-
-Save to the current working directory unless the user specifies otherwise.
+- For URLs: `study-guide-[slugified-domain-or-title].html`
 
 Tell the user the saved file path.
 
 ## Edge cases
 
-- **Paywalled or weak content**: If the fetched content is too thin or mostly blocked,
-  say so and produce a constrained digest only from what is actually accessible
-- **Very long sources**: Still cover the full argument; do not collapse into a short
-  abstract if the source is materially complex
-- **Multiple URLs/files in one request**: Produce one HTML learning artifact per source
-- **Non-article inputs**: Still use the chosen mode honestly, but label the content type
-  honestly and note when the source is not argument-driven
-- **Sparse terminology**: Do not invent terms just to hit the target range; include
-  only valid source-grounded terms and note that terminology density is limited
-- **Study-guide mode with weak structure**: If the source is too short to support chapters,
-  collapse to a lighter study-note layout but still include at least one `原文摘要` block
+- **Paywalled / weak content**: keep the close-reading structure over whatever text is
+  accessible, and say the source was thin. Don't pad with invented content.
+- **Very long sources**: still cover every section. Length is expected; do not collapse
+  into an abstract.
+- **Multiple sources in one request**: produce one artifact per source.
+- **Non-prose inputs** (slides, tables, forms): keep the structure honestly, reproduce
+  what text exists, and note when the source isn't argument-driven.
+- **Very short source**: drop the `目录`, keep at least one `.orig`/`.zh` passage and one
+  quiz; still close-read rather than summarize.

--- a/skills/index.json
+++ b/skills/index.json
@@ -120,14 +120,13 @@
     },
     {
       "name": "devpilot-learn",
-      "description": "Turn a single article, document, or web page into a standalone HTML learning artifact, either as a bilingual digest or a chaptered study guide with source summaries.",
+      "description": "Turn a single article, document, or web page into a standalone HTML close-reading study artifact that keeps the source's verbatim text with a Chinese translation beneath each passage and collapsible quizzes.",
       "files": [
         "evals/evals.json",
         "evals/test-files/sample.pdf",
         "LICENSE.txt",
-        "references/html-skeleton.md",
         "references/output-contract.md",
-        "references/study-guide-skeleton.md",
+        "references/skeleton.md",
         "references/workflow.md",
         "SKILL.md"
       ]


### PR DESCRIPTION
## What changed and why

PR #146 ("rewrite as close-reading study artifact") intended to replace the old two-mode summarizer with a single close-reading mode (verbatim original + Chinese translation beneath each passage + collapsible quizzes). It rewrote the three skeleton files — but its claimed edits to `SKILL.md`, `output-contract.md`, and `workflow.md` **never landed**. Only the skeleton files changed.

That left the skill internally contradictory:

- `references/skeleton.md` → "keep the verbatim original, single column"
- `references/workflow.md` + `output-contract.md` → still described the **old two-mode summarizer**, and told the model to lead every section with a `原文摘要` (summary)

Generation follows the workflow, so it summarized and **over-compressed** — the exact complaint that prompted this fix.

## The fix

Bring the three docs (and the stale `index.json`) in line with the skeleton's single close-reading mode:

- **`SKILL.md`** — drop the two-mode framing; describe one close-reading output. Fix dead skeleton filenames (`html-skeleton.md` / `study-guide-skeleton.md` → `skeleton.md`).
- **`references/output-contract.md`** — one mode; explicit *"guard against over-compression"* contract (keep verbatim original, coverage over brevity, artifact is normally **larger** than the source).
- **`references/workflow.md`** — single-mode flow: fetch → segment → reproduce verbatim → add translation + quizzes; same anti-compression guard.
- **`skills/index.json`** — update description and file list (drop the two deleted skeletons, add `skeleton.md`).

No skeleton or behavior-code changes — this only makes the instructions consistent with what #146 already shipped.

## Stress test

Ran the **pre-fix** skill vs. the **post-fix** skill on a 14-page law course PDF (~43k chars) and measured how much of the source's actual text each output preserved:

| | Verbatim source coverage | English words kept | Assertions |
|---|---|---|---|
| Pre-fix (contradictory) | **15.2%** | 1,704 | 5/6 |
| Post-fix (this PR) | **61.8%** | 4,344 | 6/6 |

The pre-fix output failed the "preserves ≥40% verbatim" check — it summarized away ~85% of the source. Post-fix keeps the source's real text, which is the whole point of close-reading mode.

## Review Guide

- Start with **`SKILL.md`** — it sets the single-mode framing the other files follow.
- Then **`references/output-contract.md`** → the "guard against over-compression" section is the core behavioral change.
- **`references/workflow.md`** mirrors that guard in the step-by-step flow.
- **`skills/index.json`** is a mechanical sync (per `CLAUDE.md`: update index.json when a skill's files change) — verify the file list matches the actual files in `skills/devpilot-learn/references/`.
- Watch for: any lingering reference to "digest mode," "bilingual," "two modes," or `原文摘要` as a section-lead — those would be leftover contradictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)