### PR TITLE
feat: add GitHub helpers and PR review queue skill

### DIFF
--- a/cmd/devpilot/main.go
+++ b/cmd/devpilot/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/siyuqian/devpilot/internal/auth"
 	"github.com/siyuqian/devpilot/internal/generate"
+	"github.com/siyuqian/devpilot/internal/github"
 	"github.com/siyuqian/devpilot/internal/gmail"
 	"github.com/siyuqian/devpilot/internal/graph"
 	"github.com/siyuqian/devpilot/internal/initcmd"
@@ -32,6 +33,7 @@ func main() {
 	slack.RegisterCommands(rootCmd)
 	generate.RegisterCommands(rootCmd)
 	graph.RegisterCommands(rootCmd)
+	github.RegisterCommands(rootCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -78,6 +78,23 @@ devpilot gmail summary --dm U0123ABCDE         # Send summary as a DM (marks as 
 devpilot slack send --channel "#general" --text "hi"   # Send a Slack message
 ```
 
+## GitHub
+
+These commands use the GitHub CLI for authentication and API access. Run
+`gh auth login` before using them.
+
+```bash
+devpilot github prs review-queue                         # PRs requesting review from @me
+devpilot github prs review-queue --user alice            # PRs requesting review from a user
+devpilot github prs review-queue --direct                # Only direct user review requests
+devpilot github prs authored --user alice --state all    # PRs authored by a user
+devpilot github prs authored --owner my-org --json       # Machine-readable PR list
+
+devpilot github repo activity owner/repo                 # Today's repo activity
+devpilot github repo activity owner/repo --date 2026-06-01 --timezone Pacific/Auckland
+devpilot github repo activity owner/repo --since 24h --json
+```
+
 ## Generation
 
 ```bash

--- a/internal/auth/commands.go
+++ b/internal/auth/commands.go
@@ -21,16 +21,21 @@ var loginCmd = &cobra.Command{
 	Long:  fmt.Sprintf("Authenticate with an external service.\n\nAvailable services: %s", AvailableNames()),
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		svc, err := Get(args[0])
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-		if err := svc.Login(); err != nil {
-			fmt.Fprintln(os.Stderr, "Login failed:", err)
-			os.Exit(1)
-		}
+		os.Exit(runLogin(args[0]))
 	},
+}
+
+func runLogin(service string) int {
+	svc, err := Get(service)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := svc.Login(); err != nil {
+		fmt.Fprintln(os.Stderr, "Login failed:", err)
+		return 1
+	}
+	return 0
 }
 
 var logoutCmd = &cobra.Command{
@@ -39,16 +44,21 @@ var logoutCmd = &cobra.Command{
 	Long:  fmt.Sprintf("Remove stored credentials for a service.\n\nAvailable services: %s", AvailableNames()),
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		svc, err := Get(args[0])
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-		if err := svc.Logout(); err != nil {
-			fmt.Fprintln(os.Stderr, "Logout failed:", err)
-			os.Exit(1)
-		}
+		os.Exit(runLogout(args[0]))
 	},
+}
+
+func runLogout(service string) int {
+	svc, err := Get(service)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := svc.Logout(); err != nil {
+		fmt.Fprintln(os.Stderr, "Logout failed:", err)
+		return 1
+	}
+	return 0
 }
 
 var statusCmd = &cobra.Command{
@@ -56,14 +66,18 @@ var statusCmd = &cobra.Command{
 	Short: "Show login status for all services",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		loggedIn := ListServices()
-		if len(loggedIn) == 0 {
-			fmt.Println("No services configured.")
-			fmt.Printf("Run 'devpilot login <service>' to get started. Available: %s\n", AvailableNames())
-			return
-		}
-		for _, name := range loggedIn {
-			fmt.Printf("%s: logged in\n", name)
-		}
+		runStatus()
 	},
+}
+
+func runStatus() {
+	loggedIn := ListServices()
+	if len(loggedIn) == 0 {
+		fmt.Println("No services configured.")
+		fmt.Printf("Run 'devpilot login <service>' to get started. Available: %s\n", AvailableNames())
+		return
+	}
+	for _, name := range loggedIn {
+		fmt.Printf("%s: logged in\n", name)
+	}
 }

--- a/internal/auth/commands_more_test.go
+++ b/internal/auth/commands_more_test.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type mutableTestService struct {
+	name      string
+	loginErr  error
+	logoutErr error
+	logins    int
+	logouts   int
+}
+
+func (s *mutableTestService) Name() string { return s.name }
+func (s *mutableTestService) Login() error {
+	s.logins++
+	return s.loginErr
+}
+func (s *mutableTestService) Logout() error {
+	s.logouts++
+	return s.logoutErr
+}
+func (s *mutableTestService) IsLoggedIn() bool { return true }
+
+func TestAuthRegisterCommands(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	RegisterCommands(root)
+	for _, name := range []string{"login", "logout", "status"} {
+		cmd, _, err := root.Find([]string{name})
+		if err != nil {
+			t.Fatalf("Find(%s): %v", name, err)
+		}
+		if cmd.Name() != name {
+			t.Fatalf("cmd = %q, want %q", cmd.Name(), name)
+		}
+	}
+}
+
+func TestAuthCommandHelpers(t *testing.T) {
+	oldRegistry := registry
+	registry = map[string]Service{}
+	defer func() { registry = oldRegistry }()
+
+	svc := &mutableTestService{name: "ok"}
+	Register(svc)
+	if code := runLogin("ok"); code != 0 || svc.logins != 1 {
+		t.Fatalf("runLogin ok code=%d logins=%d", code, svc.logins)
+	}
+	if code := runLogout("ok"); code != 0 || svc.logouts != 1 {
+		t.Fatalf("runLogout ok code=%d logouts=%d", code, svc.logouts)
+	}
+	if code := runLogin("missing"); code == 0 {
+		t.Fatalf("runLogin missing code=0")
+	}
+	Register(&mutableTestService{name: "bad-login", loginErr: errors.New("bad")})
+	if code := runLogin("bad-login"); code == 0 {
+		t.Fatalf("runLogin bad code=0")
+	}
+	Register(&mutableTestService{name: "bad-logout", logoutErr: errors.New("bad")})
+	if code := runLogout("bad-logout"); code == 0 {
+		t.Fatalf("runLogout bad code=0")
+	}
+}
+
+func TestRunStatus(t *testing.T) {
+	dir := t.TempDir()
+	restore := OverrideConfigDir(dir)
+	defer restore()
+
+	out := captureAuthStdout(t, runStatus)
+	if !strings.Contains(out, "No services configured") {
+		t.Fatalf("empty status output = %q", out)
+	}
+	if err := Save("trello", ServiceCredentials{"token": "t"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	out = captureAuthStdout(t, runStatus)
+	if !strings.Contains(out, "trello: logged in") {
+		t.Fatalf("status output = %q", out)
+	}
+}
+
+func captureAuthStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	return buf.String()
+}

--- a/internal/auth/oauth_more_test.go
+++ b/internal/auth/oauth_more_test.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOAuthCallbackServerBranches(t *testing.T) {
+	listener, srv, resultCh, err := startCallbackServer("state", false, 0)
+	if err != nil {
+		t.Fatalf("startCallbackServer: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+	base := "http://" + listener.Addr().String() + "/callback"
+
+	resp, err := http.Get(base + "?state=bad&code=x")
+	if err != nil {
+		t.Fatalf("invalid state get: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid state status = %d", resp.StatusCode)
+	}
+	if got := <-resultCh; got.err == nil || !strings.Contains(got.err.Error(), "invalid state") {
+		t.Fatalf("invalid state result = %#v", got)
+	}
+
+	resp, err = http.Get(base + "?state=state&code=abc")
+	if err != nil {
+		t.Fatalf("success get: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("success status = %d", resp.StatusCode)
+	}
+	if got := <-resultCh; got.code != "abc" || got.err != nil {
+		t.Fatalf("success result = %#v", got)
+	}
+
+	listener, srv, resultCh, err = startCallbackServer("state", false, 0)
+	if err != nil {
+		t.Fatalf("startCallbackServer second: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+	resp, err = http.Get("http://" + listener.Addr().String() + "/callback?error=access_denied")
+	if err != nil {
+		t.Fatalf("denied get: %v", err)
+	}
+	_ = resp.Body.Close()
+	if got := <-resultCh; !errors.Is(got.err, ErrAuthDenied) {
+		t.Fatalf("denied result = %#v", got)
+	}
+}
+
+func TestOAuthURLAndTokenExchange(t *testing.T) {
+	authURL := buildAuthURL(OAuthConfig{
+		AuthURL:  "https://auth.example/authorize",
+		ClientID: "client",
+		Scopes:   []string{"a", "b"},
+	}, "http://localhost/callback", "state")
+	for _, want := range []string{"client_id=client", "redirect_uri=http%3A%2F%2Flocalhost%2Fcallback", "scope=a+b", "state=state"} {
+		if !strings.Contains(authURL, want) {
+			t.Fatalf("authURL missing %q: %s", want, authURL)
+		}
+	}
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		switch r.Form.Get("grant_type") {
+		case "authorization_code":
+			_, _ = io.WriteString(w, `{"access_token":"access","refresh_token":"refresh","token_type":"Bearer","expires_in":60}`)
+		case "refresh_token":
+			_, _ = io.WriteString(w, `{"access_token":"new","token_type":"Bearer"}`)
+		default:
+			http.Error(w, "bad grant", http.StatusBadRequest)
+		}
+	}))
+	defer tokenServer.Close()
+
+	cfg := OAuthConfig{TokenURL: tokenServer.URL, ClientID: "id", ClientSecret: "secret"}
+	token, err := exchangeCode(cfg, "code", "http://localhost/callback")
+	if err != nil {
+		t.Fatalf("exchangeCode: %v", err)
+	}
+	if token.AccessToken != "access" || token.RefreshToken != "refresh" || token.Expiry.IsZero() {
+		t.Fatalf("token = %#v", token)
+	}
+	refreshed, err := RefreshToken(cfg, "existing-refresh")
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if refreshed.AccessToken != "new" || refreshed.RefreshToken != "existing-refresh" {
+		t.Fatalf("refreshed = %#v", refreshed)
+	}
+}
+
+func TestOAuthTokenErrors(t *testing.T) {
+	if _, err := parseTokenResponse([]byte(`{"access_token":"x","expiry":"bad"}`)); err == nil {
+		t.Fatalf("parseTokenResponse bad expiry succeeded")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"invalid_grant","error_description":"expired"}`)
+	}))
+	defer server.Close()
+	if _, err := RefreshToken(OAuthConfig{TokenURL: server.URL}, "r"); !errors.Is(err, ErrReauthRequired) {
+		t.Fatalf("RefreshToken error = %v, want ErrReauthRequired", err)
+	}
+
+	token := &OAuthToken{AccessToken: "a", RefreshToken: "r", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour).UTC()}
+	dir := t.TempDir()
+	restore := OverrideConfigDir(dir)
+	defer restore()
+	if err := SaveOAuthToken("svc", token); err != nil {
+		t.Fatalf("SaveOAuthToken: %v", err)
+	}
+	loaded, err := LoadOAuthToken("svc")
+	if err != nil {
+		t.Fatalf("LoadOAuthToken: %v", err)
+	}
+	if loaded.AccessToken != "a" || loaded.RefreshToken != "r" {
+		t.Fatalf("loaded = %#v", loaded)
+	}
+}

--- a/internal/auth/service_more_test.go
+++ b/internal/auth/service_more_test.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+type testService struct {
+	name string
+}
+
+func TestTrelloServiceLoginRejectsEmptyInput(t *testing.T) {
+	old := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("\n\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+
+	if err := (&TrelloService{}).Login(); err == nil {
+		t.Fatalf("Login() succeeded with empty input")
+	}
+}
+
+func (s testService) Name() string     { return s.name }
+func (s testService) Login() error     { return nil }
+func (s testService) Logout() error    { return nil }
+func (s testService) IsLoggedIn() bool { return true }
+
+func TestRegistryGetAndAvailableNames(t *testing.T) {
+	old := registry
+	registry = map[string]Service{}
+	defer func() { registry = old }()
+
+	Register(testService{name: "zeta"})
+	Register(testService{name: "alpha"})
+	svc, err := Get("alpha")
+	if err != nil {
+		t.Fatalf("Get(alpha) error = %v", err)
+	}
+	if svc.Name() != "alpha" {
+		t.Fatalf("service name = %q, want alpha", svc.Name())
+	}
+	if names := AvailableNames(); !strings.Contains(names, "alpha") || !strings.Contains(names, "zeta") {
+		t.Fatalf("AvailableNames() = %q", names)
+	}
+	if _, err := Get("missing"); err == nil {
+		t.Fatalf("Get(missing) succeeded, want error")
+	}
+}
+
+func TestTrelloServiceLoginStateAndVerify(t *testing.T) {
+	dir := t.TempDir()
+	restore := OverrideConfigDir(dir)
+	defer restore()
+
+	svc := &TrelloService{}
+	if svc.Name() != "trello" {
+		t.Fatalf("Name() = %q, want trello", svc.Name())
+	}
+	if svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = true before credentials")
+	}
+	if err := Save("trello", ServiceCredentials{"api_key": "k", "token": "t"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = false after credentials")
+	}
+	if err := svc.Logout(); err != nil {
+		t.Fatalf("Logout() error = %v", err)
+	}
+	if svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = true after logout")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/members/me" {
+			http.Error(w, "missing", http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("Authorization"); !strings.Contains(got, `oauth_consumer_key="k"`) || !strings.Contains(got, `oauth_token="t"`) {
+			t.Fatalf("Authorization = %q", got)
+		}
+	}))
+	defer server.Close()
+
+	svc.baseURL = server.URL
+	if err := svc.verify("k", "t"); err != nil {
+		t.Fatalf("verify() error = %v", err)
+	}
+	svc.baseURL = server.URL + "/missing"
+	if err := svc.verify("k", "t"); err == nil {
+		t.Fatalf("verify() succeeded for non-200 response")
+	}
+}

--- a/internal/generate/commands_more_test.go
+++ b/internal/generate/commands_more_test.go
@@ -1,0 +1,52 @@
+package generate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/siyuqian/devpilot/internal/project"
+	"github.com/spf13/cobra"
+)
+
+func TestGenerateRegisterCommandsAndResolveModel(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	RegisterCommands(root)
+	cmd, _, err := root.Find([]string{"commit"})
+	if err != nil {
+		t.Fatalf("Find(commit): %v", err)
+	}
+	if cmd.Name() != "commit" {
+		t.Fatalf("cmd = %q, want commit", cmd.Name())
+	}
+	if err := cmd.Flags().Set("model", "custom-model"); err != nil {
+		t.Fatalf("set model: %v", err)
+	}
+	if got := resolveModel(cmd, "commit"); got != "custom-model" {
+		t.Fatalf("resolveModel() = %q, want custom-model", got)
+	}
+}
+
+func TestResolveModelFromProjectConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := project.Save(dir, &project.Config{Models: map[string]string{"commit": "sonnet"}}); err != nil {
+		t.Fatalf("Save config: %v", err)
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("model", "", "")
+	if got := resolveModel(cmd, "commit"); got != "sonnet" {
+		t.Fatalf("resolveModel() = %q, want sonnet", got)
+	}
+}

--- a/internal/generate/commit_model_test.go
+++ b/internal/generate/commit_model_test.go
@@ -1,0 +1,273 @@
+package generate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestCommitModelStateTransitions(t *testing.T) {
+	model := newCommitModel(context.Background(), "model", "ctx", false)
+	if model.phase != phaseStagingFiles {
+		t.Fatalf("phase = %q, want %q", model.phase, phaseStagingFiles)
+	}
+	if model.model != "model" || model.context != "ctx" {
+		t.Fatalf("model context not initialized: %#v", model)
+	}
+	if model.Init() == nil {
+		t.Fatalf("Init() returned nil command")
+	}
+
+	updated, cmd := model.Update(tea.WindowSizeMsg{Width: 120})
+	model = updated.(commitModel)
+	if cmd != nil || model.width != 120 {
+		t.Fatalf("window update: width=%d cmd=%v", model.width, cmd)
+	}
+
+	updated, _ = model.handleStagingDone(stagingDoneMsg{
+		nameStatus:  "M\ta.go",
+		diffStat:    "a.go | 1 +",
+		diffContent: "diff --git a/a.go b/a.go",
+		stagedFiles: []string{"a.go"},
+	})
+	model = updated.(commitModel)
+	if model.phase != phaseAnalyzing {
+		t.Fatalf("phase = %q, want analyzing", model.phase)
+	}
+
+	plan := commitPlan{Commits: []commitEntry{{Message: "feat: x", Files: []string{"a.go"}}}}
+	updated, cmd = model.handleAnalysisDone(analysisDoneMsg{plan: plan, warnings: []string{"warn"}})
+	model = updated.(commitModel)
+	if cmd != nil || model.phase != phasePlan || len(model.warnings) != 1 {
+		t.Fatalf("analysis transition failed: phase=%q warnings=%v cmd=%v", model.phase, model.warnings, cmd)
+	}
+
+	updated, cmd = model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	model = updated.(commitModel)
+	if cmd == nil || model.phase != phaseExecuting || model.currentCommit != 0 {
+		t.Fatalf("start execution failed: phase=%q current=%d cmd=%v", model.phase, model.currentCommit, cmd)
+	}
+
+	updated, cmd = model.handleCommitExec(commitExecMsg{index: 0, hash: "abc123"})
+	model = updated.(commitModel)
+	if cmd == nil || model.phase != phaseDone || len(model.completedCommits) != 1 {
+		t.Fatalf("commit exec transition failed: phase=%q completed=%d cmd=%v", model.phase, len(model.completedCommits), cmd)
+	}
+}
+
+func TestCommitModelAsyncGitCommands(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repo, "a.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	model := newCommitModel(context.Background(), "", "", false)
+	msg := model.stageAndCollectDiff()()
+	staging, ok := msg.(stagingDoneMsg)
+	if !ok {
+		t.Fatalf("stageAndCollectDiff() = %T", msg)
+	}
+	if staging.err != nil {
+		t.Fatalf("stageAndCollectDiff() error = %v", staging.err)
+	}
+	if !contains(staging.stagedFiles, "a.go") || !strings.Contains(staging.nameStatus, "a.go") {
+		t.Fatalf("staging msg = %#v", staging)
+	}
+
+	model.plan = commitPlan{
+		Commits:  []commitEntry{{Message: "feat: add a", Files: []string{"a.go"}}},
+		Excluded: []excludedFile{{File: "scratch.txt", Reason: "ignore"}},
+	}
+	if msg := model.unstageExcluded()(); msg != nil {
+		t.Fatalf("unstageExcluded() = %#v, want nil", msg)
+	}
+
+	msg = model.executeCommit(0)()
+	execMsg, ok := msg.(commitExecMsg)
+	if !ok {
+		t.Fatalf("executeCommit() = %T", msg)
+	}
+	if execMsg.err != nil {
+		t.Fatalf("executeCommit() error = %v", execMsg.err)
+	}
+	if execMsg.hash == "" {
+		t.Fatalf("hash is empty")
+	}
+}
+
+func TestCommitModelAnalyzeChangesWithFakeClaude(t *testing.T) {
+	bin := t.TempDir()
+	claude := filepath.Join(bin, "claude")
+	script := "#!/bin/sh\nprintf '%s\\n' '{\"commits\":[{\"message\":\"feat: x\",\"files\":[\"a.go\"]}]}'\n"
+	if err := os.WriteFile(claude, []byte(script), 0o755); err != nil {
+		t.Fatalf("write claude: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	model := commitModel{
+		genCtx:      context.Background(),
+		model:       "test-model",
+		nameStatus:  "M\ta.go",
+		diffStat:    "a.go | 1 +",
+		diffContent: "diff --git a/a.go b/a.go\n",
+		stagedFiles: []string{"a.go"},
+	}
+	msg := model.analyzeChanges()()
+	analysis, ok := msg.(analysisDoneMsg)
+	if !ok {
+		t.Fatalf("analyzeChanges() = %T", msg)
+	}
+	if analysis.err != nil {
+		t.Fatalf("analyzeChanges() error = %v", analysis.err)
+	}
+	if len(analysis.plan.Commits) != 1 || analysis.plan.Commits[0].Message != "feat: x" {
+		t.Fatalf("plan = %#v", analysis.plan)
+	}
+}
+
+func TestRunClaudeFailure(t *testing.T) {
+	bin := t.TempDir()
+	claude := filepath.Join(bin, "claude")
+	if err := os.WriteFile(claude, []byte("#!/bin/sh\necho nope >&2\nexit 2\n"), 0o755); err != nil {
+		t.Fatalf("write claude: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if _, err := run(context.Background(), "prompt", ""); err == nil {
+		t.Fatalf("run() succeeded, want error")
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCommitModelErrorTransitions(t *testing.T) {
+	model := newCommitModel(context.Background(), "", "", false)
+
+	updated, cmd := model.finishWithError(errors.New("bad"))
+	model = updated.(commitModel)
+	if cmd == nil || model.phase != phaseDone || model.err == nil {
+		t.Fatalf("finishWithError failed: phase=%q err=%v cmd=%v", model.phase, model.err, cmd)
+	}
+
+	model = newCommitModel(context.Background(), "", "", false)
+	updated, cmd = model.handleStagingDone(stagingDoneMsg{err: errors.New("stage")})
+	model = updated.(commitModel)
+	if cmd == nil || model.phase != phaseDone || model.err == nil {
+		t.Fatalf("staging error transition failed: phase=%q err=%v cmd=%v", model.phase, model.err, cmd)
+	}
+
+	model = newCommitModel(context.Background(), "", "", false)
+	updated, cmd = model.handleStagingDone(stagingDoneMsg{})
+	model = updated.(commitModel)
+	if cmd == nil || !errors.Is(model.err, errNoChanges) {
+		t.Fatalf("no changes transition failed: err=%v cmd=%v", model.err, cmd)
+	}
+
+	model = commitModel{phase: phasePlan}
+	updated, cmd = model.handleAnalysisDone(analysisDoneMsg{err: errors.New("analyze")})
+	model = updated.(commitModel)
+	if cmd == nil || model.phase != phaseDone || model.err == nil {
+		t.Fatalf("analysis error transition failed: phase=%q err=%v cmd=%v", model.phase, model.err, cmd)
+	}
+
+	model = commitModel{phase: phasePlan, plan: commitPlan{Commits: []commitEntry{{Message: "feat: x"}}}}
+	updated, cmd = model.handleEditDone(editDoneMsg{err: errors.New("edit")})
+	model = updated.(commitModel)
+	if cmd != nil || len(model.warnings) != 1 {
+		t.Fatalf("edit error should warn without command: warnings=%v cmd=%v", model.warnings, cmd)
+	}
+
+	updated, cmd = model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	model = updated.(commitModel)
+	if cmd == nil || !errors.Is(model.err, errAborted) {
+		t.Fatalf("abort key failed: err=%v cmd=%v", model.err, cmd)
+	}
+}
+
+func TestCommitModelAdditionalTransitions(t *testing.T) {
+	plan := commitPlan{
+		Commits: []commitEntry{
+			{Message: "feat: one", Files: []string{"a.go"}},
+			{Message: "feat: two", Files: []string{"b.go"}},
+		},
+		Excluded: []excludedFile{{File: "scratch.txt", Reason: "ignore"}},
+	}
+	model := commitModel{phase: phasePlan, plan: plan}
+
+	updated, cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	model = updated.(commitModel)
+	if cmd == nil || model.phase != phaseExecuting {
+		t.Fatalf("multi-commit accept failed: phase=%q cmd=%v", model.phase, cmd)
+	}
+
+	updated, cmd = model.handleCommitExec(commitExecMsg{index: 0, hash: "abc123"})
+	model = updated.(commitModel)
+	if cmd == nil || model.phase != phaseExecuting || model.currentCommit != 1 || len(model.completedCommits) != 1 {
+		t.Fatalf("next commit transition failed: phase=%q current=%d completed=%d cmd=%v", model.phase, model.currentCommit, len(model.completedCommits), cmd)
+	}
+
+	updated, cmd = model.handleCommitExec(commitExecMsg{index: 1, err: errors.New("commit failed")})
+	model = updated.(commitModel)
+	if cmd == nil || model.phase != phaseDone || model.err == nil || len(model.completedCommits) != 2 {
+		t.Fatalf("commit error transition failed: phase=%q err=%v completed=%d cmd=%v", model.phase, model.err, len(model.completedCommits), cmd)
+	}
+
+	model = commitModel{phase: phasePlan}
+	updated, cmd = model.handleEditDone(editDoneMsg{plan: commitPlan{Commits: []commitEntry{{Message: "fix: edited"}}}})
+	model = updated.(commitModel)
+	if cmd != nil || len(model.warnings) != 0 || model.plan.Commits[0].Message != "fix: edited" {
+		t.Fatalf("edit success transition failed: plan=%#v warnings=%v cmd=%v", model.plan, model.warnings, cmd)
+	}
+
+	model = commitModel{phase: phaseAnalyzing}
+	updated, cmd = model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd != nil {
+		t.Fatalf("non-plan key produced cmd: %v", cmd)
+	}
+	if updated.(commitModel).phase != phaseAnalyzing {
+		t.Fatalf("phase changed outside plan: %q", updated.(commitModel).phase)
+	}
+
+	updated, cmd = model.Update(struct{}{})
+	if cmd != nil || updated.(commitModel).phase != phaseAnalyzing {
+		t.Fatalf("unknown update changed state: %#v cmd=%v", updated, cmd)
+	}
+}

--- a/internal/generate/commit_view_test.go
+++ b/internal/generate/commit_view_test.go
@@ -1,0 +1,128 @@
+package generate
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCommitModelViews(t *testing.T) {
+	plan := commitPlan{
+		Commits: []commitEntry{
+			{Message: "feat: add x\n\nbody", Files: []string{"a.go", "gone.go"}},
+			{Message: "fix: y", Files: []string{"b.go"}},
+		},
+		Excluded: []excludedFile{{File: "scratch.txt", Reason: "unrelated"}},
+	}
+	base := commitModel{
+		plan:       plan,
+		nameStatus: "A\ta.go\nD\tgone.go\nM\tb.go\n",
+		warnings:   []string{"check this"},
+	}
+
+	cases := []struct {
+		name  string
+		model commitModel
+		want  []string
+	}{
+		{
+			name:  "staging",
+			model: commitModel{phase: phaseStagingFiles},
+			want:  []string{"Staging changes"},
+		},
+		{
+			name:  "analyzing",
+			model: commitModel{phase: phaseAnalyzing},
+			want:  []string{"Analyzing changes"},
+		},
+		{
+			name: "plan multi",
+			model: func() commitModel {
+				m := base
+				m.phase = phasePlan
+				return m
+			}(),
+			want: []string{"Commit Plan", "feat:", "scratch.txt", "check this", "[a]ccept all"},
+		},
+		{
+			name: "plan dry run",
+			model: func() commitModel {
+				m := base
+				m.phase = phasePlan
+				m.dryRun = true
+				return m
+			}(),
+			want: []string{"dry-run"},
+		},
+		{
+			name: "executing",
+			model: commitModel{
+				phase:            phaseExecuting,
+				plan:             plan,
+				currentCommit:    1,
+				completedCommits: []commitResult{{hash: "abc123", message: "feat: add x"}},
+			},
+			want: []string{"Committing", "abc123", "fix: y"},
+		},
+		{
+			name: "done success",
+			model: commitModel{
+				phase:            phaseDone,
+				plan:             plan,
+				completedCommits: []commitResult{{hash: "abc123", message: "feat: add x"}},
+			},
+			want: []string{"Done", "abc123", "feat: add x"},
+		},
+		{
+			name:  "done aborted",
+			model: commitModel{phase: phaseDone, err: errAborted},
+			want:  []string{"Aborted"},
+		},
+		{
+			name:  "done no changes",
+			model: commitModel{phase: phaseDone, err: errNoChanges},
+			want:  []string{"No changes to commit"},
+		},
+		{
+			name: "done error with completed",
+			model: commitModel{
+				phase:            phaseDone,
+				err:              errors.New("failed"),
+				completedCommits: []commitResult{{hash: "abc123", message: "feat: add x"}},
+			},
+			want: []string{"Error: failed", "Completed before failure", "abc123"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.model.View()
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("View() missing %q:\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCommitViewHelpers(t *testing.T) {
+	if got := firstLineOf("one\ntwo"); got != "one" {
+		t.Errorf("firstLineOf() = %q, want one", got)
+	}
+	if got := firstLineOf("one"); got != "one" {
+		t.Errorf("firstLineOf() = %q, want one", got)
+	}
+	status := parseNameStatus("A\ta.go\nD\tgone.go\nbad\n")
+	if status["a.go"] != "A" || status["gone.go"] != "D" {
+		t.Fatalf("parseNameStatus() = %#v", status)
+	}
+	for _, file := range []string{"a.go", "gone.go", "other.go"} {
+		if got := formatFileEntry(file, status); !strings.Contains(got, file) {
+			t.Errorf("formatFileEntry(%q) = %q", file, got)
+		}
+	}
+	if got := formatCommitMessage("feat: add x\n\nbody"); !strings.Contains(got, "add x") {
+		t.Errorf("formatCommitMessage() = %q", got)
+	}
+}

--- a/internal/github/activity.go
+++ b/internal/github/activity.go
@@ -1,0 +1,459 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ActivityDigest is the normalized repo activity payload.
+type ActivityDigest struct {
+	Repo         string          `json:"repo"`
+	From         time.Time       `json:"from"`
+	To           time.Time       `json:"to"`
+	Events       []ActivityEvent `json:"events"`
+	PullRequests []PR            `json:"pullRequests"`
+	Issues       []Issue         `json:"issues"`
+	WorkflowRuns []WorkflowRun   `json:"workflowRuns"`
+	Releases     []Release       `json:"releases"`
+}
+
+// Issue describes an issue updated in the requested window.
+type Issue struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	URL       string    `json:"url"`
+	State     string    `json:"state"`
+	Author    User      `json:"author"`
+	Repo      Repo      `json:"repository"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// ActivityEvent is a normalized GitHub repository event.
+type ActivityEvent struct {
+	Type      string    `json:"type"`
+	Action    string    `json:"action,omitempty"`
+	Actor     string    `json:"actor"`
+	CreatedAt time.Time `json:"createdAt"`
+	Ref       string    `json:"ref,omitempty"`
+	Number    int       `json:"number,omitempty"`
+	Title     string    `json:"title,omitempty"`
+	URL       string    `json:"url,omitempty"`
+	Summary   string    `json:"summary"`
+}
+
+// WorkflowRun describes a GitHub Actions run in the requested window.
+type WorkflowRun struct {
+	Name        string    `json:"name"`
+	DisplayName string    `json:"displayTitle"`
+	Status      string    `json:"status"`
+	Conclusion  string    `json:"conclusion"`
+	Event       string    `json:"event"`
+	Branch      string    `json:"headBranch"`
+	URL         string    `json:"url"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+// Release describes a release in the requested window.
+type Release struct {
+	Name         string    `json:"name"`
+	TagName      string    `json:"tagName"`
+	IsDraft      bool      `json:"isDraft"`
+	IsPrerelease bool      `json:"isPrerelease"`
+	CreatedAt    time.Time `json:"createdAt"`
+	PublishedAt  time.Time `json:"publishedAt"`
+}
+
+type ActivityQuery struct {
+	Repo     string
+	Date     string
+	Since    time.Duration
+	Timezone string
+	Limit    int
+}
+
+type repoEvent struct {
+	Type      string          `json:"type"`
+	Actor     User            `json:"actor"`
+	CreatedAt time.Time       `json:"created_at"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type eventPayload struct {
+	Action      string `json:"action"`
+	Ref         string `json:"ref"`
+	RefType     string `json:"ref_type"`
+	Size        int    `json:"size"`
+	Number      int    `json:"number"`
+	PullRequest *struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		URL    string `json:"html_url"`
+		APIURL string `json:"url"`
+	} `json:"pull_request"`
+	Issue *struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		URL    string `json:"html_url"`
+		APIURL string `json:"url"`
+	} `json:"issue"`
+	Comment *struct {
+		URL string `json:"html_url"`
+	} `json:"comment"`
+	Release *struct {
+		Name    string `json:"name"`
+		TagName string `json:"tag_name"`
+		URL     string `json:"html_url"`
+	} `json:"release"`
+}
+
+func repoActivity(ctx context.Context, r Runner, q ActivityQuery) (*ActivityDigest, error) {
+	if q.Repo == "" {
+		return nil, fmt.Errorf("repo is required")
+	}
+	if err := checkAuth(ctx, r); err != nil {
+		return nil, err
+	}
+
+	from, to, err := activityWindow(q)
+	if err != nil {
+		return nil, err
+	}
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+
+	events, err := fetchEvents(ctx, r, q.Repo, from, to, limit)
+	if err != nil {
+		return nil, err
+	}
+	prs, err := fetchUpdatedPRs(ctx, r, q.Repo, from, to, limit)
+	if err != nil {
+		return nil, err
+	}
+	issues, err := fetchUpdatedIssues(ctx, r, q.Repo, from, to, limit)
+	if err != nil {
+		return nil, err
+	}
+	enrichEvents(events, prs, issues)
+	runs, err := fetchWorkflowRuns(ctx, r, q.Repo, from, to, limit)
+	if err != nil {
+		return nil, err
+	}
+	releases, err := fetchReleases(ctx, r, q.Repo, from, to, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].CreatedAt.After(events[j].CreatedAt)
+	})
+	sort.Slice(prs, func(i, j int) bool {
+		return prs[i].UpdatedAt.After(prs[j].UpdatedAt)
+	})
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].UpdatedAt.After(issues[j].UpdatedAt)
+	})
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].CreatedAt.After(runs[j].CreatedAt)
+	})
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].PublishedAt.After(releases[j].PublishedAt)
+	})
+	events = emptyIfNil(events)
+	prs = emptyIfNil(prs)
+	issues = emptyIfNil(issues)
+	runs = emptyIfNil(runs)
+	releases = emptyIfNil(releases)
+
+	return &ActivityDigest{
+		Repo:         q.Repo,
+		From:         from,
+		To:           to,
+		Events:       events,
+		PullRequests: prs,
+		Issues:       issues,
+		WorkflowRuns: runs,
+		Releases:     releases,
+	}, nil
+}
+
+func emptyIfNil[S ~[]E, E any](s S) S {
+	if s == nil {
+		return S{}
+	}
+	return s
+}
+
+func activityWindow(q ActivityQuery) (time.Time, time.Time, error) {
+	loc := time.Local
+	if q.Timezone != "" {
+		loaded, err := time.LoadLocation(q.Timezone)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("loading timezone %q: %w", q.Timezone, err)
+		}
+		loc = loaded
+	}
+	if q.Since > 0 {
+		to := time.Now().In(loc)
+		return to.Add(-q.Since), to, nil
+	}
+	date := q.Date
+	if date == "" {
+		date = time.Now().In(loc).Format(time.DateOnly)
+	}
+	start, err := time.ParseInLocation(time.DateOnly, date, loc)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("parsing date %q: %w", date, err)
+	}
+	return start, start.AddDate(0, 0, 1), nil
+}
+
+func fetchEvents(ctx context.Context, r Runner, repo string, from, to time.Time, limit int) ([]ActivityEvent, error) {
+	out, err := r.Run(ctx, "api", "repos/"+repo+"/events", "--paginate", "--slurp")
+	if err != nil {
+		return nil, fmt.Errorf("fetching repository events: %w", err)
+	}
+	var pages [][]repoEvent
+	if err := json.Unmarshal(out, &pages); err != nil {
+		return nil, fmt.Errorf("decoding repository events: %w", err)
+	}
+
+	var events []ActivityEvent
+	for _, page := range pages {
+		for _, ev := range page {
+			if !inWindow(ev.CreatedAt, from, to) {
+				continue
+			}
+			events = append(events, normalizeEvent(ev))
+			if len(events) >= limit {
+				return events, nil
+			}
+		}
+	}
+	return events, nil
+}
+
+func normalizeEvent(ev repoEvent) ActivityEvent {
+	var payload eventPayload
+	_ = json.Unmarshal(ev.Payload, &payload)
+
+	out := ActivityEvent{
+		Type:      ev.Type,
+		Action:    payload.Action,
+		Actor:     ev.Actor.Login,
+		CreatedAt: ev.CreatedAt,
+		Ref:       payload.Ref,
+	}
+	switch {
+	case payload.PullRequest != nil:
+		out.Number = payload.PullRequest.Number
+		out.Title = payload.PullRequest.Title
+		out.URL = firstNonEmpty(payload.PullRequest.URL, webURL(payload.PullRequest.APIURL))
+	case payload.Issue != nil:
+		out.Number = payload.Issue.Number
+		out.Title = payload.Issue.Title
+		out.URL = firstNonEmpty(payload.Issue.URL, webURL(payload.Issue.APIURL))
+	case payload.Release != nil:
+		out.Title = firstNonEmpty(payload.Release.Name, payload.Release.TagName)
+		out.URL = payload.Release.URL
+	}
+	out.Summary = eventSummary(out, payload)
+	return out
+}
+
+func eventSummary(ev ActivityEvent, payload eventPayload) string {
+	switch ev.Type {
+	case "PullRequestEvent":
+		return fmt.Sprintf("PR #%d %s: %s", ev.Number, ev.Action, ev.Title)
+	case "PullRequestReviewEvent":
+		return fmt.Sprintf("PR review %s on #%d", ev.Action, ev.Number)
+	case "PullRequestReviewCommentEvent":
+		return fmt.Sprintf("PR review comment %s on #%d", ev.Action, ev.Number)
+	case "IssuesEvent":
+		return fmt.Sprintf("Issue #%d %s: %s", ev.Number, ev.Action, ev.Title)
+	case "IssueCommentEvent":
+		return fmt.Sprintf("Issue comment %s on #%d: %s", ev.Action, ev.Number, ev.Title)
+	case "PushEvent":
+		if payload.Size == 0 {
+			return fmt.Sprintf("Push to %s", shortRef(ev.Ref))
+		}
+		return fmt.Sprintf("Push to %s (%d commit%s)", shortRef(ev.Ref), payload.Size, plural(payload.Size))
+	case "CreateEvent":
+		return fmt.Sprintf("Created %s %s", payload.RefType, ev.Ref)
+	case "DeleteEvent":
+		return fmt.Sprintf("Deleted %s %s", payload.RefType, ev.Ref)
+	case "ReleaseEvent":
+		return fmt.Sprintf("Release %s: %s", ev.Action, ev.Title)
+	default:
+		action := ev.Action
+		if action == "" {
+			return ev.Type
+		}
+		return ev.Type + " " + action
+	}
+}
+
+func enrichEvents(events []ActivityEvent, prs []PR, issues []Issue) {
+	prsByNumber := make(map[int]PR)
+	for _, pr := range prs {
+		prsByNumber[pr.Number] = pr
+	}
+	issuesByNumber := make(map[int]Issue)
+	for _, issue := range issues {
+		issuesByNumber[issue.Number] = issue
+	}
+	for i := range events {
+		switch events[i].Type {
+		case "PullRequestEvent":
+			pr, ok := prsByNumber[events[i].Number]
+			if !ok {
+				continue
+			}
+			if events[i].Title == "" {
+				events[i].Title = pr.Title
+			}
+			if events[i].URL == "" {
+				events[i].URL = pr.URL
+			}
+			events[i].Summary = eventSummary(events[i], eventPayload{Action: events[i].Action})
+		case "IssuesEvent", "IssueCommentEvent":
+			issue, ok := issuesByNumber[events[i].Number]
+			if !ok {
+				continue
+			}
+			if events[i].Title == "" {
+				events[i].Title = issue.Title
+			}
+			if events[i].URL == "" {
+				events[i].URL = issue.URL
+			}
+			events[i].Summary = eventSummary(events[i], eventPayload{Action: events[i].Action})
+		}
+	}
+}
+
+func fetchUpdatedPRs(ctx context.Context, r Runner, repo string, from, to time.Time, limit int) ([]PR, error) {
+	out, err := r.Run(ctx,
+		"search", "prs",
+		"--repo", repo,
+		"--limit", fmt.Sprint(limit),
+		"--json", "repository,number,title,url,author,createdAt,updatedAt,isDraft,state",
+		"updated:>="+from.Format(time.DateOnly),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fetching updated pull requests: %w", err)
+	}
+	var raw []PR
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("decoding updated pull requests: %w", err)
+	}
+	var prs []PR
+	for _, pr := range raw {
+		if inWindow(pr.CreatedAt, from, to) || inWindow(pr.UpdatedAt, from, to) {
+			prs = append(prs, pr)
+		}
+	}
+	return prs, nil
+}
+
+func fetchUpdatedIssues(ctx context.Context, r Runner, repo string, from, to time.Time, limit int) ([]Issue, error) {
+	out, err := r.Run(ctx,
+		"search", "issues",
+		"--repo", repo,
+		"--limit", fmt.Sprint(limit),
+		"--json", "repository,number,title,url,author,createdAt,updatedAt,state",
+		"updated:>="+from.Format(time.DateOnly),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fetching updated issues: %w", err)
+	}
+	var raw []Issue
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("decoding updated issues: %w", err)
+	}
+	var issues []Issue
+	for _, issue := range raw {
+		if inWindow(issue.CreatedAt, from, to) || inWindow(issue.UpdatedAt, from, to) {
+			issues = append(issues, issue)
+		}
+	}
+	return issues, nil
+}
+
+func fetchWorkflowRuns(ctx context.Context, r Runner, repo string, from, to time.Time, limit int) ([]WorkflowRun, error) {
+	out, err := r.Run(ctx, "run", "list", "--repo", repo, "--limit", fmt.Sprint(limit), "--json", "name,displayTitle,status,conclusion,event,headBranch,url,createdAt,updatedAt")
+	if err != nil {
+		return nil, fmt.Errorf("fetching workflow runs: %w", err)
+	}
+	var raw []WorkflowRun
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("decoding workflow runs: %w", err)
+	}
+	var runs []WorkflowRun
+	for _, run := range raw {
+		if inWindow(run.CreatedAt, from, to) || inWindow(run.UpdatedAt, from, to) {
+			runs = append(runs, run)
+		}
+	}
+	return runs, nil
+}
+
+func fetchReleases(ctx context.Context, r Runner, repo string, from, to time.Time, limit int) ([]Release, error) {
+	out, err := r.Run(ctx, "release", "list", "--repo", repo, "--limit", fmt.Sprint(limit), "--json", "name,tagName,isDraft,isPrerelease,createdAt,publishedAt")
+	if err != nil {
+		return nil, fmt.Errorf("fetching releases: %w", err)
+	}
+	var raw []Release
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("decoding releases: %w", err)
+	}
+	var releases []Release
+	for _, release := range raw {
+		if inWindow(release.CreatedAt, from, to) || inWindow(release.PublishedAt, from, to) {
+			releases = append(releases, release)
+		}
+	}
+	return releases, nil
+}
+
+func inWindow(t, from, to time.Time) bool {
+	if t.IsZero() {
+		return false
+	}
+	return !t.Before(from) && t.Before(to)
+}
+
+func shortRef(ref string) string {
+	return strings.TrimPrefix(ref, "refs/heads/")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func webURL(apiURL string) string {
+	if apiURL == "" {
+		return ""
+	}
+	url := strings.Replace(apiURL, "https://api.github.com/repos/", "https://github.com/", 1)
+	return strings.Replace(url, "/pulls/", "/pull/", 1)
+}

--- a/internal/github/commands.go
+++ b/internal/github/commands.go
@@ -1,0 +1,196 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// RegisterCommands installs the `github` command tree.
+func RegisterCommands(parent *cobra.Command) {
+	parent.AddCommand(newCommand(ghRunner{}))
+}
+
+func newCommand(r Runner) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "github",
+		Short: "GitHub pull request and repository activity helpers",
+	}
+	c.AddCommand(newPRsCommand(r), newRepoCommand(r))
+	return c
+}
+
+func newPRsCommand(r Runner) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "prs",
+		Short: "List GitHub pull requests",
+	}
+	c.AddCommand(newReviewQueueCommand(r), newAuthoredCommand(r))
+	return c
+}
+
+func newReviewQueueCommand(r Runner) *cobra.Command {
+	var q PRQuery
+	var jsonOut bool
+	c := &cobra.Command{
+		Use:   "review-queue",
+		Short: "List pull requests requesting review from a user",
+		Run: func(cmd *cobra.Command, args []string) {
+			q.Mode = "review-requested"
+			prs, err := listPRs(cmd.Context(), r, q)
+			exitOnErr(err)
+			printPRs(prs, jsonOut)
+		},
+	}
+	addPRFlags(c, &q, &jsonOut)
+	c.Flags().BoolVar(&q.Direct, "direct", false, "Only include PRs directly requesting the user, excluding team requests")
+	return c
+}
+
+func newAuthoredCommand(r Runner) *cobra.Command {
+	var q PRQuery
+	var jsonOut bool
+	c := &cobra.Command{
+		Use:   "authored",
+		Short: "List pull requests authored by a user",
+		Run: func(cmd *cobra.Command, args []string) {
+			q.Mode = "authored"
+			prs, err := listPRs(cmd.Context(), r, q)
+			exitOnErr(err)
+			printPRs(prs, jsonOut)
+		},
+	}
+	addPRFlags(c, &q, &jsonOut)
+	return c
+}
+
+func addPRFlags(c *cobra.Command, q *PRQuery, jsonOut *bool) {
+	c.Flags().StringVar(&q.User, "user", "@me", "GitHub user login or @me")
+	c.Flags().StringVar(&q.State, "state", "open", "PR state: open, closed, or all")
+	c.Flags().IntVar(&q.Limit, "limit", 200, "Maximum number of pull requests to return")
+	c.Flags().StringVar(&q.Repo, "repo", "", "Restrict to one repository, owner/name")
+	c.Flags().StringVar(&q.Owner, "owner", "", "Restrict to repositories owned by this user or organization")
+	c.Flags().BoolVar(&q.IncludeDrafts, "include-drafts", false, "Include draft pull requests")
+	c.Flags().BoolVar(jsonOut, "json", false, "Print normalized JSON")
+}
+
+func newRepoCommand(r Runner) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "repo",
+		Short: "Inspect GitHub repositories",
+	}
+	c.AddCommand(newActivityCommand(r))
+	return c
+}
+
+func newActivityCommand(r Runner) *cobra.Command {
+	var q ActivityQuery
+	var since string
+	var jsonOut bool
+	c := &cobra.Command{
+		Use:   "activity <owner/repo>",
+		Short: "Show repository activity for a day or recent duration",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			q.Repo = args[0]
+			if since != "" {
+				d, err := time.ParseDuration(since)
+				exitOnErr(err)
+				q.Since = d
+			}
+			digest, err := repoActivity(cmd.Context(), r, q)
+			exitOnErr(err)
+			printActivity(digest, jsonOut)
+		},
+	}
+	c.Flags().StringVar(&q.Date, "date", "", "Date to inspect in YYYY-MM-DD, default today in the selected timezone")
+	c.Flags().StringVar(&since, "since", "", "Recent duration to inspect, for example 24h")
+	c.Flags().StringVar(&q.Timezone, "timezone", "", "IANA timezone for date windows, default local timezone")
+	c.Flags().IntVar(&q.Limit, "limit", 200, "Maximum items to fetch per source")
+	c.Flags().BoolVar(&jsonOut, "json", false, "Print normalized JSON")
+	return c
+}
+
+func printPRs(prs []PR, jsonOut bool) {
+	if jsonOut {
+		printJSON(prs)
+		return
+	}
+	if len(prs) == 0 {
+		fmt.Println("No pull requests found.")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	_, _ = fmt.Fprintln(w, "REPO\tPR\tSTATE\tDRAFT\tAUTHOR\tTITLE\tURL")
+	for _, pr := range prs {
+		_, _ = fmt.Fprintln(w, strings.Join(prRow(pr), "\t"))
+	}
+	_ = w.Flush()
+}
+
+func printActivity(d *ActivityDigest, jsonOut bool) {
+	if jsonOut {
+		printJSON(d)
+		return
+	}
+	fmt.Printf("%s activity from %s to %s\n", d.Repo, d.From.Format(time.RFC3339), d.To.Format(time.RFC3339))
+
+	if len(d.Events) == 0 && len(d.PullRequests) == 0 && len(d.Issues) == 0 && len(d.WorkflowRuns) == 0 && len(d.Releases) == 0 {
+		fmt.Println("No activity found.")
+		return
+	}
+	if len(d.PullRequests) > 0 {
+		fmt.Println("\nPull Requests")
+		for _, pr := range d.PullRequests {
+			fmt.Printf("  %s  #%d  %-8s  %s  %s\n", pr.UpdatedAt.Format("15:04"), pr.Number, strings.ToLower(pr.State), pr.Title, pr.URL)
+		}
+	}
+	if len(d.Issues) > 0 {
+		fmt.Println("\nIssues")
+		for _, issue := range d.Issues {
+			fmt.Printf("  %s  #%d  %-8s  %s  %s\n", issue.UpdatedAt.Format("15:04"), issue.Number, strings.ToLower(issue.State), issue.Title, issue.URL)
+		}
+	}
+	if len(d.Events) > 0 {
+		fmt.Println("\nEvents")
+		for _, ev := range d.Events {
+			fmt.Printf("  %s  %-18s  %s\n", ev.CreatedAt.Format("15:04"), ev.Actor, ev.Summary)
+		}
+	}
+	if len(d.WorkflowRuns) > 0 {
+		fmt.Println("\nWorkflow Runs")
+		for _, run := range d.WorkflowRuns {
+			status := firstNonEmpty(run.Conclusion, run.Status)
+			fmt.Printf("  %s  %-12s  %s on %s  %s\n", run.CreatedAt.Format("15:04"), status, firstNonEmpty(run.DisplayName, run.Name), run.Branch, run.URL)
+		}
+	}
+	if len(d.Releases) > 0 {
+		fmt.Println("\nReleases")
+		for _, release := range d.Releases {
+			fmt.Printf("  %s  %s  %s\n", release.PublishedAt.Format("15:04"), release.TagName, release.Name)
+		}
+	}
+}
+
+func printJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	exitOnErr(enc.Encode(v))
+}
+
+func exitOnErr(err error) {
+	if err == nil {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Error:", err)
+	os.Exit(1)
+}
+
+func init() {
+	cobra.EnableCommandSorting = false
+}

--- a/internal/github/commands_test.go
+++ b/internal/github/commands_test.go
@@ -1,0 +1,189 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCommandConstructors(t *testing.T) {
+	parent := &cobra.Command{Use: "root"}
+	RegisterCommands(parent)
+	if cmd, _, err := parent.Find([]string{"github"}); err != nil || cmd.Name() != "github" {
+		t.Fatalf("registered github command missing: cmd=%v err=%v", cmd, err)
+	}
+
+	root := newCommand(&fakeRunner{})
+	if root.Use != "github" {
+		t.Fatalf("Use = %q, want github", root.Use)
+	}
+	for _, path := range [][]string{
+		{"prs", "review-queue"},
+		{"prs", "authored"},
+		{"repo", "activity"},
+	} {
+		cmd := root
+		for _, name := range path {
+			var nextFound bool
+			for _, child := range cmd.Commands() {
+				if child.Name() == name {
+					cmd = child
+					nextFound = true
+					break
+				}
+			}
+			if !nextFound {
+				t.Fatalf("command path %v missing %q", path, name)
+			}
+		}
+	}
+}
+
+func TestReviewQueueCommandExecutesQuery(t *testing.T) {
+	r := &fakeRunner{responses: map[string]string{
+		"auth\x00status": "ok",
+		"search\x00prs\x00--state\x00open\x00--limit\x001\x00--json\x00repository,number,title,url,author,createdAt,updatedAt,isDraft,state\x00--review-requested\x00alice\x00--draft=false": "[]",
+	}}
+	cmd := newReviewQueueCommand(r)
+	cmd.SetArgs([]string{"--user", "alice", "--limit", "1", "--json"})
+
+	out := captureStdout(t, func() {
+		if err := cmd.ExecuteContext(context.Background()); err != nil {
+			t.Fatalf("ExecuteContext() error = %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "[]" {
+		t.Fatalf("stdout = %q, want []", out)
+	}
+}
+
+func TestActivityCommandExecutesQuery(t *testing.T) {
+	r := &fakeRunner{responses: map[string]string{
+		"auth\x00status": "ok",
+		"api\x00repos/SiyuQian/devpilot/events\x00--paginate\x00--slurp": "[]",
+		"search\x00prs\x00--repo\x00SiyuQian/devpilot\x00--limit\x001\x00--json\x00repository,number,title,url,author,createdAt,updatedAt,isDraft,state\x00updated:>=2026-06-01": "[]",
+		"search\x00issues\x00--repo\x00SiyuQian/devpilot\x00--limit\x001\x00--json\x00repository,number,title,url,author,createdAt,updatedAt,state\x00updated:>=2026-06-01":      "[]",
+		"run\x00list\x00--repo\x00SiyuQian/devpilot\x00--limit\x001\x00--json\x00name,displayTitle,status,conclusion,event,headBranch,url,createdAt,updatedAt":                   "[]",
+		"release\x00list\x00--repo\x00SiyuQian/devpilot\x00--limit\x001\x00--json\x00name,tagName,isDraft,isPrerelease,createdAt,publishedAt":                                    "[]",
+	}}
+	cmd := newActivityCommand(r)
+	cmd.SetArgs([]string{"SiyuQian/devpilot", "--date", "2026-06-01", "--timezone", "UTC", "--limit", "1", "--json"})
+
+	out := captureStdout(t, func() {
+		if err := cmd.ExecuteContext(context.Background()); err != nil {
+			t.Fatalf("ExecuteContext() error = %v", err)
+		}
+	})
+	for _, want := range []string{`"repo": "SiyuQian/devpilot"`, `"events": []`, `"workflowRuns": []`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintPRsHumanOutput(t *testing.T) {
+	prs := []PR{{
+		Number:  7,
+		Title:   "a title",
+		URL:     "https://example.com/pr/7",
+		State:   "open",
+		IsDraft: true,
+		Author:  User{Login: "alice"},
+		Repo:    Repo{NameWithOwner: "owner/repo"},
+	}}
+	out := captureStdout(t, func() { printPRs(prs, false) })
+	for _, want := range []string{"REPO", "owner/repo", "#7", "draft", "alice", "a title"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+
+	empty := captureStdout(t, func() { printPRs(nil, false) })
+	if !strings.Contains(empty, "No pull requests found.") {
+		t.Errorf("empty stdout = %q", empty)
+	}
+}
+
+func TestPrintActivityHumanOutput(t *testing.T) {
+	now := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+	digest := &ActivityDigest{
+		Repo: "owner/repo",
+		From: now,
+		To:   now.Add(time.Hour),
+		PullRequests: []PR{{
+			Number:    1,
+			Title:     "feat: x",
+			URL:       "https://example.com/pr/1",
+			State:     "OPEN",
+			UpdatedAt: now,
+		}},
+		Issues: []Issue{{
+			Number:    2,
+			Title:     "bug",
+			URL:       "https://example.com/issues/2",
+			State:     "OPEN",
+			UpdatedAt: now,
+		}},
+		Events: []ActivityEvent{{
+			Actor:     "alice",
+			CreatedAt: now,
+			Summary:   "Created branch main",
+		}},
+		WorkflowRuns: []WorkflowRun{{
+			Name:      "test",
+			Status:    "completed",
+			Branch:    "main",
+			URL:       "https://example.com/actions/1",
+			CreatedAt: now,
+		}},
+		Releases: []Release{{
+			Name:        "release",
+			TagName:     "v1",
+			PublishedAt: now,
+		}},
+	}
+	out := captureStdout(t, func() { printActivity(digest, false) })
+	for _, want := range []string{"Pull Requests", "Issues", "Events", "Workflow Runs", "Releases", "feat: x", "release"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+
+	empty := *digest
+	empty.PullRequests = nil
+	empty.Issues = nil
+	empty.Events = nil
+	empty.WorkflowRuns = nil
+	empty.Releases = nil
+	out = captureStdout(t, func() { printActivity(&empty, false) })
+	if !strings.Contains(out, "No activity found.") {
+		t.Errorf("empty stdout = %q", out)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("reading stdout: %v", err)
+	}
+	return buf.String()
+}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -3,6 +3,8 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +26,40 @@ func (r *fakeRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
 		return []byte(out), nil
 	}
 	return []byte("[]"), nil
+}
+
+func TestGHRunnerRun(t *testing.T) {
+	bin := t.TempDir()
+	gh := filepath.Join(bin, "gh")
+	if err := os.WriteFile(gh, []byte("#!/bin/sh\nprintf '%s' \"$1 $2\"\n"), 0o755); err != nil {
+		t.Fatalf("write gh: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := ghRunner{}.Run(context.Background(), "auth", "status")
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if string(out) != "auth status" {
+		t.Fatalf("out = %q", out)
+	}
+}
+
+func TestGHRunnerRunErrorIncludesStderr(t *testing.T) {
+	bin := t.TempDir()
+	gh := filepath.Join(bin, "gh")
+	if err := os.WriteFile(gh, []byte("#!/bin/sh\necho bad auth >&2\nexit 2\n"), 0o755); err != nil {
+		t.Fatalf("write gh: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := ghRunner{}.Run(context.Background(), "auth", "status")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "bad auth") {
+		t.Fatalf("error = %v", err)
+	}
 }
 
 func TestListPRsReviewQueueBuildsDirectQuery(t *testing.T) {
@@ -200,5 +236,63 @@ func TestRepoActivityFiltersAndNormalizesSources(t *testing.T) {
 	}
 	if _, err := json.Marshal(digest); err != nil {
 		t.Errorf("digest should be JSON serializable: %v", err)
+	}
+}
+
+func TestActivityHelpersCoverEventVariants(t *testing.T) {
+	now := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+	events := []repoEvent{
+		{Type: "IssuesEvent", Actor: User{Login: "alice"}, CreatedAt: now, Payload: json.RawMessage(`{"action":"opened","issue":{"number":3,"title":"bug","url":"https://api.github.com/repos/o/r/issues/3"}}`)},
+		{Type: "IssueCommentEvent", Actor: User{Login: "alice"}, CreatedAt: now, Payload: json.RawMessage(`{"action":"created","issue":{"number":3,"title":"bug"}}`)},
+		{Type: "PullRequestReviewEvent", Actor: User{Login: "bob"}, CreatedAt: now, Payload: json.RawMessage(`{"action":"submitted","number":4}`)},
+		{Type: "PullRequestReviewCommentEvent", Actor: User{Login: "bob"}, CreatedAt: now, Payload: json.RawMessage(`{"action":"created","number":4}`)},
+		{Type: "PushEvent", Actor: User{Login: "bob"}, CreatedAt: now, Payload: json.RawMessage(`{"ref":"refs/heads/main","size":1}`)},
+		{Type: "CreateEvent", Actor: User{Login: "bob"}, CreatedAt: now, Payload: json.RawMessage(`{"ref_type":"tag","ref":"v1"}`)},
+		{Type: "ReleaseEvent", Actor: User{Login: "bob"}, CreatedAt: now, Payload: json.RawMessage(`{"action":"published","release":{"name":"Release","tag_name":"v1","html_url":"https://example.com/release"}}`)},
+		{Type: "WatchEvent", Actor: User{Login: "bob"}, CreatedAt: now, Payload: json.RawMessage(`{"action":"started"}`)},
+	}
+	var normalized []ActivityEvent
+	for _, ev := range events {
+		normalized = append(normalized, normalizeEvent(ev))
+	}
+	enrichEvents(normalized, nil, []Issue{{Number: 3, Title: "bug", URL: "https://github.com/o/r/issues/3"}})
+	for _, ev := range normalized {
+		if ev.Summary == "" {
+			t.Fatalf("empty summary for %#v", ev)
+		}
+	}
+	if got := shortRef("refs/heads/main"); got != "main" {
+		t.Fatalf("shortRef() = %q, want main", got)
+	}
+	if got := plural(2); got != "s" {
+		t.Fatalf("plural(2) = %q, want s", got)
+	}
+	if got := webURL(""); got != "" {
+		t.Fatalf("webURL(empty) = %q, want empty", got)
+	}
+	if got := webURL("https://api.github.com/repos/o/r/pulls/1"); got != "https://github.com/o/r/pull/1" {
+		t.Fatalf("webURL() = %q", got)
+	}
+}
+
+func TestPRRowAndTrimForTable(t *testing.T) {
+	pr := PR{
+		Number:  9,
+		Title:   "hello\nworld with a very long title",
+		URL:     "https://example.com/pr/9",
+		State:   "open",
+		IsDraft: true,
+		Author:  User{Login: "alice"},
+		Repo:    Repo{Name: "repo"},
+	}
+	row := prRow(pr)
+	if row[0] != "repo" || row[1] != "#9" || row[3] != "draft" || row[4] != "alice" {
+		t.Fatalf("prRow() = %#v", row)
+	}
+	if got := trimForTable("abcdef", 3); got != "abc" {
+		t.Fatalf("trimForTable short max = %q", got)
+	}
+	if got := trimForTable("abcdef", 5); got != "ab..." {
+		t.Fatalf("trimForTable ellipsis = %q", got)
 	}
 }

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,0 +1,204 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeRunner struct {
+	calls     [][]string
+	responses map[string]string
+	errs      map[string]error
+}
+
+func (r *fakeRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	key := strings.Join(args, "\x00")
+	if err := r.errs[key]; err != nil {
+		return nil, err
+	}
+	if out, ok := r.responses[key]; ok {
+		return []byte(out), nil
+	}
+	return []byte("[]"), nil
+}
+
+func TestListPRsReviewQueueBuildsDirectQuery(t *testing.T) {
+	r := &fakeRunner{
+		responses: map[string]string{
+			"auth\x00status": "ok",
+			"search\x00prs\x00--state\x00open\x00--limit\x0050\x00--json\x00repository,number,title,url,author,createdAt,updatedAt,isDraft,state\x00--repo\x00SiyuQian/devpilot\x00user-review-requested:@me\x00--draft=false": `[{
+				"number": 147,
+				"title": "docs: sync learn skill",
+				"url": "https://github.com/SiyuQian/devpilot/pull/147",
+				"state": "open",
+				"isDraft": false,
+				"author": {"login": "SiyuQian"},
+				"repository": {"nameWithOwner": "SiyuQian/devpilot"},
+				"createdAt": "2026-06-01T01:00:00Z",
+				"updatedAt": "2026-06-01T02:00:00Z"
+			}]`,
+		},
+	}
+
+	prs, err := listPRs(context.Background(), r, PRQuery{
+		Mode:   "review-requested",
+		Direct: true,
+		Repo:   "SiyuQian/devpilot",
+		Limit:  50,
+	})
+	if err != nil {
+		t.Fatalf("listPRs() error = %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("len(prs) = %d, want 1", len(prs))
+	}
+	if prs[0].Repo.NameWithOwner != "SiyuQian/devpilot" {
+		t.Errorf("repo = %q, want SiyuQian/devpilot", prs[0].Repo.NameWithOwner)
+	}
+	got := strings.Join(r.calls[1], " ")
+	if !strings.Contains(got, "user-review-requested:@me") {
+		t.Errorf("search args = %q, want direct review qualifier", got)
+	}
+	if strings.Contains(got, "--review-requested") {
+		t.Errorf("search args = %q, should not include --review-requested for direct mode", got)
+	}
+}
+
+func TestListPRsAuthoredBuildsAuthorQuery(t *testing.T) {
+	r := &fakeRunner{responses: map[string]string{
+		"auth\x00status": "ok",
+		"search\x00prs\x00--limit\x00200\x00--json\x00repository,number,title,url,author,createdAt,updatedAt,isDraft,state\x00--owner\x00SiyuQian\x00--author\x00octocat\x00--draft=false": "[]",
+	}}
+
+	_, err := listPRs(context.Background(), r, PRQuery{
+		Mode:  "authored",
+		User:  "octocat",
+		State: "all",
+		Owner: "SiyuQian",
+	})
+	if err != nil {
+		t.Fatalf("listPRs() error = %v", err)
+	}
+	got := strings.Join(r.calls[1], " ")
+	for _, want := range []string{"--author octocat", "--owner SiyuQian"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("search args = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "--state") {
+		t.Errorf("search args = %q, should omit --state for all", got)
+	}
+}
+
+func TestActivityWindowUsesTimezoneDate(t *testing.T) {
+	from, to, err := activityWindow(ActivityQuery{
+		Date:     "2026-06-01",
+		Timezone: "Pacific/Auckland",
+	})
+	if err != nil {
+		t.Fatalf("activityWindow() error = %v", err)
+	}
+	if got := from.Format(time.RFC3339); got != "2026-06-01T00:00:00+12:00" {
+		t.Errorf("from = %s, want 2026-06-01T00:00:00+12:00", got)
+	}
+	if got := to.Format(time.RFC3339); got != "2026-06-02T00:00:00+12:00" {
+		t.Errorf("to = %s, want 2026-06-02T00:00:00+12:00", got)
+	}
+}
+
+func TestRepoActivityFiltersAndNormalizesSources(t *testing.T) {
+	events := `[[{
+		"type": "PullRequestEvent",
+		"actor": {"login": "SiyuQian"},
+		"created_at": "2026-06-01T06:24:14Z",
+		"payload": {"action": "merged", "pull_request": {
+			"number": 147,
+			"title": "docs: sync learn skill",
+			"html_url": "https://github.com/SiyuQian/devpilot/pull/147"
+		}}
+	}, {
+		"type": "PushEvent",
+		"actor": {"login": "SiyuQian"},
+		"created_at": "2026-05-30T06:24:14Z",
+		"payload": {"ref": "refs/heads/main", "size": 1}
+	}]]`
+	runs := `[{
+		"name": "test",
+		"displayTitle": "test main",
+		"status": "completed",
+		"conclusion": "success",
+		"event": "push",
+		"headBranch": "main",
+		"url": "https://github.com/SiyuQian/devpilot/actions/runs/1",
+		"createdAt": "2026-06-01T07:00:00Z",
+		"updatedAt": "2026-06-01T07:10:00Z"
+	}]`
+	releases := `[{
+		"name": "v1",
+		"tagName": "v1.0.0",
+		"isDraft": false,
+		"isPrerelease": false,
+		"createdAt": "2026-06-01T05:00:00Z",
+		"publishedAt": "2026-06-01T05:01:00Z"
+	}]`
+	r := &fakeRunner{responses: map[string]string{
+		"auth\x00status": "ok",
+		"api\x00repos/SiyuQian/devpilot/events\x00--paginate\x00--slurp": events,
+		"search\x00prs\x00--repo\x00SiyuQian/devpilot\x00--limit\x00200\x00--json\x00repository,number,title,url,author,createdAt,updatedAt,isDraft,state\x00updated:>=2026-06-01": `[{
+			"number": 147,
+			"title": "docs: sync learn skill",
+			"url": "https://github.com/SiyuQian/devpilot/pull/147",
+			"state": "merged",
+			"author": {"login": "SiyuQian"},
+			"repository": {"nameWithOwner": "SiyuQian/devpilot"},
+			"createdAt": "2026-06-01T06:23:23Z",
+			"updatedAt": "2026-06-01T06:24:15Z"
+		}]`,
+		"search\x00issues\x00--repo\x00SiyuQian/devpilot\x00--limit\x00200\x00--json\x00repository,number,title,url,author,createdAt,updatedAt,state\x00updated:>=2026-06-01": `[{
+			"number": 12,
+			"title": "track activity",
+			"url": "https://github.com/SiyuQian/devpilot/issues/12",
+			"state": "open",
+			"author": {"login": "SiyuQian"},
+			"repository": {"nameWithOwner": "SiyuQian/devpilot"},
+			"createdAt": "2026-05-31T06:23:23Z",
+			"updatedAt": "2026-06-01T06:24:15Z"
+		}]`,
+		"run\x00list\x00--repo\x00SiyuQian/devpilot\x00--limit\x00200\x00--json\x00name,displayTitle,status,conclusion,event,headBranch,url,createdAt,updatedAt": runs,
+		"release\x00list\x00--repo\x00SiyuQian/devpilot\x00--limit\x00200\x00--json\x00name,tagName,isDraft,isPrerelease,createdAt,publishedAt":                  releases,
+	}}
+
+	digest, err := repoActivity(context.Background(), r, ActivityQuery{
+		Repo:     "SiyuQian/devpilot",
+		Date:     "2026-06-01",
+		Timezone: "UTC",
+	})
+	if err != nil {
+		t.Fatalf("repoActivity() error = %v", err)
+	}
+	if len(digest.Events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(digest.Events))
+	}
+	if digest.Events[0].Summary != "PR #147 merged: docs: sync learn skill" {
+		t.Errorf("summary = %q", digest.Events[0].Summary)
+	}
+	if len(digest.WorkflowRuns) != 1 {
+		t.Errorf("len(workflowRuns) = %d, want 1", len(digest.WorkflowRuns))
+	}
+	if len(digest.PullRequests) != 1 {
+		t.Errorf("len(pullRequests) = %d, want 1", len(digest.PullRequests))
+	}
+	if len(digest.Issues) != 1 {
+		t.Errorf("len(issues) = %d, want 1", len(digest.Issues))
+	}
+	if len(digest.Releases) != 1 {
+		t.Errorf("len(releases) = %d, want 1", len(digest.Releases))
+	}
+	if _, err := json.Marshal(digest); err != nil {
+		t.Errorf("digest should be JSON serializable: %v", err)
+	}
+}

--- a/internal/github/prs.go
+++ b/internal/github/prs.go
@@ -1,0 +1,138 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PR describes a pull request returned by the GitHub search command.
+type PR struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	URL       string    `json:"url"`
+	State     string    `json:"state"`
+	IsDraft   bool      `json:"isDraft"`
+	Author    User      `json:"author"`
+	Repo      Repo      `json:"repository"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// User is a GitHub user fragment.
+type User struct {
+	Login string `json:"login"`
+}
+
+// Repo is a GitHub repository fragment.
+type Repo struct {
+	Name          string `json:"name"`
+	NameWithOwner string `json:"nameWithOwner"`
+}
+
+type PRQuery struct {
+	Mode          string
+	User          string
+	Direct        bool
+	State         string
+	Limit         int
+	Repo          string
+	Owner         string
+	IncludeDrafts bool
+}
+
+func listPRs(ctx context.Context, r Runner, q PRQuery) ([]PR, error) {
+	if err := checkAuth(ctx, r); err != nil {
+		return nil, err
+	}
+
+	state := q.State
+	if state == "" {
+		state = "open"
+	}
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+
+	args := []string{"search", "prs"}
+	if state != "all" {
+		args = append(args, "--state", state)
+	}
+	args = append(args, "--limit", fmt.Sprint(limit))
+	args = append(args, "--json", "repository,number,title,url,author,createdAt,updatedAt,isDraft,state")
+	if q.Repo != "" {
+		args = append(args, "--repo", q.Repo)
+	}
+	if q.Owner != "" {
+		args = append(args, "--owner", q.Owner)
+	}
+
+	user := q.User
+	if user == "" {
+		user = "@me"
+	}
+	switch q.Mode {
+	case "review-requested":
+		if q.Direct {
+			args = append(args, "user-review-requested:"+user)
+		} else {
+			args = append(args, "--review-requested", user)
+		}
+	case "authored":
+		args = append(args, "--author", user)
+	default:
+		return nil, fmt.Errorf("unknown PR query mode %q", q.Mode)
+	}
+	if !q.IncludeDrafts {
+		args = append(args, "--draft=false")
+	}
+
+	out, err := r.Run(ctx, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing pull requests: %w", err)
+	}
+	var prs []PR
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("decoding pull requests: %w", err)
+	}
+	return prs, nil
+}
+
+func prRow(pr PR) []string {
+	repo := pr.Repo.NameWithOwner
+	if repo == "" {
+		repo = pr.Repo.Name
+	}
+	author := pr.Author.Login
+	if author == "" {
+		author = "-"
+	}
+	draft := ""
+	if pr.IsDraft {
+		draft = "draft"
+	}
+	return []string{
+		repo,
+		fmt.Sprintf("#%d", pr.Number),
+		pr.State,
+		draft,
+		author,
+		trimForTable(pr.Title, 72),
+		pr.URL,
+	}
+}
+
+func trimForTable(s string, max int) string {
+	s = strings.ReplaceAll(s, "\t", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/internal/github/runner.go
+++ b/internal/github/runner.go
@@ -1,0 +1,33 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// Runner executes gh commands.
+type Runner interface {
+	Run(ctx context.Context, args ...string) ([]byte, error)
+}
+
+type ghRunner struct{}
+
+func (r ghRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh %v: %s", args, exitErr.Stderr)
+		}
+		return nil, fmt.Errorf("gh %v: %w", args, err)
+	}
+	return out, nil
+}
+
+func checkAuth(ctx context.Context, r Runner) error {
+	if _, err := r.Run(ctx, "auth", "status"); err != nil {
+		return fmt.Errorf("checking GitHub CLI auth: %w", err)
+	}
+	return nil
+}

--- a/internal/gmail/client_test.go
+++ b/internal/gmail/client_test.go
@@ -3,8 +3,10 @@ package gmail
 import (
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -59,6 +61,72 @@ func TestListMessagesEmpty(t *testing.T) {
 	if len(refs) != 0 {
 		t.Fatalf("expected 0 messages, got %d", len(refs))
 	}
+}
+
+func TestListAllMessageIDsPaginated(t *testing.T) {
+	call := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		if r.URL.Query().Get("q") != "is:unread" {
+			t.Fatalf("unexpected query: %s", r.URL.Query().Get("q"))
+		}
+		if r.URL.Query().Get("maxResults") != "500" {
+			t.Fatalf("unexpected maxResults: %s", r.URL.Query().Get("maxResults"))
+		}
+		switch call {
+		case 1:
+			_ = json.NewEncoder(w).Encode(MessageListResponse{
+				Messages:      []MessageRef{{ID: "msg1"}},
+				NextPageToken: "next",
+			})
+		case 2:
+			if r.URL.Query().Get("pageToken") != "next" {
+				t.Fatalf("unexpected pageToken: %s", r.URL.Query().Get("pageToken"))
+			}
+			_ = json.NewEncoder(w).Encode(MessageListResponse{
+				Messages: []MessageRef{{ID: "msg2"}},
+			})
+		default:
+			t.Fatalf("unexpected call %d", call)
+		}
+	}))
+	defer srv.Close()
+
+	ids, err := NewClient("test-token", WithBaseURL(srv.URL)).ListAllMessageIDs("is:unread")
+	if err != nil {
+		t.Fatalf("ListAllMessageIDs error: %v", err)
+	}
+	if strings.Join(ids, ",") != "msg1,msg2" {
+		t.Fatalf("ids = %v", ids)
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host != "gmail.test" {
+			t.Fatalf("unexpected host: %s", r.URL.Host)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"messages":[{"id":"msg1"}]}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	client := NewClient("test-token", WithBaseURL("https://gmail.test"), WithHTTPClient(&http.Client{Transport: transport}))
+
+	refs, err := client.ListMessages("", 0)
+	if err != nil {
+		t.Fatalf("ListMessages error: %v", err)
+	}
+	if len(refs) != 1 || refs[0].ID != "msg1" {
+		t.Fatalf("refs = %#v", refs)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }
 
 func TestGetMessage(t *testing.T) {

--- a/internal/gmail/commands.go
+++ b/internal/gmail/commands.go
@@ -11,6 +11,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type messageClient interface {
+	ListMessages(query string, limit int) ([]MessageRef, error)
+	ListAllMessageIDs(query string) ([]string, error)
+	GetMessage(id string) (*Message, error)
+	BatchModify(ids []string, removeLabelIDs []string) error
+}
+
+var (
+	lookPathFn     = exec.LookPath
+	runClaudeFn    = RunClaude
+	sendToSlackFn  = SendToSlack
+	fetchEmailsFn  = FetchEmails
+	requireLoginFn = requireLogin
+)
+
 // RegisterCommands adds the `gmail` subtree to parent.
 func RegisterCommands(parent *cobra.Command) {
 	gmailCmd := &cobra.Command{
@@ -50,66 +65,67 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List emails",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := requireLogin()
+		client, err := requireLoginFn()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-
-		unread, _ := cmd.Flags().GetBool("unread")
-		after, _ := cmd.Flags().GetString("after")
-		limit, _ := cmd.Flags().GetInt("limit")
-
-		var queryParts []string
-		if unread {
-			queryParts = append(queryParts, "is:unread")
-		}
-		if after != "" {
-			queryParts = append(queryParts, "after:"+after)
-		}
-		query := strings.Join(queryParts, " ")
-
-		refs, err := client.ListMessages(query, limit)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		if len(refs) == 0 {
-			if unread {
-				fmt.Println("No unread messages.")
-			} else {
-				fmt.Println("No messages found.")
-			}
-			return
-		}
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-		_, _ = fmt.Fprintln(w, "ID\tFROM\tSUBJECT\tDATE")
-		for _, ref := range refs {
-			msg, err := client.GetMessage(ref.ID)
-			if err != nil {
-				continue
-			}
-			from := GetHeader(msg, "From")
-			subject := GetHeader(msg, "Subject")
-			date := GetHeader(msg, "Date")
-
-			// Truncate long fields for table display
-			if len(from) > 30 {
-				from = from[:27] + "..."
-			}
-			if len(subject) > 40 {
-				subject = subject[:37] + "..."
-			}
-			if len(date) > 20 {
-				date = date[:20]
-			}
-
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ref.ID, from, subject, date)
-		}
-		_ = w.Flush()
+		os.Exit(runList(cmd, client))
 	},
+}
+
+func runList(cmd *cobra.Command, client messageClient) int {
+	unread, _ := cmd.Flags().GetBool("unread")
+	after, _ := cmd.Flags().GetString("after")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	var queryParts []string
+	if unread {
+		queryParts = append(queryParts, "is:unread")
+	}
+	if after != "" {
+		queryParts = append(queryParts, "after:"+after)
+	}
+	query := strings.Join(queryParts, " ")
+
+	refs, err := client.ListMessages(query, limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	if len(refs) == 0 {
+		if unread {
+			fmt.Println("No unread messages.")
+		} else {
+			fmt.Println("No messages found.")
+		}
+		return 0
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tFROM\tSUBJECT\tDATE")
+	for _, ref := range refs {
+		msg, err := client.GetMessage(ref.ID)
+		if err != nil {
+			continue
+		}
+		from := GetHeader(msg, "From")
+		subject := GetHeader(msg, "Subject")
+		date := GetHeader(msg, "Date")
+		if len(from) > 30 {
+			from = from[:27] + "..."
+		}
+		if len(subject) > 40 {
+			subject = subject[:37] + "..."
+		}
+		if len(date) > 20 {
+			date = date[:20]
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ref.ID, from, subject, date)
+	}
+	_ = w.Flush()
+	return 0
 }
 
 var readCmd = &cobra.Command{
@@ -117,171 +133,166 @@ var readCmd = &cobra.Command{
 	Short: "Read a specific email",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := requireLogin()
+		client, err := requireLoginFn()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-
-		msg, err := client.GetMessage(args[0])
-		if err != nil {
-			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
-				fmt.Fprintf(os.Stderr, "Message not found: %s\n", args[0])
-			} else {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			}
-			os.Exit(1)
-		}
-
-		fmt.Printf("From: %s\n", GetHeader(msg, "From"))
-		fmt.Printf("Subject: %s\n", GetHeader(msg, "Subject"))
-		fmt.Printf("Date: %s\n", GetHeader(msg, "Date"))
-		fmt.Println()
-		fmt.Println(GetBody(msg))
+		os.Exit(runRead(args[0], client))
 	},
+}
+
+func runRead(id string, client messageClient) int {
+	msg, err := client.GetMessage(id)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
+			fmt.Fprintf(os.Stderr, "Message not found: %s\n", id)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		return 1
+	}
+
+	fmt.Printf("From: %s\n", GetHeader(msg, "From"))
+	fmt.Printf("Subject: %s\n", GetHeader(msg, "Subject"))
+	fmt.Printf("Date: %s\n", GetHeader(msg, "Date"))
+	fmt.Println()
+	fmt.Println(GetBody(msg))
+	return 0
 }
 
 var bulkMarkReadCmd = &cobra.Command{
 	Use:   "bulk-mark-read --query <gmail-query>",
 	Short: "Mark all emails matching a query as read",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := requireLogin()
+		client, err := requireLoginFn()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-
 		query, _ := cmd.Flags().GetString("query")
-		fullQuery := "is:unread " + query
-
-		fmt.Printf("Searching for emails matching: %s\n", fullQuery)
-		ids, err := client.ListAllMessageIDs(fullQuery)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		if len(ids) == 0 {
-			fmt.Println("No matching unread messages found.")
-			return
-		}
-
-		fmt.Printf("Found %d messages. Marking as read...\n", len(ids))
-
-		// BatchModify supports up to 1000 IDs per call
-		batchSize := 1000
-		marked := 0
-		for i := 0; i < len(ids); i += batchSize {
-			end := i + batchSize
-			if end > len(ids) {
-				end = len(ids)
-			}
-			if err := client.BatchModify(ids[i:end], []string{"UNREAD"}); err != nil {
-				fmt.Fprintf(os.Stderr, "Error at batch %d-%d: %v\n", i, end, err)
-				os.Exit(1)
-			}
-			marked += end - i
-			fmt.Printf("  Progress: %d/%d\n", marked, len(ids))
-		}
-
-		fmt.Printf("Done. Marked %d message(s) as read.\n", len(ids))
+		os.Exit(runBulkMarkRead(query, client))
 	},
+}
+
+func runBulkMarkRead(query string, client messageClient) int {
+	fullQuery := "is:unread " + query
+	fmt.Printf("Searching for emails matching: %s\n", fullQuery)
+	ids, err := client.ListAllMessageIDs(fullQuery)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	if len(ids) == 0 {
+		fmt.Println("No matching unread messages found.")
+		return 0
+	}
+
+	fmt.Printf("Found %d messages. Marking as read...\n", len(ids))
+	batchSize := 1000
+	marked := 0
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if err := client.BatchModify(ids[i:end], []string{"UNREAD"}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error at batch %d-%d: %v\n", i, end, err)
+			return 1
+		}
+		marked += end - i
+		fmt.Printf("  Progress: %d/%d\n", marked, len(ids))
+	}
+	fmt.Printf("Done. Marked %d message(s) as read.\n", len(ids))
+	return 0
 }
 
 var summaryCmd = &cobra.Command{
 	Use:   "summary",
 	Short: "Summarize today's unread emails using AI",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := requireLogin()
+		client, err := requireLoginFn()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-
-		// Check claude is available
-		if _, err := exec.LookPath("claude"); err != nil {
-			fmt.Fprintln(os.Stderr, "Error: Claude Code CLI is required but not found on PATH. Install it from https://claude.ai/code")
-			os.Exit(1)
-		}
-
-		channel, _ := cmd.Flags().GetString("channel")
-		dm, _ := cmd.Flags().GetString("dm")
-		noMarkRead, _ := cmd.Flags().GetBool("no-mark-read")
-
-		// Default to dry run when no output target is specified
-		hasOutputTarget := channel != "" || dm != ""
-		if !hasOutputTarget && !cmd.Flags().Changed("no-mark-read") {
-			noMarkRead = true
-		}
-
-		// Fetch all unread email IDs
-		query := UnreadQuery()
-		fmt.Printf("Fetching unread emails (%s)...\n", query)
-		ids, err := client.ListAllMessageIDs(query)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching emails: %v\n", err)
-			os.Exit(1)
-		}
-
-		if len(ids) == 0 {
-			fmt.Println("No unread emails for today.")
-			return
-		}
-
-		fmt.Printf("Found %d unread email(s). Fetching content...\n", len(ids))
-
-		// Fetch email content concurrently
-		emails, err := FetchEmails(client, ids)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error fetching email content: %v\n", err)
-			os.Exit(1)
-		}
-
-		// Build prompt and invoke claude -p
-		prompt := BuildPrompt(emails)
-		fmt.Println("Generating summary with Claude...")
-		summary, err := RunClaude(prompt)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		// Print summary to stdout
-		fmt.Println()
-		fmt.Println(summary)
-
-		// Send to Slack if requested
-		slackTarget := channel
-		if dm != "" {
-			slackTarget = dm
-		}
-		if slackTarget != "" {
-			fmt.Printf("\nSending summary to Slack (%s)...\n", slackTarget)
-			if err := SendToSlack(summary, slackTarget); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
-				// Still mark as read per design decision
-			} else {
-				fmt.Println("Summary sent to Slack.")
-			}
-		}
-
-		// Mark emails as read unless --no-mark-read
-		if !noMarkRead {
-			fmt.Printf("Marking %d email(s) as read...\n", len(ids))
-			batchSize := 1000
-			for i := 0; i < len(ids); i += batchSize {
-				end := i + batchSize
-				if end > len(ids) {
-					end = len(ids)
-				}
-				if err := client.BatchModify(ids[i:end], []string{"UNREAD"}); err != nil {
-					fmt.Fprintf(os.Stderr, "Error marking emails as read: %v\n", err)
-					os.Exit(1)
-				}
-			}
-			fmt.Println("Done.")
-		}
+		os.Exit(runSummary(cmd, client))
 	},
+}
+
+func runSummary(cmd *cobra.Command, client *Client) int {
+	if _, err := lookPathFn("claude"); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: Claude Code CLI is required but not found on PATH. Install it from https://claude.ai/code")
+		return 1
+	}
+
+	channel, _ := cmd.Flags().GetString("channel")
+	dm, _ := cmd.Flags().GetString("dm")
+	noMarkRead, _ := cmd.Flags().GetBool("no-mark-read")
+	hasOutputTarget := channel != "" || dm != ""
+	if !hasOutputTarget && !cmd.Flags().Changed("no-mark-read") {
+		noMarkRead = true
+	}
+
+	query := UnreadQuery()
+	fmt.Printf("Fetching unread emails (%s)...\n", query)
+	ids, err := client.ListAllMessageIDs(query)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching emails: %v\n", err)
+		return 1
+	}
+	if len(ids) == 0 {
+		fmt.Println("No unread emails for today.")
+		return 0
+	}
+
+	fmt.Printf("Found %d unread email(s). Fetching content...\n", len(ids))
+	emails, err := fetchEmailsFn(client, ids)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching email content: %v\n", err)
+		return 1
+	}
+
+	prompt := BuildPrompt(emails)
+	fmt.Println("Generating summary with Claude...")
+	summary, err := runClaudeFn(prompt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	fmt.Println()
+	fmt.Println(summary)
+
+	slackTarget := channel
+	if dm != "" {
+		slackTarget = dm
+	}
+	if slackTarget != "" {
+		fmt.Printf("\nSending summary to Slack (%s)...\n", slackTarget)
+		if err := sendToSlackFn(summary, slackTarget); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		} else {
+			fmt.Println("Summary sent to Slack.")
+		}
+	}
+
+	if !noMarkRead {
+		fmt.Printf("Marking %d email(s) as read...\n", len(ids))
+		batchSize := 1000
+		for i := 0; i < len(ids); i += batchSize {
+			end := i + batchSize
+			if end > len(ids) {
+				end = len(ids)
+			}
+			if err := client.BatchModify(ids[i:end], []string{"UNREAD"}); err != nil {
+				fmt.Fprintf(os.Stderr, "Error marking emails as read: %v\n", err)
+				return 1
+			}
+		}
+		fmt.Println("Done.")
+	}
+	return 0
 }
 
 var markReadCmd = &cobra.Command{
@@ -289,17 +300,20 @@ var markReadCmd = &cobra.Command{
 	Short: "Mark one or more emails as read",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := requireLogin()
+		client, err := requireLoginFn()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-
-		if err := client.BatchModify(args, []string{"UNREAD"}); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		fmt.Printf("Marked %d message(s) as read.\n", len(args))
+		os.Exit(runMarkRead(args, client))
 	},
+}
+
+func runMarkRead(ids []string, client messageClient) int {
+	if err := client.BatchModify(ids, []string{"UNREAD"}); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Marked %d message(s) as read.\n", len(ids))
+	return 0
 }

--- a/internal/gmail/commands_more_test.go
+++ b/internal/gmail/commands_more_test.go
@@ -1,0 +1,291 @@
+package gmail
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/siyuqian/devpilot/internal/auth"
+	"github.com/spf13/cobra"
+)
+
+type fakeMessageClient struct {
+	refs       []MessageRef
+	ids        []string
+	messages   map[string]*Message
+	err        error
+	batchErr   error
+	batchCalls int
+}
+
+func (c *fakeMessageClient) ListMessages(query string, limit int) ([]MessageRef, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.refs, nil
+}
+
+func (c *fakeMessageClient) ListAllMessageIDs(query string) ([]string, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.ids, nil
+}
+
+func (c *fakeMessageClient) GetMessage(id string) (*Message, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	msg := c.messages[id]
+	if msg == nil {
+		return nil, errors.New("404 Not Found")
+	}
+	return msg, nil
+}
+
+func (c *fakeMessageClient) BatchModify(ids []string, removeLabelIDs []string) error {
+	c.batchCalls++
+	return c.batchErr
+}
+
+func TestGmailCommandHelpers(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	RegisterCommands(root)
+	if cmd, _, err := root.Find([]string{"gmail", "list"}); err != nil || cmd.Name() != "list" {
+		t.Fatalf("registered gmail list missing: cmd=%v err=%v", cmd, err)
+	}
+
+	msg := &Message{Payload: Payload{
+		Headers: []Header{
+			{Name: "From", Value: strings.Repeat("a", 35)},
+			{Name: "Subject", Value: strings.Repeat("b", 45)},
+			{Name: "Date", Value: "Mon, 01 Jun 2026 12:34:56 +0000"},
+		},
+		Body: Body{Data: "SGVsbG8="},
+	}}
+	client := &fakeMessageClient{
+		refs:     []MessageRef{{ID: "m1"}, {ID: "missing"}},
+		ids:      []string{"m1", "m2", "m3"},
+		messages: map[string]*Message{"m1": msg},
+	}
+
+	list := &cobra.Command{}
+	list.Flags().Bool("unread", true, "")
+	list.Flags().String("after", "2026-06-01", "")
+	list.Flags().Int("limit", 10, "")
+	out := captureGmailStdout(t, func() {
+		if code := runList(list, client); code != 0 {
+			t.Fatalf("runList code = %d", code)
+		}
+	})
+	for _, want := range []string{"ID", "m1", "aaa...", "bbb..."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("runList output missing %q:\n%s", want, out)
+		}
+	}
+
+	out = captureGmailStdout(t, func() {
+		if code := runRead("m1", client); code != 0 {
+			t.Fatalf("runRead code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "Hello") {
+		t.Errorf("runRead output = %s", out)
+	}
+
+	out = captureGmailStdout(t, func() {
+		if code := runBulkMarkRead("from:a", client); code != 0 {
+			t.Fatalf("runBulkMarkRead code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "Marked 3 message") || client.batchCalls != 1 {
+		t.Errorf("bulk output=%s batchCalls=%d", out, client.batchCalls)
+	}
+
+	out = captureGmailStdout(t, func() {
+		if code := runMarkRead([]string{"m1", "m2"}, client); code != 0 {
+			t.Fatalf("runMarkRead code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "Marked 2 message") {
+		t.Errorf("mark output=%s", out)
+	}
+}
+
+func TestGmailCommandHelperErrorsAndEmpty(t *testing.T) {
+	dir := t.TempDir()
+	restore := auth.OverrideConfigDir(dir)
+	defer restore()
+	if _, err := requireLogin(); err == nil {
+		t.Fatalf("requireLogin succeeded without token")
+	}
+
+	errClient := &fakeMessageClient{err: errors.New("boom")}
+	list := &cobra.Command{}
+	list.Flags().Bool("unread", false, "")
+	list.Flags().String("after", "", "")
+	list.Flags().Int("limit", 0, "")
+	if code := runList(list, errClient); code == 0 {
+		t.Fatalf("runList error code = 0")
+	}
+	if code := runRead("missing", errClient); code == 0 {
+		t.Fatalf("runRead error code = 0")
+	}
+	if code := runBulkMarkRead("q", errClient); code == 0 {
+		t.Fatalf("runBulkMarkRead error code = 0")
+	}
+	if code := runMarkRead([]string{"m"}, &fakeMessageClient{batchErr: errors.New("bad")}); code == 0 {
+		t.Fatalf("runMarkRead error code = 0")
+	}
+
+	emptyClient := &fakeMessageClient{}
+	out := captureGmailStdout(t, func() {
+		if code := runList(list, emptyClient); code != 0 {
+			t.Fatalf("runList empty code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "No messages found") {
+		t.Errorf("empty list output=%s", out)
+	}
+	out = captureGmailStdout(t, func() {
+		if code := runBulkMarkRead("q", emptyClient); code != 0 {
+			t.Fatalf("runBulkMarkRead empty code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "No matching unread") {
+		t.Errorf("empty bulk output=%s", out)
+	}
+}
+
+func TestRunSummary(t *testing.T) {
+	oldLookPath, oldRunClaude, oldSendToSlack := lookPathFn, runClaudeFn, sendToSlackFn
+	defer func() {
+		lookPathFn = oldLookPath
+		runClaudeFn = oldRunClaude
+		sendToSlackFn = oldSendToSlack
+	}()
+	lookPathFn = func(string) (string, error) { return "/bin/claude", nil }
+	runClaudeFn = func(string) (string, error) { return "summary", nil }
+	var sentTarget string
+	sendToSlackFn = func(summary, target string) error {
+		sentTarget = target
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages":
+			_, _ = w.Write([]byte(`{"messages":[{"id":"m1"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages/m1":
+			_, _ = w.Write([]byte(`{"id":"m1","payload":{"headers":[{"name":"Subject","value":"Hi"}],"body":{"data":"SGVsbG8="}}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/gmail/v1/users/me/messages/batchModify":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("token", WithBaseURL(server.URL))
+	cmd := &cobra.Command{}
+	cmd.Flags().String("channel", "daily", "")
+	cmd.Flags().String("dm", "", "")
+	cmd.Flags().Bool("no-mark-read", false, "")
+	out := captureGmailStdout(t, func() {
+		if code := runSummary(cmd, client); code != 0 {
+			t.Fatalf("runSummary code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "summary") || sentTarget != "daily" {
+		t.Fatalf("summary output=%s sentTarget=%q", out, sentTarget)
+	}
+
+	lookPathFn = func(string) (string, error) { return "", errors.New("missing") }
+	if code := runSummary(cmd, client); code == 0 {
+		t.Fatalf("runSummary missing claude code = 0")
+	}
+}
+
+func TestRunSummaryBranches(t *testing.T) {
+	oldLookPath, oldRunClaude, oldSendToSlack, oldFetchEmails := lookPathFn, runClaudeFn, sendToSlackFn, fetchEmailsFn
+	defer func() {
+		lookPathFn = oldLookPath
+		runClaudeFn = oldRunClaude
+		sendToSlackFn = oldSendToSlack
+		fetchEmailsFn = oldFetchEmails
+	}()
+	lookPathFn = func(string) (string, error) { return "/bin/claude", nil }
+	runClaudeFn = func(string) (string, error) { return "summary", nil }
+	sendToSlackFn = func(summary, target string) error { return errors.New("slack down") }
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages":
+			_, _ = w.Write([]byte(`{"messages":[]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/gmail/v1/users/me/messages/batchModify":
+			http.Error(w, "bad", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("channel", "", "")
+	cmd.Flags().String("dm", "", "")
+	cmd.Flags().Bool("no-mark-read", false, "")
+	client := NewClient("token", WithBaseURL(server.URL))
+	if code := runSummary(cmd, client); code != 0 {
+		t.Fatalf("runSummary empty code = %d", code)
+	}
+
+	fetchEmailsFn = func(*Client, []string) ([]EmailSummary, error) {
+		return []EmailSummary{{ID: "m1", Subject: "s", Body: "b"}}, nil
+	}
+	fullServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages":
+			_, _ = w.Write([]byte(`{"messages":[{"id":"m1"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/gmail/v1/users/me/messages/batchModify":
+			http.Error(w, "bad", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer fullServer.Close()
+	cmd.Flags().Set("channel", "daily") //nolint:errcheck
+	if code := runSummary(cmd, NewClient("token", WithBaseURL(fullServer.URL))); code == 0 {
+		t.Fatalf("runSummary batch error code = 0")
+	}
+
+	runClaudeFn = func(string) (string, error) { return "", errors.New("claude failed") }
+	cmd.Flags().Set("no-mark-read", "true") //nolint:errcheck
+	if code := runSummary(cmd, NewClient("token", WithBaseURL(fullServer.URL))); code == 0 {
+		t.Fatalf("runSummary claude error code = 0")
+	}
+}
+
+func captureGmailStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return buf.String()
+}

--- a/internal/gmail/service_more_test.go
+++ b/internal/gmail/service_more_test.go
@@ -1,0 +1,75 @@
+package gmail
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/siyuqian/devpilot/internal/auth"
+)
+
+func TestServiceStateAndOAuthConfig(t *testing.T) {
+	dir := t.TempDir()
+	restore := auth.OverrideConfigDir(dir)
+	defer restore()
+
+	svc := NewService()
+	if svc.Name() != "gmail" {
+		t.Fatalf("Name() = %q, want gmail", svc.Name())
+	}
+	if svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = true before credentials")
+	}
+	if err := auth.Save("gmail", auth.ServiceCredentials{
+		"client_id":     "id",
+		"client_secret": "secret",
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = false after credentials")
+	}
+	cfg := svc.oauthConfig()
+	if cfg.ClientID != "id" || cfg.ClientSecret != "secret" || cfg.AuthURL == "" || cfg.TokenURL == "" {
+		t.Fatalf("oauthConfig() = %#v", cfg)
+	}
+	if len(cfg.Scopes) != 1 || cfg.Scopes[0] != gmailScope {
+		t.Fatalf("scopes = %v", cfg.Scopes)
+	}
+	if err := svc.Logout(); err != nil {
+		t.Fatalf("Logout() error = %v", err)
+	}
+	if svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = true after logout")
+	}
+}
+
+func TestServiceLoginRejectsEmptyInput(t *testing.T) {
+	old := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("\n\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+
+	if err := NewService().Login(); err == nil {
+		t.Fatalf("Login() succeeded with empty input")
+	}
+}
+
+func TestNewClientFromTokenAndOptions(t *testing.T) {
+	token := &auth.OAuthToken{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		Expiry:       time.Now().Add(time.Hour),
+	}
+	client := NewClientFromToken(token, WithBaseURL("https://example.com"))
+	if client.accessToken != "access" || client.refreshToken != "refresh" || client.baseURL != "https://example.com" {
+		t.Fatalf("client not initialized from token: %#v", client)
+	}
+}

--- a/internal/gmail/summary_test.go
+++ b/internal/gmail/summary_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -105,6 +107,62 @@ func TestUnreadQuery(t *testing.T) {
 	expected := "is:unread"
 	if query != expected {
 		t.Errorf("UnreadQuery() = %q, want %q", query, expected)
+	}
+}
+
+func TestRunClaude(t *testing.T) {
+	bin := t.TempDir()
+	claude := filepath.Join(bin, "claude")
+	if err := os.WriteFile(claude, []byte("#!/bin/sh\necho digest\n"), 0o755); err != nil {
+		t.Fatalf("write claude: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := RunClaude("prompt")
+	if err != nil {
+		t.Fatalf("RunClaude error: %v", err)
+	}
+	if out != "digest" {
+		t.Fatalf("out = %q", out)
+	}
+}
+
+func TestRunClaudeEmptyOutput(t *testing.T) {
+	bin := t.TempDir()
+	claude := filepath.Join(bin, "claude")
+	if err := os.WriteFile(claude, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write claude: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err := RunClaude("prompt"); err == nil {
+		t.Fatal("expected empty output error")
+	}
+}
+
+func TestSendToSlack(t *testing.T) {
+	bin := t.TempDir()
+	devpilot := filepath.Join(bin, "devpilot")
+	if err := os.WriteFile(devpilot, []byte("#!/bin/sh\n[ \"$1\" = slack ] && [ \"$2\" = send ]\n"), 0o755); err != nil {
+		t.Fatalf("write devpilot: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := SendToSlack("digest", "daily"); err != nil {
+		t.Fatalf("SendToSlack error: %v", err)
+	}
+}
+
+func TestSendToSlackError(t *testing.T) {
+	bin := t.TempDir()
+	devpilot := filepath.Join(bin, "devpilot")
+	if err := os.WriteFile(devpilot, []byte("#!/bin/sh\necho nope\nexit 2\n"), 0o755); err != nil {
+		t.Fatalf("write devpilot: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := SendToSlack("digest", "daily"); err == nil {
+		t.Fatal("expected slack error")
 	}
 }
 

--- a/internal/graph/cache/paths_more_test.go
+++ b/internal/graph/cache/paths_more_test.go
@@ -1,0 +1,10 @@
+package cache
+
+import "testing"
+
+func TestHomeUsesEnvironment(t *testing.T) {
+	t.Setenv("DEVPILOT_HOME", "/tmp/devpilot-home")
+	if got := Home(); got != "/tmp/devpilot-home" {
+		t.Fatalf("Home() = %q", got)
+	}
+}

--- a/internal/graph/cache/walk_more_test.go
+++ b/internal/graph/cache/walk_more_test.go
@@ -1,0 +1,12 @@
+package cache
+
+import "testing"
+
+func TestIsHidden(t *testing.T) {
+	if !IsHidden(".git") || !IsHidden(".devpilot") {
+		t.Fatalf("expected hidden paths")
+	}
+	if IsHidden("src") {
+		t.Fatalf("src should not be hidden")
+	}
+}

--- a/internal/graph/cli_more_test.go
+++ b/internal/graph/cli_more_test.go
@@ -1,0 +1,159 @@
+package graph
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siyuqian/devpilot/internal/graph/cache"
+)
+
+func TestGraphCommandConstructors(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	RegisterCommands(root)
+	graphCmd, _, err := root.Find([]string{"graph"})
+	if err != nil {
+		t.Fatalf("Find(graph) error = %v", err)
+	}
+	if graphCmd == nil || graphCmd.Name() != "graph" {
+		t.Fatalf("graph command missing")
+	}
+	for _, name := range []string{"build", "status", "clean", "query", "impact", "hubs", "context", "detect-changes", "preflight"} {
+		cmd, _, err := graphCmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("Find(%s) error = %v", name, err)
+		}
+		if cmd == nil || cmd.Name() != name {
+			t.Fatalf("command %q missing", name)
+		}
+	}
+}
+
+func TestGraphRunDiffCommandsSuccess(t *testing.T) {
+	repo := seedQueryStore(t)
+	graphTestGit(t, repo, "init")
+	graphTestGit(t, repo, "config", "user.email", "devpilot@example.com")
+	graphTestGit(t, repo, "config", "user.name", "DevPilot")
+	graphTestGit(t, repo, "add", "src.go")
+	graphTestGit(t, repo, "commit", "-m", "base")
+	base := strings.TrimSpace(string(graphTestGit(t, repo, "rev-parse", "HEAD")))
+	if err := os.WriteFile(filepath.Join(repo, "src.go"), []byte("package p\nfunc Target() {\n\tprintln(\"changed\")\n}\nfunc Caller() {\n\tTarget()\n}\n"), 0o644); err != nil {
+		t.Fatalf("write changed source: %v", err)
+	}
+	graphTestGit(t, repo, "add", "src.go")
+	graphTestGit(t, repo, "commit", "-m", "head")
+	head := strings.TrimSpace(string(graphTestGit(t, repo, "rev-parse", "HEAD")))
+
+	cases := []struct {
+		name string
+		run  func() int
+		want string
+	}{
+		{name: "detect changes", run: func() int { return runDetectChanges(repo, base, head) }, want: "graph.detect-changes"},
+		{name: "preflight", run: func() int { return runPreflight(repo, base, head) }, want: "graph.preflight"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rc int
+			out := captureStdout(t, func() {
+				rc = tc.run()
+			})
+			if rc != 0 {
+				t.Fatalf("rc=%d output=%s", rc, out)
+			}
+			var env map[string]any
+			if err := json.Unmarshal(out, &env); err != nil {
+				t.Fatalf("json decode: %v\n%s", err, out)
+			}
+			if env["command"] != tc.want || env["ok"] != true {
+				t.Fatalf("unexpected envelope: %v", env)
+			}
+		})
+	}
+}
+
+func graphTestGit(t *testing.T, dir string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return out
+}
+
+func TestGraphRunCommandsSuccess(t *testing.T) {
+	repo := seedQueryStore(t)
+	home := cache.Home()
+	key := cache.RepoKey(repo)
+	if err := cache.WriteMeta(cache.MetaFile(home, key), cache.Meta{
+		SchemaVersion: cache.CurrentSchemaVersion,
+		HeadSHA:       "abc123",
+		Languages:     []string{"go"},
+		BuiltAtUnix:   1780300000,
+	}); err != nil {
+		t.Fatalf("WriteMeta: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		run  func() int
+		want string
+	}{
+		{name: "status", run: func() int { return runStatus(repo) }, want: "graph.status"},
+		{name: "context", run: func() int { return runContext(repo, "target", 1) }, want: "graph.context"},
+		{name: "hubs", run: func() int { return runHubs(repo, 2) }, want: "graph.hubs"},
+		{name: "impact", run: func() int { return runImpact(repo, "src.go", 1) }, want: "graph.impact"},
+		{name: "clean repo", run: func() int { return runClean(repo, false) }, want: "graph.clean"},
+		{name: "clean all", run: func() int { return runClean("", true) }, want: "graph.clean"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rc int
+			out := captureStdout(t, func() {
+				rc = tc.run()
+			})
+			if rc != 0 {
+				t.Fatalf("rc=%d output=%s", rc, out)
+			}
+			var env map[string]any
+			if err := json.Unmarshal(out, &env); err != nil {
+				t.Fatalf("json decode: %v\n%s", err, out)
+			}
+			if env["command"] != tc.want || env["ok"] != true {
+				t.Fatalf("unexpected envelope: %v", env)
+			}
+		})
+	}
+}
+
+func TestGraphRunCommandsValidateArgs(t *testing.T) {
+	badRepo := "/path/that/does/not/exist"
+	cases := []struct {
+		name string
+		code int
+	}{
+		{name: "clean requires args", code: runClean("", false)},
+		{name: "clean invalid repo", code: runClean(badRepo, false)},
+		{name: "status invalid repo", code: runStatus(badRepo)},
+		{name: "context invalid repo", code: runContext(badRepo, "", 0)},
+		{name: "hubs invalid repo", code: runHubs(badRepo, 0)},
+		{name: "impact invalid repo", code: runImpact(badRepo, "", 0)},
+		{name: "preflight invalid repo", code: runPreflight(badRepo, "", "")},
+		{name: "detect changes invalid repo", code: runDetectChanges(badRepo, "", "")},
+		{name: "query invalid repo", code: runQuery(queryOpts{repo: badRepo}, "unknown", "")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.code == 0 {
+				t.Fatalf("exit code = 0, want failure")
+			}
+		})
+	}
+}

--- a/internal/graph/parser/registry_more_test.go
+++ b/internal/graph/parser/registry_more_test.go
@@ -1,0 +1,22 @@
+package parser
+
+import "testing"
+
+func TestRegistryForLanguage(t *testing.T) {
+	r := DefaultRegistry()
+	if p := r.ForLanguage("go"); p == nil || p.Language() != "go" {
+		t.Fatalf("ForLanguage(go) = %v", p)
+	}
+	if p := r.ForLanguage("missing"); p != nil {
+		t.Fatalf("ForLanguage(missing) = %v", p)
+	}
+}
+
+func TestRelFromPrefix(t *testing.T) {
+	if got := relFromPrefix("/repo/pkg/a.go", "/repo"); got != "/pkg/a.go" {
+		t.Fatalf("relFromPrefix = %q", got)
+	}
+	if got := relFromPrefix("pkg/a.go", "/repo"); got != "pkg/a.go" {
+		t.Fatalf("relFromPrefix relative = %q", got)
+	}
+}

--- a/internal/graph/store/store_test.go
+++ b/internal/graph/store/store_test.go
@@ -252,6 +252,46 @@ func mustInsertNodes(t *testing.T, s *Store, n []Node) {
 	}
 }
 
+func TestCountsHubsAndDeleteByLanguage(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "graph.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+
+	mustInsertNodes(t, s, []Node{
+		{ID: "go_a", Kind: "function", Path: "a.go", Name: "A", Language: "go"},
+		{ID: "go_b", Kind: "function", Path: "b.go", Name: "B", Language: "go"},
+		{ID: "ts_a", Kind: "function", Path: "a.ts", Name: "A", Language: "typescript"},
+	})
+	if err := s.InsertEdges([]Edge{
+		{Src: "go_a", Dst: "go_b", Kind: "calls"},
+		{Src: "ts_a", Dst: "go_b", Kind: "calls"},
+	}); err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+	if got, err := s.CountNodes(); err != nil || got != 3 {
+		t.Fatalf("CountNodes = %d, %v; want 3, nil", got, err)
+	}
+	if got, err := s.CountEdges(); err != nil || got != 2 {
+		t.Fatalf("CountEdges = %d, %v; want 2, nil", got, err)
+	}
+	hubs, err := s.HubsByCalls(2)
+	if err != nil {
+		t.Fatalf("HubsByCalls: %v", err)
+	}
+	if len(hubs) != 1 || hubs[0].ID != "go_b" || hubs[0].Count != 2 {
+		t.Fatalf("hubs = %#v", hubs)
+	}
+	nodes, edges, err := s.DeleteByLanguage("typescript")
+	if err != nil {
+		t.Fatalf("DeleteByLanguage: %v", err)
+	}
+	if nodes != 1 || edges != 1 {
+		t.Fatalf("deleted nodes=%d edges=%d, want 1/1", nodes, edges)
+	}
+}
+
 func mustInsertEdges(t *testing.T, s *Store, e []Edge) {
 	t.Helper()
 	if err := s.InsertEdges(e); err != nil {

--- a/internal/initcmd/commands.go
+++ b/internal/initcmd/commands.go
@@ -27,86 +27,85 @@ var initCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "Failed to get working directory:", err)
 			os.Exit(1)
 		}
-
-		status := Detect(dir)
-
-		fmt.Println("Scanning project...")
-		for _, line := range formatStatus(status) {
-			fmt.Println(line)
-		}
-
-		if allConfigured(status) {
-			fmt.Println("\nProject already initialized!")
-			return
-		}
-
 		yes, _ := cmd.Flags().GetBool("yes")
-		opts := GenerateOpts{
-			Dir:         dir,
-			Interactive: !yes,
-		}
-		if opts.Interactive {
-			opts.Reader = bufio.NewReader(os.Stdin)
-		}
-
-		fmt.Println()
-
-		// Task source selection + board/label configuration.
-		// If source is already set to "github" in config, nothing more to set up.
-		// If source is "trello" (or unset) and no board is configured yet, proceed.
-		if status.Source == "github" {
-			// Already configured as GitHub Issues — labels may already exist; skip.
-		} else if !status.HasBoardConfig && shouldGenerate(opts, "Configure task source? [Y/n]: ") {
-			// Determine source: respect explicit config value; ask only when truly unset.
-			sourceName := status.Source // "trello" or ""
-			if sourceName == "" && opts.Interactive {
-				fmt.Print("  Task source (trello/github) [trello]: ")
-				line, err := opts.Reader.ReadString('\n')
-				if err == nil {
-					if input := strings.TrimSpace(strings.ToLower(line)); input == "github" {
-						sourceName = "github"
-					}
-				}
-			}
-
-			if sourceName == "github" {
-				if err := ConfigureGitHubSource(opts); err != nil {
-					fmt.Fprintf(os.Stderr, "  Error configuring GitHub source: %v\n", err)
-				}
-			} else {
-				var listBoardsFn func() ([]Board, error)
-				if status.HasTrelloCreds {
-					creds, _ := auth.Load("trello") // Ignore error; missing credentials detected as nil below
-					client := trello.NewClient(creds["api_key"], creds["token"])
-					listBoardsFn = func() ([]Board, error) {
-						boards, err := client.GetBoards()
-						if err != nil {
-							return nil, err
-						}
-						result := make([]Board, len(boards))
-						for i, b := range boards {
-							result[i] = Board{Name: b.Name}
-						}
-						return result, nil
-					}
-				}
-				if err := ConfigureBoard(opts, listBoardsFn); err != nil {
-					fmt.Fprintf(os.Stderr, "  Error configuring board: %v\n", err)
-				}
-			}
-		}
-
-		// Gitignore
-		if status.IsGitRepo {
-			if err := EnsureGitignore(dir, []string{".devpilot/logs/"}); err != nil {
-				fmt.Fprintf(os.Stderr, "  Error updating .gitignore: %v\n", err)
-			}
-		}
-
-		fmt.Println("\nDone!")
-		fmt.Println("\nTo install Claude Code skills, run:")
-		fmt.Println("  npx skills add siyuqian/devpilot")
+		os.Exit(runInit(dir, yes, bufio.NewReader(os.Stdin)))
 	},
+}
+
+func runInit(dir string, yes bool, reader *bufio.Reader) int {
+	status := Detect(dir)
+
+	fmt.Println("Scanning project...")
+	for _, line := range formatStatus(status) {
+		fmt.Println(line)
+	}
+
+	if allConfigured(status) {
+		fmt.Println("\nProject already initialized!")
+		return 0
+	}
+
+	opts := GenerateOpts{
+		Dir:         dir,
+		Interactive: !yes,
+	}
+	if opts.Interactive {
+		opts.Reader = reader
+	}
+
+	fmt.Println()
+
+	if status.Source == "github" {
+		// Already configured as GitHub Issues — labels may already exist; skip.
+	} else if !status.HasBoardConfig && shouldGenerate(opts, "Configure task source? [Y/n]: ") {
+		sourceName := status.Source // "trello" or ""
+		if sourceName == "" && opts.Interactive {
+			fmt.Print("  Task source (trello/github) [trello]: ")
+			line, err := opts.Reader.ReadString('\n')
+			if err == nil {
+				if input := strings.TrimSpace(strings.ToLower(line)); input == "github" {
+					sourceName = "github"
+				}
+			}
+		}
+
+		if sourceName == "github" {
+			if err := ConfigureGitHubSource(opts); err != nil {
+				fmt.Fprintf(os.Stderr, "  Error configuring GitHub source: %v\n", err)
+			}
+		} else {
+			var listBoardsFn func() ([]Board, error)
+			if status.HasTrelloCreds {
+				creds, _ := auth.Load("trello") // Ignore error; missing credentials detected as nil below
+				client := trello.NewClient(creds["api_key"], creds["token"])
+				listBoardsFn = func() ([]Board, error) {
+					boards, err := client.GetBoards()
+					if err != nil {
+						return nil, err
+					}
+					result := make([]Board, len(boards))
+					for i, b := range boards {
+						result[i] = Board{Name: b.Name}
+					}
+					return result, nil
+				}
+			}
+			if err := ConfigureBoard(opts, listBoardsFn); err != nil {
+				fmt.Fprintf(os.Stderr, "  Error configuring board: %v\n", err)
+			}
+		}
+	}
+
+	if status.IsGitRepo {
+		if err := EnsureGitignore(dir, []string{".devpilot/logs/"}); err != nil {
+			fmt.Fprintf(os.Stderr, "  Error updating .gitignore: %v\n", err)
+		}
+	}
+
+	fmt.Println("\nDone!")
+	fmt.Println("\nTo install Claude Code skills, run:")
+	fmt.Println("  npx skills add siyuqian/devpilot")
+	return 0
 }
 
 func formatStatus(s *Status) []string {

--- a/internal/initcmd/generate_more_test.go
+++ b/internal/initcmd/generate_more_test.go
@@ -1,0 +1,48 @@
+package initcmd
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/siyuqian/devpilot/internal/project"
+)
+
+func TestConfigureGitHubSource(t *testing.T) {
+	dir := t.TempDir()
+	bin := t.TempDir()
+	logPath := filepath.Join(dir, "gh.log")
+	gh := filepath.Join(bin, "gh")
+	script := "#!/bin/sh\necho \"$@\" >> " + logPath + "\nexit 0\n"
+	if err := os.WriteFile(gh, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gh: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := ConfigureGitHubSource(GenerateOpts{Dir: dir}); err != nil {
+		t.Fatalf("ConfigureGitHubSource() error = %v", err)
+	}
+	cfg, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("Load config: %v", err)
+	}
+	if cfg.Source != "github" {
+		t.Fatalf("Source = %q, want github", cfg.Source)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read gh log: %v", err)
+	}
+	if got := string(data); got == "" {
+		t.Fatalf("gh log is empty")
+	}
+}
+
+func TestRunInitNonInteractive(t *testing.T) {
+	dir := t.TempDir()
+	if code := runInit(dir, true, bufio.NewReader(strings.NewReader(""))); code != 0 {
+		t.Fatalf("runInit code = %d", code)
+	}
+}

--- a/internal/project/config_more_test.go
+++ b/internal/project/config_more_test.go
@@ -1,0 +1,16 @@
+package project
+
+import "testing"
+
+func TestResolveSource(t *testing.T) {
+	cfg := &Config{Source: "github"}
+	if got := cfg.ResolveSource(""); got != "github" {
+		t.Fatalf("ResolveSource empty = %q, want github", got)
+	}
+	if got := cfg.ResolveSource("trello"); got != "trello" {
+		t.Fatalf("ResolveSource override = %q, want trello", got)
+	}
+	if got := (&Config{}).ResolveSource(""); got != "trello" {
+		t.Fatalf("ResolveSource default = %q, want trello", got)
+	}
+}

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -2,8 +2,10 @@ package slack
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/siyuqian/devpilot/internal/auth"
@@ -155,6 +157,60 @@ func TestResolveChannelNotFound(t *testing.T) {
 	}
 }
 
+func TestOpenConversation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/conversations.open" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if r.PostForm.Get("users") != "U001" {
+			t.Fatalf("users = %q", r.PostForm.Get("users"))
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D001"}}`))
+	}))
+	defer srv.Close()
+
+	id, err := NewClient("test-token", WithBaseURL(srv.URL)).OpenConversation("U001")
+	if err != nil {
+		t.Fatalf("OpenConversation error: %v", err)
+	}
+	if id != "D001" {
+		t.Fatalf("id = %q", id)
+	}
+}
+
+func TestOpenConversationError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":false,"error":"user_not_found"}`))
+	}))
+	defer srv.Close()
+
+	_, err := NewClient("test-token", WithBaseURL(srv.URL)).OpenConversation("U404")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSlackWithHTTPClient(t *testing.T) {
+	transport := slackRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host != "slack.test" {
+			t.Fatalf("unexpected host: %s", r.URL.Host)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true,"channels":[]}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	client := NewClient("test-token", WithBaseURL("https://slack.test"), WithHTTPClient(&http.Client{Transport: transport}))
+
+	if _, err := client.ListConversations(); err != nil {
+		t.Fatalf("ListConversations error: %v", err)
+	}
+}
+
 func TestPostMessage(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/chat.postMessage" {
@@ -190,6 +246,12 @@ func TestPostMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostMessage error: %v", err)
 	}
+}
+
+type slackRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f slackRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }
 
 func TestPostMessageNotInChannel(t *testing.T) {

--- a/internal/slack/commands.go
+++ b/internal/slack/commands.go
@@ -9,6 +9,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type slackClient interface {
+	OpenConversation(userID string) (string, error)
+	ResolveChannel(name string) (string, error)
+	PostMessage(channelID, text string) error
+}
+
+var requireSlackLoginFn = requireSlackLogin
+
 // RegisterCommands adds the "slack" command group to the given parent command.
 func RegisterCommands(parent *cobra.Command) {
 	slackCmd := &cobra.Command{
@@ -37,54 +45,56 @@ var sendCmd = &cobra.Command{
 	Use:   "send",
 	Short: "Send a message to a Slack channel",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := requireSlackLogin()
+		client, err := requireSlackLoginFn()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-
-		channel, _ := cmd.Flags().GetString("channel")
-		message, _ := cmd.Flags().GetString("message")
-
-		if message == "" {
-			data, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error reading stdin: %v\n", err)
-				os.Exit(1)
-			}
-			message = strings.TrimSpace(string(data))
-		}
-
-		if message == "" {
-			fmt.Fprintln(os.Stderr, "Error: message is required (use --message or pipe via stdin)")
-			os.Exit(1)
-		}
-
-		var channelID, label string
-		if strings.HasPrefix(channel, "U") && !strings.Contains(channel, " ") {
-			dmID, err := client.OpenConversation(channel)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-			channelID = dmID
-			label = "as DM"
-		} else {
-			channelName := strings.TrimPrefix(channel, "#")
-			id, err := client.ResolveChannel(channelName)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-			channelID = id
-			label = "to #" + channelName
-		}
-
-		if err := client.PostMessage(channelID, message); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		fmt.Printf("Message sent %s.\n", label)
+		os.Exit(runSend(cmd, client, os.Stdin))
 	},
+}
+
+func runSend(cmd *cobra.Command, client slackClient, in io.Reader) int {
+	channel, _ := cmd.Flags().GetString("channel")
+	message, _ := cmd.Flags().GetString("message")
+
+	if message == "" {
+		data, err := io.ReadAll(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading stdin: %v\n", err)
+			return 1
+		}
+		message = strings.TrimSpace(string(data))
+	}
+	if message == "" {
+		fmt.Fprintln(os.Stderr, "Error: message is required (use --message or pipe via stdin)")
+		return 1
+	}
+
+	var channelID, label string
+	if strings.HasPrefix(channel, "U") && !strings.Contains(channel, " ") {
+		dmID, err := client.OpenConversation(channel)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		channelID = dmID
+		label = "as DM"
+	} else {
+		channelName := strings.TrimPrefix(channel, "#")
+		id, err := client.ResolveChannel(channelName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		channelID = id
+		label = "to #" + channelName
+	}
+
+	if err := client.PostMessage(channelID, message); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Message sent %s.\n", label)
+	return 0
 }

--- a/internal/slack/commands_more_test.go
+++ b/internal/slack/commands_more_test.go
@@ -1,0 +1,119 @@
+package slack
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type fakeSlackClient struct {
+	openID     string
+	resolveID  string
+	postErr    error
+	resolveErr error
+	openErr    error
+	postedTo   string
+	postedText string
+}
+
+func (c *fakeSlackClient) OpenConversation(userID string) (string, error) {
+	return c.openID, c.openErr
+}
+
+func (c *fakeSlackClient) ResolveChannel(name string) (string, error) {
+	return c.resolveID, c.resolveErr
+}
+
+func (c *fakeSlackClient) PostMessage(channelID, text string) error {
+	c.postedTo = channelID
+	c.postedText = text
+	return c.postErr
+}
+
+func TestRunSendChannelAndDM(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("channel", "#general", "")
+	cmd.Flags().String("message", "hello", "")
+	client := &fakeSlackClient{resolveID: "C1", openID: "D1"}
+	out := captureSlackStdout(t, func() {
+		if code := runSend(cmd, client, strings.NewReader("")); code != 0 {
+			t.Fatalf("runSend channel code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "to #general") || client.postedTo != "C1" || client.postedText != "hello" {
+		t.Fatalf("channel send failed output=%s client=%#v", out, client)
+	}
+
+	cmd = &cobra.Command{}
+	cmd.Flags().String("channel", "U123", "")
+	cmd.Flags().String("message", "", "")
+	client = &fakeSlackClient{resolveID: "C1", openID: "D1"}
+	out = captureSlackStdout(t, func() {
+		if code := runSend(cmd, client, strings.NewReader("from stdin\n")); code != 0 {
+			t.Fatalf("runSend dm code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "as DM") || client.postedTo != "D1" || client.postedText != "from stdin" {
+		t.Fatalf("dm send failed output=%s client=%#v", out, client)
+	}
+}
+
+func TestRunSendErrors(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("channel", "#general", "")
+	cmd.Flags().String("message", "", "")
+	if code := runSend(cmd, &fakeSlackClient{}, strings.NewReader("")); code == 0 {
+		t.Fatalf("empty message code = 0")
+	}
+	cmd.Flags().Set("message", "hi") //nolint:errcheck
+	if code := runSend(cmd, &fakeSlackClient{resolveErr: errors.New("no channel")}, strings.NewReader("")); code == 0 {
+		t.Fatalf("resolve error code = 0")
+	}
+	if code := runSend(cmd, &fakeSlackClient{resolveID: "C1", postErr: errors.New("post")}, strings.NewReader("")); code == 0 {
+		t.Fatalf("post error code = 0")
+	}
+
+	dm := &cobra.Command{}
+	dm.Flags().String("channel", "U123", "")
+	dm.Flags().String("message", "hi", "")
+	if code := runSend(dm, &fakeSlackClient{openErr: errors.New("open")}, strings.NewReader("")); code == 0 {
+		t.Fatalf("open error code = 0")
+	}
+}
+
+func TestRegisterCommands(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	RegisterCommands(root)
+	cmd, _, err := root.Find([]string{"slack", "send"})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if cmd.Name() != "send" {
+		t.Fatalf("cmd = %q, want send", cmd.Name())
+	}
+}
+
+func captureSlackStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	return buf.String()
+}

--- a/internal/slack/service_more_test.go
+++ b/internal/slack/service_more_test.go
@@ -1,0 +1,70 @@
+package slack
+
+import (
+	"os"
+	"testing"
+
+	"github.com/siyuqian/devpilot/internal/auth"
+)
+
+func TestServiceStateOAuthConfigAndBotToken(t *testing.T) {
+	dir := t.TempDir()
+	restore := auth.OverrideConfigDir(dir)
+	defer restore()
+
+	svc := NewService()
+	if svc.Name() != "slack" {
+		t.Fatalf("Name() = %q, want slack", svc.Name())
+	}
+	if svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = true before credentials")
+	}
+	if _, err := loadBotToken(); err == nil {
+		t.Fatalf("loadBotToken() succeeded before login")
+	}
+	if err := auth.Save("slack", auth.ServiceCredentials{
+		"client_id":     "id",
+		"client_secret": "secret",
+		"access_token":  "bot",
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = false after credentials")
+	}
+	cfg := svc.oauthConfig()
+	if cfg.ClientID != "id" || cfg.ClientSecret != "secret" || !cfg.UseTLS || cfg.RedirectPort != 17321 {
+		t.Fatalf("oauthConfig() = %#v", cfg)
+	}
+	token, err := loadBotToken()
+	if err != nil {
+		t.Fatalf("loadBotToken() error = %v", err)
+	}
+	if token != "bot" {
+		t.Fatalf("token = %q, want bot", token)
+	}
+	if err := svc.Logout(); err != nil {
+		t.Fatalf("Logout() error = %v", err)
+	}
+	if svc.IsLoggedIn() {
+		t.Fatalf("IsLoggedIn() = true after logout")
+	}
+}
+
+func TestServiceLoginRejectsEmptyInput(t *testing.T) {
+	old := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("\n\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+
+	if err := NewService().Login(); err == nil {
+		t.Fatalf("Login() succeeded with empty input")
+	}
+}

--- a/internal/trello/commands.go
+++ b/internal/trello/commands.go
@@ -26,96 +26,93 @@ var pushCmd = &cobra.Command{
 	Long:  "Read a plan markdown file and create a Trello card or GitHub Issue with the title from the first # heading and the full file contents as the description.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Fprintln(os.Stderr, "WARNING: 'devpilot push' is deprecated. Use OpenSpec + 'devpilot sync' instead.")
-		fmt.Fprintln(os.Stderr, "  See: https://github.com/Fission-AI/OpenSpec")
-		fmt.Fprintln(os.Stderr, "")
-
-		filePath := args[0]
-		listName, _ := cmd.Flags().GetString("list")     // flag registered above
-		sourceName, _ := cmd.Flags().GetString("source") // flag registered above
-		dir, _ := os.Getwd()                             // error handled by downstream calls
-		projectCfg, _ := project.Load(dir)               // project config is optional
-		sourceName = projectCfg.ResolveSource(sourceName)
-
-		// Read the plan file
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading file: %v\n", err)
-			os.Exit(1)
-		}
-
-		// Extract title from first # heading
-		title := extractTitle(string(content))
-		if title == "" {
-			fmt.Fprintln(os.Stderr, "Error: no # heading found in file")
-			os.Exit(1)
-		}
-
-		switch sourceName {
-		case "trello":
-			boardName, _ := cmd.Flags().GetString("board") // flag registered above
-
-			if boardName == "" {
-				if projectCfg.Board != "" {
-					boardName = projectCfg.Board
-				}
-			}
-			if boardName == "" {
-				fmt.Fprintln(os.Stderr, "Error: --board is required (or run: devpilot init)")
-				os.Exit(1)
-			}
-
-			// Load Trello credentials
-			creds, err := auth.Load("trello")
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "Not logged in to Trello. Run: devpilot login trello")
-				os.Exit(1)
-			}
-
-			client := NewClient(creds["api_key"], creds["token"])
-
-			// Resolve board
-			board, err := client.FindBoardByName(boardName)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-
-			// Resolve list
-			list, err := client.FindListByName(board.ID, listName)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-
-			// Create card
-			card, err := client.CreateCard(list.ID, title, string(content))
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error creating card: %v\n", err)
-				os.Exit(1)
-			}
-
-			fmt.Printf("Created card: %s\n", title)
-			if card.ShortURL != "" {
-				fmt.Println(card.ShortURL)
-			}
-		case "github":
-			out, err := exec.Command("gh", "issue", "create",
-				"--title", title,
-				"--body", string(content),
-				"--label", "devpilot",
-			).Output()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error creating issue: %v\n", err)
-				os.Exit(1)
-			}
-			fmt.Printf("Created issue: %s\n", title)
-			fmt.Println(strings.TrimSpace(string(out)))
-		default:
-			fmt.Fprintf(os.Stderr, "Unknown source %q. Must be trello or github.\n", sourceName)
-			os.Exit(1)
-		}
+		os.Exit(runPush(cmd, args[0]))
 	},
+}
+
+func runPush(cmd *cobra.Command, filePath string) int {
+	fmt.Fprintln(os.Stderr, "WARNING: 'devpilot push' is deprecated. Use OpenSpec + 'devpilot sync' instead.")
+	fmt.Fprintln(os.Stderr, "  See: https://github.com/Fission-AI/OpenSpec")
+	fmt.Fprintln(os.Stderr, "")
+
+	listName, _ := cmd.Flags().GetString("list")     // flag registered above
+	sourceName, _ := cmd.Flags().GetString("source") // flag registered above
+	dir, _ := os.Getwd()                             // error handled by downstream calls
+	projectCfg, _ := project.Load(dir)               // project config is optional
+	sourceName = projectCfg.ResolveSource(sourceName)
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading file: %v\n", err)
+		return 1
+	}
+
+	title := extractTitle(string(content))
+	if title == "" {
+		fmt.Fprintln(os.Stderr, "Error: no # heading found in file")
+		return 1
+	}
+
+	switch sourceName {
+	case "trello":
+		boardName, _ := cmd.Flags().GetString("board") // flag registered above
+
+		if boardName == "" {
+			if projectCfg.Board != "" {
+				boardName = projectCfg.Board
+			}
+		}
+		if boardName == "" {
+			fmt.Fprintln(os.Stderr, "Error: --board is required (or run: devpilot init)")
+			return 1
+		}
+
+		creds, err := auth.Load("trello")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Not logged in to Trello. Run: devpilot login trello")
+			return 1
+		}
+
+		client := NewClient(creds["api_key"], creds["token"])
+		board, err := client.FindBoardByName(boardName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+
+		list, err := client.FindListByName(board.ID, listName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+
+		card, err := client.CreateCard(list.ID, title, string(content))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating card: %v\n", err)
+			return 1
+		}
+
+		fmt.Printf("Created card: %s\n", title)
+		if card.ShortURL != "" {
+			fmt.Println(card.ShortURL)
+		}
+	case "github":
+		out, err := exec.Command("gh", "issue", "create",
+			"--title", title,
+			"--body", string(content),
+			"--label", "devpilot",
+		).Output()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating issue: %v\n", err)
+			return 1
+		}
+		fmt.Printf("Created issue: %s\n", title)
+		fmt.Println(strings.TrimSpace(string(out)))
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown source %q. Must be trello or github.\n", sourceName)
+		return 1
+	}
+	return 0
 }
 
 func extractTitle(content string) string {

--- a/internal/trello/commands_more_test.go
+++ b/internal/trello/commands_more_test.go
@@ -1,0 +1,88 @@
+package trello
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRunPushGitHubAndErrors(t *testing.T) {
+	dir := t.TempDir()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	bin := t.TempDir()
+	ghLog := filepath.Join(dir, "gh.log")
+	gh := filepath.Join(bin, "gh")
+	if err := os.WriteFile(gh, []byte("#!/bin/sh\necho \"$@\" >> "+ghLog+"\necho https://github.com/o/r/issues/1\n"), 0o755); err != nil {
+		t.Fatalf("write gh: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	plan := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(plan, []byte("# My task\n\nBody"), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+	cmd := pushTestCmd(t, "github", "")
+	if code := runPush(cmd, plan); code != 0 {
+		t.Fatalf("runPush github code = %d", code)
+	}
+	log, err := os.ReadFile(ghLog)
+	if err != nil {
+		t.Fatalf("read gh log: %v", err)
+	}
+	if !strings.Contains(string(log), "issue create") || !strings.Contains(string(log), "My task") {
+		t.Fatalf("gh log = %s", log)
+	}
+
+	if code := runPush(cmd, filepath.Join(dir, "missing.md")); code == 0 {
+		t.Fatalf("missing file code = 0")
+	}
+	noTitle := filepath.Join(dir, "no-title.md")
+	if err := os.WriteFile(noTitle, []byte("body"), 0o644); err != nil {
+		t.Fatalf("write no title: %v", err)
+	}
+	if code := runPush(cmd, noTitle); code == 0 {
+		t.Fatalf("no title code = 0")
+	}
+	if code := runPush(pushTestCmd(t, "bad", ""), plan); code == 0 {
+		t.Fatalf("unknown source code = 0")
+	}
+	if code := runPush(pushTestCmd(t, "trello", ""), plan); code == 0 {
+		t.Fatalf("missing board code = 0")
+	}
+}
+
+func TestRegisterCommands(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	RegisterCommands(root)
+	cmd, _, err := root.Find([]string{"push"})
+	if err != nil {
+		t.Fatalf("Find(push): %v", err)
+	}
+	if cmd.Name() != "push" {
+		t.Fatalf("cmd = %q, want push", cmd.Name())
+	}
+}
+
+func pushTestCmd(t *testing.T, source, board string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("source", source, "")
+	cmd.Flags().String("board", board, "")
+	cmd.Flags().String("list", "Ready", "")
+	return cmd
+}

--- a/skills/devpilot-batch-pr-review/SKILL.md
+++ b/skills/devpilot-batch-pr-review/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: devpilot-batch-pr-review
+description: Use when the user wants to review every pull request currently requesting their review, batch review a review queue, sweep pending PR reviews, or run PR reviews across all review-requested pull requests. Discovers the queue with `devpilot github prs review-queue` and delegates each real review to `devpilot-pr-review`; do not use for reviewing a single specified PR.
+---
+
+# Batch PR Review
+
+## Overview
+
+Find the current GitHub PR review queue, normalize it into explicit PR targets, then invoke `devpilot-pr-review` once per eligible PR. This skill owns discovery, ordering, and progress accounting only.
+
+Do not perform the review yourself. The actual review workflow, posting behavior, eligibility gate, inline comments, and confidence filtering belong to `devpilot-pr-review`.
+
+## Workflow
+
+1. Confirm GitHub CLI auth is available:
+
+   ```bash
+   gh auth status
+   ```
+
+   If auth is missing, stop and ask the user to run `gh auth login`.
+
+2. Discover PRs requesting review:
+
+   ```bash
+   devpilot github prs review-queue --user @me --limit 200 --json
+   ```
+
+   Add filters only when the user asks or context requires them:
+
+   ```bash
+   devpilot github prs review-queue --user <login-or-@me> --owner <owner> --json
+   devpilot github prs review-queue --user <login-or-@me> --repo <owner/repo> --json
+   devpilot github prs review-queue --user <login-or-@me> --direct --json
+   ```
+
+3. Parse the JSON array. Each item is expected to include `url`, `repository.nameWithOwner`, `number`, `title`, `author.login`, `isDraft`, `state`, and timestamps.
+
+4. Apply queue-level filtering:
+
+   - Keep only open PRs.
+   - Skip drafts unless explicitly requested with an include-drafts instruction.
+   - Preserve the command order unless the user asks for a different order.
+   - If the command returns no PRs, report that the review queue is empty and stop.
+
+5. Review each remaining PR by invoking `devpilot-pr-review` with the PR URL:
+
+   ```text
+   Use devpilot-pr-review to review <pr-url>.
+   ```
+
+   Run one PR at a time by default so review posting, CI context, and failures are easy to attribute. If the user explicitly asks for parallelism, dispatch reviews in parallel only when the review tooling and repository rate limits make that safe.
+
+6. Maintain a short progress ledger:
+
+   ```text
+   queued: <n>
+   reviewed: <n>
+   skipped: <n> (<reason summary>)
+   failed: <n> (<pr-url>: <reason>)
+   ```
+
+   Continue after a single PR review fails unless the failure indicates a shared blocker such as missing GitHub auth, missing `devpilot`, or repository-wide permissions.
+
+## Command Notes
+
+- Prefer `devpilot github prs review-queue --json` over raw `gh search prs`; PR #148 added the normalized helper for this exact queue-discovery task.
+- Use `--user @me` by default. Use a concrete login only when the user names someone else.
+- Use `--direct` only when team review requests should be excluded.
+- Use `--include-drafts` only when the user explicitly wants draft PRs included; otherwise skip drafts unless they appear because an older helper version did not filter them out.
+- In short: skip drafts unless explicitly requested.
+
+## Handoff Contract
+
+For each PR handed to `devpilot-pr-review`, pass only the PR URL plus any user-specified review constraints that apply to every PR in the batch. Do not pass the whole queue JSON unless the single-PR review needs it.
+
+Example handoff:
+
+```text
+Use devpilot-pr-review to review https://github.com/SiyuQian/devpilot/pull/148.
+Apply the user's batch constraint: focus on correctness and missing tests.
+```
+
+## Final Report
+
+End with a concise queue summary:
+
+- PRs discovered and reviewed.
+- PRs skipped with reasons.
+- PRs that failed and the next action needed.
+- Link or identify any reviews posted by `devpilot-pr-review` when that skill reports them.

--- a/skills/devpilot-batch-pr-review/evals/evals.json
+++ b/skills/devpilot-batch-pr-review/evals/evals.json
@@ -1,0 +1,10 @@
+[
+  {
+    "prompt": "Review every pull request currently requesting my review.",
+    "expected_output": "Uses devpilot-batch-pr-review, runs `devpilot github prs review-queue --user @me --limit 200 --json`, filters the queue, and invokes devpilot-pr-review once per eligible PR URL instead of reviewing the queue directly."
+  },
+  {
+    "prompt": "Batch review all PRs in SiyuQian/devpilot that need my review, direct requests only.",
+    "expected_output": "Uses `devpilot github prs review-queue --user @me --repo SiyuQian/devpilot --direct --json`, skips drafts unless explicitly included, then hands each PR URL to devpilot-pr-review."
+  }
+]

--- a/skills/devpilot-pr-review-queue/SKILL.md
+++ b/skills/devpilot-pr-review-queue/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: devpilot-batch-pr-review
+name: devpilot-pr-review-queue
 description: Use when the user wants to review every pull request currently requesting their review, batch review a review queue, sweep pending PR reviews, or run PR reviews across all review-requested pull requests. Discovers the queue with `devpilot github prs review-queue` and delegates each real review to `devpilot-pr-review`; do not use for reviewing a single specified PR.
 ---
 
-# Batch PR Review
+# PR Review Queue
 
 ## Overview
 

--- a/skills/devpilot-pr-review-queue/evals/evals.json
+++ b/skills/devpilot-pr-review-queue/evals/evals.json
@@ -1,7 +1,7 @@
 [
   {
     "prompt": "Review every pull request currently requesting my review.",
-    "expected_output": "Uses devpilot-batch-pr-review, runs `devpilot github prs review-queue --user @me --limit 200 --json`, filters the queue, and invokes devpilot-pr-review once per eligible PR URL instead of reviewing the queue directly."
+    "expected_output": "Uses devpilot-pr-review-queue, runs `devpilot github prs review-queue --user @me --limit 200 --json`, filters the queue, and invokes devpilot-pr-review once per eligible PR URL instead of reviewing the queue directly."
   },
   {
     "prompt": "Batch review all PRs in SiyuQian/devpilot that need my review, direct requests only.",

--- a/skills/index.json
+++ b/skills/index.json
@@ -170,7 +170,7 @@
       ]
     },
     {
-      "name": "devpilot-batch-pr-review",
+      "name": "devpilot-pr-review-queue",
       "description": "Use when the user wants to review every pull request currently requesting their review, batch review a review queue, sweep pending PR reviews, or run PR reviews across all review-requested pull requests.",
       "files": [
         "evals/evals.json",

--- a/skills/index.json
+++ b/skills/index.json
@@ -170,6 +170,14 @@
       ]
     },
     {
+      "name": "devpilot-batch-pr-review",
+      "description": "Use when the user wants to review every pull request currently requesting their review, batch review a review queue, sweep pending PR reviews, or run PR reviews across all review-requested pull requests.",
+      "files": [
+        "evals/evals.json",
+        "SKILL.md"
+      ]
+    },
+    {
       "name": "devpilot-resolve-issues",
       "description": "End-to-end loop that works through open GitHub issues one at a time: triage, self-assign, investigate code, render a REAL / FALSE-POSITIVE / NEEDS-HUMAN verdict, and for REAL issues fix in a per-issue git worktree — decompose into 1–3 tasks dispatched as one implementer subagent per task with superpowers:requesting-code-review gating each task, then open a PR with Closes #N. Runs until the issue filter is empty.",
       "files": [


### PR DESCRIPTION
## Description

Adds a new `devpilot github` command tree backed by the GitHub CLI, plus a `devpilot-pr-review-queue` skill that consumes the new review-queue helper to find PRs requesting review and delegate each PR to `devpilot-pr-review`.

The GitHub PR helpers list review-requested pull requests and user-authored pull requests with normalized table or JSON output. The repo activity helper builds a day or duration-based digest from repository events, updated PRs, updated issues, workflow runs, and releases, with timezone-aware windows and stable JSON arrays for script and agent consumption.

The root CLI now registers the GitHub domain, `docs/cli-reference.md` documents the new commands and the `gh auth login` prerequisite, and `skills/index.json` registers the new PR review queue skill. The queue skill keeps discovery separate from actual review work: it uses `devpilot github prs review-queue --json`, filters open non-draft PRs by default, and hands each eligible PR URL to `devpilot-pr-review`.

## Review Guide

Start with `internal/github/commands.go` to review the CLI surface and flags, then read `internal/github/prs.go` for PR search behavior. Review `internal/github/activity.go` after that because it contains the activity aggregation, event normalization, timezone windowing, and event enrichment logic. `internal/github/github_test.go` covers command argument construction and digest filtering/normalization paths.

For the skill addition, start with `skills/devpilot-pr-review-queue/SKILL.md`, then check `skills/devpilot-pr-review-queue/evals/evals.json` and the `skills/index.json` registration. The key behavior to verify is that the queue skill does not perform reviews itself; it only discovers the queue and delegates each PR URL to `devpilot-pr-review`.

## Validation

- [x] `go test ./internal/github`
- [x] `make test`
- [x] `make build`
- [x] `make lint`
- [x] Live smoke: `go run ./cmd/devpilot github prs review-queue --user @me --limit 5 --json`
- [x] Live smoke: `go run ./cmd/devpilot github prs authored --user SiyuQian --owner SiyuQian --state all --limit 3`
- [x] Live smoke: `go run ./cmd/devpilot github repo activity SiyuQian/devpilot --date 2026-06-01 --timezone Pacific/Auckland --json`
- [x] `python3 /Users/siyu/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/devpilot-pr-review-queue`
- [x] `python3 -m json.tool skills/index.json`
- [x] `python3 -m json.tool skills/devpilot-pr-review-queue/evals/evals.json`
