### PR TITLE
test(harness-engineering): add output-quality eval suite

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -2,6 +2,7 @@
 
 Active work, newest first. Each entry: status, one-line goal, link.
 
+- 2026-06-06 — Author an output-quality eval suite for the `devpilot-harness-engineering` skill (scenarios + fixtures + assertions; author-only). ([design](docs/exec-plans/active/2026-06-06-harness-skill-evals-design.md))
 - 2026-04-24 — Remove the runner and sibling AI-wrapping commands; reposition DevPilot as a skill catalog + narrow Go helpers. ([design](docs/exec-plans/active/2026-04-24-remove-runner-design.md), [plan](docs/exec-plans/active/2026-04-24-remove-runner-plan.md))
 
 ## Recently completed

--- a/docs/exec-plans/active/2026-06-06-harness-skill-evals-design.md
+++ b/docs/exec-plans/active/2026-06-06-harness-skill-evals-design.md
@@ -1,0 +1,147 @@
+# Output-quality eval suite for `devpilot-harness-engineering`
+
+**Status:** active
+**Owner:** agent (Siyu)
+**Started:** 2026-06-06
+
+## Goal
+
+The `devpilot-harness-engineering` skill currently has no way to tell whether the
+advice it produces is actually better than what baseline Claude would say. This
+plan delivers a committed, reviewable **eval suite** that measures the *quality of
+the harness advice the skill produces*, structured so the skill's lift over a
+no-skill baseline is visible.
+
+"Done" = the suite (scenarios, fixtures, assertions, grader rubric) lives under
+`skills/devpilot-harness-engineering/evals/`, is committed, and a later session can
+run it with the skill-creator harness without further authoring. This plan
+**authors** the suite; it does **not** run it.
+
+## Non-goals
+
+- **Running** the evals (spawning with-skill/baseline subagents, grading,
+  aggregating the benchmark, opening the viewer). Left to a follow-up session.
+- **Triggering-accuracy** evals (does the description fire on the right prompts).
+  We deliberately chose output/advice quality as the target instead.
+- Fixing the `index.json` filename drift for this skill — it lists
+  `references/agent-context.md` / `architectural-constraints.md`, which do not
+  exist (real files: `agents.md`, `architecture.md`, …). Real adjacent bug,
+  tracked here but out of scope for this plan.
+- Fixing the stale "Available now: `agents.md`, `architecture.md`, `plans.md`" line
+  in `SKILL.md` (omits `depth-first-decomposition.md`, `golden-principles.md`,
+  `guides-and-sensors.md`, which exist). Adjacent, out of scope.
+- Registering the eval files in `skills/index.json` — evals are dev-time
+  artifacts, not shipped skill content.
+
+## Design
+
+### Input strategy
+
+Mix of prompt-only scenarios (breadth, cheap to author) plus a small number of
+fixture repos for the cases where file inspection is the entire point.
+
+### Grading strategy
+
+Per-scenario **assertions** (3–5 per scenario, LLM-graded via a shared
+`rubric.md`, scripts where a claim is mechanically checkable) **plus baseline
+lift**: each scenario is run both with the skill and without it (the skill-creator
+harness), so we both diagnose specific quality and prove the skill adds value over
+Claude's default knowledge.
+
+The central risk for a guidance skill is **non-discriminating assertions** —
+claims that both the with-skill and baseline arms pass, because baseline Claude
+already knows generic harness advice (write an AGENTS.md, add a linter). The
+analyzer pass flags these, but we pre-empt the problem by:
+
+1. Anchoring every scenario to a *distinctive* idea of the skill — the
+   guide↔sensor pairing, the anti-speculation (Hashimoto) rule, the GC/drift
+   loop, depth-first one-block-one-PR sizing, AGENTS.md progressive disclosure,
+   tool/context bloat — where baseline Claude tends to give generic-but-wrong
+   advice.
+2. Including at least one **negative** assertion per scenario that catches
+   baseline over-eagerness (e.g. "does NOT create all six root docs upfront").
+3. A `rubric.md` that instructs the grader to reward skill-specific framework
+   moves and *not* credit generic advice both arms would give.
+
+### Layout
+
+```
+skills/devpilot-harness-engineering/
+  evals/
+    evals.json            # 6 scenarios: prompt, input-files, assertions
+    rubric.md             # shared grading guidance for the grader subagent
+    fixtures/
+      bloated-agents-md/    # ~200-line AGENTS.md of if-X-then-Y rules
+      rule-without-sensor/  # CLAUDE.md bans a pattern; nothing enforces it
+```
+
+`evals.json` follows the skill-creator schema (an `evals` array; each entry has a
+prompt, optional input files, and an assertions list). Run outputs go in a
+sibling `*-workspace/` at run time (gitignored, not created by this plan).
+
+### The 6 scenarios
+
+Each anchored to a distinctive idea so lift shows; each carries 3–5 assertions
+including ≥1 negative assertion.
+
+| # | Type | Scenario | Distinctive idea | Sample discriminating assertions |
+|---|------|----------|------------------|----------------------------------|
+| 1 | fixture (`rule-without-sensor/`) | A CLAUDE.md rule bans a pattern but agents still do it occasionally | guide↔**sensor** pairing | recommends a *mechanical* check (linter/test/hook); says sensor output must carry agent-actionable correction text; ¬ "just reword the doc" |
+| 2 | prompt | "Set me up for agents: create AGENTS.md, SECURITY.md, RELIABILITY.md, FRONTEND.md, QUALITY_SCORE.md now" | **anti-speculation** (Hashimoto) | only AGENTS.md + ARCHITECTURE.md mandatory; defers the rest to observed failures; **¬ creates all six upfront** |
+| 3 | prompt | "Every PR passes review but the repo feels worse month over month; no single culprit" | **GC loop** / compounding drift | names golden-principles + background refactor agent; frames it as drift not a per-PR sensor gap; ¬ "just tighten per-PR review" |
+| 4 | prompt | "Agent PRs are huge — reviewing takes longer than the agent took to write them" | **depth-first** one-block = one-PR sizing | recommends decomposition + plan index; ties block size to one context window; ¬ generic "ask for smaller PRs" only |
+| 5 | fixture (`bloated-agents-md/`) | A ~200-line AGENTS.md full of conditional rules | AGENTS.md bloat / progressive disclosure | flags that it's injected on every prompt; move detail into skills; cites the ~60/100-line bar |
+| 6 | prompt | "I added 12 MCP servers 'just in case' and the agent seems dumber / context blown" | tool & context bloat | prune/scope tool descriptions; prefer CLIs the model already knows; ¬ "add more tools" |
+
+### Spec location rationale
+
+Written as a plain exec-plan (`docs/exec-plans/active/`) per the repo's PLANS.md
+convention, not the generic superpowers `docs/superpowers/specs/` path: this is
+tooling that touches no user-facing spec surface, which the OpenSpec-vs-plain-plan
+rule (`references/plans.md`) routes to a plain exec-plan.
+
+## Tasks
+
+- [ ] 1. Create `evals/fixtures/bloated-agents-md/` — a minimal repo skeleton with
+      a ~200-line `AGENTS.md` of if-X-then-Y conditional rules and a couple of
+      stub source dirs, enough that the right advice is "split into skills."
+      Verify: `AGENTS.md` line count > 150 and contains conditional ("if … then")
+      phrasing.
+- [ ] 2. Create `evals/fixtures/rule-without-sensor/` — a skeleton with a
+      `CLAUDE.md` that states a banned pattern in prose, and source files that
+      *violate* it, with no linter/test/hook config present. Verify: the banned
+      pattern appears in `CLAUDE.md` and at least one source file violates it, and
+      there is no lint/test config enforcing it.
+- [ ] 3. Write `evals/rubric.md` — grading guidance for the grader subagent:
+      how to score each assertion, the explicit instruction to NOT credit generic
+      advice both arms give, and how negative assertions are scored. Verify: file
+      states the non-discrimination rule and covers negative-assertion handling.
+- [ ] 4. Write `evals/evals.json` — the 6 scenarios above, each with prompt,
+      input-files (fixtures for #1 and #5; none otherwise), and 3–5 named
+      assertions including ≥1 negative assertion each. Verify: valid JSON, 6
+      entries, every entry has ≥3 assertions and ≥1 assertion whose name marks it
+      negative; assertion names are descriptive (readable in the viewer).
+- [ ] 5. Add a short `README.md` (or header comment) in `evals/` pointing at the
+      skill-creator run procedure (spawn with+baseline, grade via `rubric.md`,
+      aggregate, view) so a later session can run without re-deriving it. Verify:
+      file names the run steps and the expected `*-workspace/` output location.
+- [ ] 6. Update `PLANS.md` index line and confirm nothing was added to
+      `skills/index.json`. Verify: `PLANS.md` has one line linking this plan;
+      `git diff skills/index.json` is empty.
+
+## Decisions log
+
+- 2026-06-06 — Target output/advice quality over triggering accuracy (user choice).
+- 2026-06-06 — Mix prompt-only + a few fixtures for inputs (user choice).
+- 2026-06-06 — Grade with per-scenario assertions + baseline lift (user choice).
+- 2026-06-06 — Anchor scenarios to distinctive skill ideas so lift is visible,
+  ~6 cases for iteration 1 (user choice).
+- 2026-06-06 — Author-only deliverable; running the suite is a follow-up (user choice).
+- 2026-06-06 — Plain exec-plan, not superpowers spec path, per repo PLANS.md
+  convention (tooling, no spec surface).
+
+## Open questions
+
+- None blocking. The `index.json` filename drift and the stale SKILL.md
+  "Available now" line are real but explicitly out of scope; raise as a separate
+  cleanup if desired.

--- a/skills/devpilot-harness-engineering/evals/README.md
+++ b/skills/devpilot-harness-engineering/evals/README.md
@@ -1,0 +1,54 @@
+# Evals — devpilot-harness-engineering
+
+An **output-quality** eval suite: it measures whether the advice this skill
+produces beats baseline Claude's default knowledge about agent harnesses. It does
+**not** measure triggering accuracy.
+
+## What's here
+
+- `evals.json` — 6 scenarios, each anchored to a *distinctive* idea of the skill
+  (guide↔sensor pairing, anti-speculation, GC/drift loop, depth-first sizing,
+  AGENTS.md progressive disclosure, tool/context bloat). Each carries 3–5
+  `expectations`, including ≥1 negative assertion that catches baseline
+  over-eagerness.
+- `rubric.md` — grading guidance layered on top of the skill-creator grader
+  contract; its core is the **non-discrimination rule** (don't credit advice the
+  baseline arm would also give).
+- `fixtures/bloated-agents-md/` — a repo whose AGENTS.md is ~160 lines of
+  if-X-then-Y rules (scenario 5).
+- `fixtures/rule-without-sensor/` — a repo with a documented ban and no
+  mechanical check enforcing it; two source files violate it (scenario 1).
+
+`evals.json` follows the skill-creator schema (`references/schemas.md` in the
+skill-creator skill).
+
+## How to run it (later session)
+
+This suite is **authored, not run**. To run it, drive the `skill-creator` skill's
+eval loop ("Running and evaluating test cases"). In short:
+
+1. **Stage fixtures.** Scenarios 1 and 5 reference a fixture *directory* in their
+   `files`. Copy that directory into the executor's working area so the agent can
+   inspect it, and phrase the prompt so the agent knows where the repo is.
+2. **Spawn paired runs in the same turn.** For every scenario, launch two
+   subagents at once — one **with** the skill loaded, one **baseline** (no skill)
+   — on the same prompt. Don't run all with-skill first.
+3. **Grade** each run with a grader subagent that reads `rubric.md` plus the
+   skill-creator grader contract (`agents/grader.md`); write `grading.json`
+   (`text` / `passed` / `evidence`) per run.
+4. **Aggregate** into `benchmark.json` via the skill-creator aggregation script;
+   the signal is the **pass-rate delta** (with_skill − without_skill), not the
+   absolute rate.
+5. **Analyst pass + viewer.** Flag non-discriminating assertions (both arms pass)
+   and open the eval viewer for the qualitative read.
+
+Run outputs belong in a sibling workspace
+(`devpilot-harness-engineering-workspace/`, organized by `iteration-N/eval-<id>/`),
+**not** committed here.
+
+## Reading the results
+
+Because baseline Claude already knows generic harness advice, expect some
+assertions to be near-ties. The scenarios were chosen so the *distinctive* moves
+discriminate — pay closest attention to the negative assertions and to the two
+fixture scenarios, where the skill must actually inspect files to answer well.

--- a/skills/devpilot-harness-engineering/evals/evals.json
+++ b/skills/devpilot-harness-engineering/evals/evals.json
@@ -1,0 +1,85 @@
+{
+  "skill_name": "devpilot-harness-engineering",
+  "evals": [
+    {
+      "id": 1,
+      "name": "guide-without-sensor",
+      "prompt": "Here's my repo (a Go payments service). My CLAUDE.md clearly says never call time.Now() directly in business logic — inject a Clock instead — but the agents keep doing it anyway and it slips through. How do I actually stop this?",
+      "expected_output": "Diagnoses a guide with no paired sensor and recommends a mechanical, agent-actionable check that enforces the rule; does not stop at re-wording the doc.",
+      "files": ["evals/fixtures/rule-without-sensor"],
+      "expectations": [
+        "Recommends adding a mechanical sensor (linter rule such as forbidigo / golangci-lint, an import-restriction lint, a test, or a pre-commit hook) that enforces the no-direct-time.Now() rule.",
+        "Frames the problem explicitly as a guide (feedforward) with no paired sensor (feedback) — a rule that nothing mechanically checks.",
+        "Specifies that the sensor's output should tell the agent HOW to fix the violation (inject/read a Clock), not merely report that a violation exists.",
+        "Shows it inspected the repo by identifying the actual violations in internal/order/order.go and internal/billing/invoice.go.",
+        "NEGATIVE: Does NOT propose that the fix is merely re-wording or strengthening the CLAUDE.md prose."
+      ]
+    },
+    {
+      "id": 2,
+      "name": "anti-speculation",
+      "prompt": "I'm setting up my repo so coding agents can work in it well. Go ahead and create AGENTS.md, SECURITY.md, RELIABILITY.md, FRONTEND.md, and QUALITY_SCORE.md so we're fully covered from day one.",
+      "expected_output": "Treats only AGENTS.md (+ ARCHITECTURE.md) as day-one essentials, invokes the build-from-observed-failures principle, and declines to scaffold all five docs upfront.",
+      "files": [],
+      "expectations": [
+        "Treats only AGENTS.md (and ARCHITECTURE.md) as day-one essentials and treats the other docs as add-when-a-real-need-appears.",
+        "Invokes the anti-speculation principle (Hashimoto's rule): build the harness from observed agent failures, not from imagined ones.",
+        "Notes that some of the requested docs may be noise for this repo (e.g. FRONTEND.md with no frontend, RELIABILITY.md for a simple tool).",
+        "NEGATIVE: Does NOT create or scaffold all five requested docs upfront, and does NOT hedge toward 'create the empty stubs now and fill them in later'."
+      ]
+    },
+    {
+      "id": 3,
+      "name": "compounding-drift-gc-loop",
+      "prompt": "Every individual PR looks fine when I review it, but month over month the quality of the codebase is clearly dropping — and I genuinely can't point to a single PR that caused it. What do I do?",
+      "expected_output": "Diagnoses compounding drift that per-PR review can't catch and prescribes golden principles plus a background GC/refactor sweep.",
+      "files": [],
+      "expectations": [
+        "Diagnoses this as compounding drift that per-PR review structurally cannot catch, rather than a reviewer-diligence problem.",
+        "Recommends encoding golden principles (taste/structure) and running a background garbage-collection / refactor agent to counter the drift.",
+        "Distinguishes a repo-wide drift sweep from per-PR sensors (the problem is between PRs, not within one).",
+        "NEGATIVE: Does NOT reduce the answer to 'review each PR more strictly' or 'add more reviewers'."
+      ]
+    },
+    {
+      "id": 4,
+      "name": "depth-first-decomposition",
+      "prompt": "My agents keep opening enormous PRs — reviewing one takes me longer than the agent spent writing it. How should I change the way I feed work to them?",
+      "expected_output": "Prescribes depth-first decomposition sized to one block = one context window = one reviewable PR, tracked in a plan index.",
+      "files": [],
+      "expectations": [
+        "Recommends depth-first decomposition: sizing each unit of work so one block = one context window = one reviewable PR.",
+        "Ties the oversized-PR symptom to missing decomposition (and/or weak sensors), not merely to the agent's verbosity.",
+        "Recommends tracking in-flight work in a plan index (e.g. PLANS.md / exec-plans) so blocks stay bounded and depth-first.",
+        "NEGATIVE: Does NOT stop at generic advice like 'tell the agent to make smaller PRs' without giving the one-block-one-context-window sizing rule."
+      ]
+    },
+    {
+      "id": 5,
+      "name": "agents-md-bloat",
+      "prompt": "Audit the agent harness in this repo and tell me the single most important thing to fix.",
+      "expected_output": "Identifies the oversized AGENTS.md (injected every prompt) as the top problem and prescribes moving detail into on-demand skills via progressive disclosure.",
+      "files": ["evals/fixtures/bloated-agents-md"],
+      "expectations": [
+        "Identifies the oversized AGENTS.md as the primary problem and notes that it is injected into every prompt, so its length has a standing per-turn cost.",
+        "Recommends moving the conditional (if-X-then-Y) detail into on-demand skills with progressive disclosure, keeping AGENTS.md tight.",
+        "References a concrete length bar (~60-line target, ~100-line hard split) or otherwise quantifies that the file is far too long.",
+        "Shows it actually inspected the file (e.g. cites the ~160-line length or the nested if-then structure).",
+        "NEGATIVE: Does NOT advise merely trimming a few lines or reformatting while leaving all the detail inside AGENTS.md."
+      ]
+    },
+    {
+      "id": 6,
+      "name": "tool-context-bloat",
+      "prompt": "I wired up about a dozen MCP servers so the agent would have every tool it might possibly need, but now it feels dumber and sometimes runs out of context. What went wrong?",
+      "expected_output": "Explains that tool descriptions consume context every turn and prescribes pruning/scoping tools per task, preferring known CLIs over custom MCP wrappers.",
+      "files": [],
+      "expectations": [
+        "Explains that tool descriptions are injected and consume context on every turn, so 'just in case' tools carry a standing cost even when unused.",
+        "Recommends pruning and scoping tools per task rather than loading the full set all the time.",
+        "Recommends preferring CLIs the model already knows over custom MCP wrappers where that's an option.",
+        "NEGATIVE: Does NOT suggest adding more tools, and does NOT treat the large tool count as harmless."
+      ]
+    }
+  ]
+}

--- a/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/AGENTS.md
+++ b/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/AGENTS.md
@@ -1,0 +1,161 @@
+# AGENTS.md
+
+This file is injected into every agent prompt. Read all of it before doing anything.
+
+## General
+
+- If you are adding a new HTTP handler, then put it in `internal/api/handlers/` and register it in `internal/api/router.go`,
+  - if the handler needs auth then wrap it with `RequireAuth`
+  - if it is public then add it to the `publicRoutes` allowlist
+  - if it returns JSON then use `respondJSON`
+  - if it returns a file then use `respondStream`.
+- If you are writing a database query, then use the `sqlc`-generated code in `internal/db/gen/`,
+  - if the query is new then add the `.sql` file under `internal/db/queries/` first and run `make sqlc`
+  - if the query joins more than three tables then add an index and note it in `docs/db-indexes.md`
+  - if it writes then wrap it in a transaction via `db.WithTx`.
+- If you touch anything under `internal/billing/`, then ping the billing owner in the PR description,
+  - if the change affects invoices then add a row to `docs/billing-changelog.md`
+  - if it changes a price then it must be behind a feature flag
+  - if it is a refund path then add an integration test.
+- If you add a config value, then add it to `config/schema.go`,
+  - if it is a secret then it goes in the vault not the repo
+  - if it has a default then document the default in `config/README.md`
+  - if it is environment-specific then add it to all three of `config/dev.yaml`, `config/staging.yaml`, `config/prod.yaml`.
+
+## Naming
+
+- If a function returns an error as its last value, then name it so the verb is first,
+  - if it is a constructor then prefix with `New`
+  - if it builds without I/O then prefix with `Make`
+  - if it is a getter then do not prefix with `Get` unless it does I/O.
+- If a type is an interface, then do not suffix it with `Interface` or `Iface`,
+  - if it has one method then name it after the method plus `-er`
+  - if it is a mock then put it in `mocks/` and suffix with `Mock`.
+- If a variable is a context, then name it `ctx`,
+  - if it is an error then name it `err`
+  - if it is a temporary buffer then name it `buf`
+  - if it is a loop index over a domain slice then name it after the singular noun, not `i`.
+- If you introduce an acronym, then keep it all-caps in exported names (`HTTPServer`, not `HttpServer`),
+  - if it starts an unexported name then keep it all-lowercase (`httpServer`).
+
+## Errors
+
+- If you return an error across a package boundary, then wrap it with `fmt.Errorf("...: %w", err)`,
+  - if the message would duplicate the caller's context then drop the redundant words
+  - if the error is sentinel-checked then export it as `ErrXxx`
+  - if it is user-facing then map it through `apierr.From`.
+- If a function can fail in more than three distinct ways, then return a typed error, not a string,
+  - if the caller needs to branch on the failure then expose `errors.Is`/`errors.As` targets.
+- If you log an error, then do not also return it logged at a lower layer (log once, at the top),
+  - if it is a background goroutine then log with the request id if one exists.
+
+## Testing
+
+- If you add a function, then add a table-driven test,
+  - if it has more than two branches then cover each branch with a named subtest
+  - if it does I/O then add a fake, not a mock of our own package
+  - if it is concurrent then run the test with `-race`.
+- If you add an integration test, then put it behind the `integration` build tag,
+  - if it needs a database then use the `testdb` helper
+  - if it needs the network then skip it in CI unless `RUN_NET_TESTS=1`.
+- If a test is flaky, then quarantine it with `t.Skip` and open an issue the same day,
+  - if it stays skipped for two weeks then delete it.
+- If you assert on an error, then assert on the wrapped target with `errors.Is`, not on the string,
+  - if the string matters then assert a substring, not equality.
+
+## HTTP
+
+- If a handler reads a body, then cap it with `http.MaxBytesReader`,
+  - if it parses JSON then reject unknown fields
+  - if it is idempotent then support an `Idempotency-Key` header
+  - if it is paginated then use cursor pagination, not offset.
+- If you add a response header, then add it in middleware if it applies to all routes,
+  - if it is a CORS header then change `internal/api/cors.go` only
+  - if it is a cache header then make sure it matches the CDN config in `infra/cdn.tf`.
+- If a request is slow, then add a timeout context derived from the request,
+  - if it calls a third party then add a circuit breaker
+  - if it retries then cap retries at three with jittered backoff.
+
+## Frontend
+
+- If you add a React component, then put it in `web/src/components/`,
+  - if it is a page then put it in `web/src/pages/`
+  - if it fetches data then use the `useQuery` wrapper, not raw `fetch`
+  - if it mutates then use `useMutation` and invalidate the relevant query keys.
+- If you add a style, then use the design tokens in `web/src/theme/`,
+  - if a token does not exist then add it there first
+  - if it is a one-off then still do not inline a hex value.
+- If you add a form, then use `react-hook-form`,
+  - if it has validation then use the shared `zod` schemas in `web/src/schemas/`
+  - if it submits money then double-confirm with a modal.
+- If a component re-renders too often, then memoize the expensive child,
+  - if the prop is a function then wrap it in `useCallback`
+  - if it is an object then wrap it in `useMemo`.
+
+## Migrations
+
+- If you change the schema, then add a migration in `migrations/` with both `up` and `down`,
+  - if it is destructive then it ships in its own PR
+  - if it backfills then the backfill runs as a separate job, not in the migration
+  - if it adds a NOT NULL column then add it nullable first, backfill, then add the constraint.
+- If a migration is large, then run it in batches,
+  - if it locks a table then schedule it for the maintenance window
+  - if it cannot be reversed then document the recovery procedure in the PR.
+
+## Security
+
+- If you handle user input, then validate it at the boundary,
+  - if it reaches a query then it must be parameterized
+  - if it reaches a shell then do not
+  - if it reaches a template then auto-escape.
+- If you add an endpoint that returns user data, then check the caller owns the data,
+  - if it is admin-only then gate it behind the `admin` scope
+  - if it is internal then require mTLS.
+- If you add a dependency, then check its license is in the allowlist,
+  - if it is a transitive bump then run `make audit`
+  - if it has a known CVE then do not add it.
+- If you store a password, then it is `argon2id`, never anything else,
+  - if you store a token then store only its hash
+  - if you log a request then redact `Authorization` and `Cookie`.
+
+## Performance
+
+- If a query is in a hot path, then it must use an index,
+  - if it returns many rows then it must paginate
+  - if it is read-heavy then consider the read replica
+  - if it is cacheable then cache it with an explicit TTL.
+- If you allocate in a loop, then hoist the allocation,
+  - if you build a string then use a `strings.Builder`
+  - if you marshal repeatedly then reuse the encoder.
+
+## Observability
+
+- If you add a code path that can fail, then add a metric for it,
+  - if it is latency-sensitive then add a histogram
+  - if it is a queue then export depth and age
+  - if it is a feature flag then export which branch was taken.
+- If you add a log line, then make it structured,
+  - if it is in a request path then include the trace id
+  - if it is an error then include enough context to reproduce without the log being PII.
+
+## Releases
+
+- If you cut a release, then update `CHANGELOG.md`,
+  - if it is a breaking change then bump the major and write a migration note
+  - if it touches the public API then update `docs/api/openapi.yaml`
+  - if it changes the CLI then update `docs/cli.md`.
+- If a release fails in staging, then roll back before debugging,
+  - if the rollback fails then page the on-call
+  - if it is a data issue then freeze writes first.
+
+## Pull requests
+
+- If your PR is larger than 400 lines, then split it,
+  - if it cannot be split then explain why in the description
+  - if it touches more than three domains then it almost certainly should be split.
+- If your PR changes behavior, then it needs a test that fails before and passes after,
+  - if it is a refactor then it needs no behavior change and the tests prove it
+  - if it is a revert then link the original.
+- If CI is red, then do not request review,
+  - if it is red because of flake then link the quarantine issue
+  - if it is red because of lint then just fix it.

--- a/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/README.md
+++ b/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/README.md
@@ -1,0 +1,13 @@
+# bloated-agents-md (eval fixture)
+
+A deliberately broken harness fixture for the `devpilot-harness-engineering`
+eval suite. The defect: `AGENTS.md` is ~190 lines of nested `if X then Y`
+conditional rules — content that is injected into every prompt and that should
+live in on-demand skills with progressive disclosure.
+
+**Correct advice when pointed at this repo:** flag that AGENTS.md is injected on
+every turn, that it has blown past the ~60/100-line bar, and that the conditional
+detail belongs in skills the agent loads on demand — not a flat dump.
+
+Not a real project; `internal/` and `web/` are empty stubs so the repo reads as
+plausible.

--- a/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/go.mod
+++ b/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/go.mod
@@ -1,0 +1,5 @@
+// Nested module so the parent repo's `go build ./...` / `make test` skips this
+// eval fixture. The fixture exists to be inspected, not built.
+module example.com/bloated-agents-md
+
+go 1.22

--- a/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/internal/api/handlers/handlers.go
+++ b/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/internal/api/handlers/handlers.go
@@ -1,0 +1,3 @@
+package handlers
+
+// Stub. See AGENTS.md for the (overgrown) conventions.

--- a/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/internal/billing/billing.go
+++ b/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/internal/billing/billing.go
@@ -1,0 +1,3 @@
+package billing
+
+// Stub.

--- a/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/web/src/components/App.tsx
+++ b/skills/devpilot-harness-engineering/evals/fixtures/bloated-agents-md/web/src/components/App.tsx
@@ -1,0 +1,2 @@
+// Stub component.
+export function App() { return null }

--- a/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/CLAUDE.md
+++ b/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/CLAUDE.md
@@ -1,0 +1,20 @@
+# Project conventions
+
+This is a payments service. A few hard rules:
+
+## Time
+
+**Never call `time.Now()` directly in business logic.** Wall-clock reads inside
+domain code make behavior untestable and cause flaky tests. Inject a `Clock`
+interface and read the time through it, so tests can pin the clock. The only
+place a raw `time.Now()` is allowed is in `cmd/` wiring, where the real clock is
+constructed.
+
+## Money
+
+Represent money as integer minor units (cents) via the `Money` type in
+`internal/money`. Never use `float64` for amounts.
+
+## Errors
+
+Wrap errors at package boundaries with `fmt.Errorf("...: %w", err)`.

--- a/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/README.md
+++ b/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/README.md
@@ -1,0 +1,15 @@
+# rule-without-sensor (eval fixture)
+
+A deliberately broken harness fixture for the `devpilot-harness-engineering`
+eval suite. The defect: `CLAUDE.md` states a hard rule in prose ("never call
+`time.Now()` directly in business logic"), but **nothing mechanical enforces
+it** — there is no linter config, no forbidigo rule, no test, no pre-commit
+hook. Two source files (`internal/order/order.go`, `internal/billing/invoice.go`)
+violate the rule right now.
+
+**Correct advice when pointed at this repo:** a guide with no sensor doesn't
+hold — pair the rule with a mechanical check (a `forbidigo`/golangci-lint rule,
+an import-restriction lint, or a test) whose output tells the *agent* how to
+fix the violation, not just that one exists. Re-wording the doc is not the fix.
+
+Not a real project; only enough Go to make the violation real.

--- a/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/cmd/server/main.go
+++ b/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/cmd/server/main.go
@@ -1,0 +1,4 @@
+package main
+
+// Allowed: wiring layer may construct the real clock here.
+func main() {}

--- a/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/go.mod
+++ b/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/go.mod
@@ -1,0 +1,3 @@
+module example.com/payments
+
+go 1.22

--- a/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/internal/billing/invoice.go
+++ b/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/internal/billing/invoice.go
@@ -1,0 +1,13 @@
+package billing
+
+import "time"
+
+// VIOLATION: another direct time.Now() in domain code.
+func NewInvoice(id string) *Invoice {
+	return &Invoice{ID: id, IssuedAt: time.Now()}
+}
+
+type Invoice struct {
+	ID       string
+	IssuedAt time.Time
+}

--- a/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/internal/order/order.go
+++ b/skills/devpilot-harness-engineering/evals/fixtures/rule-without-sensor/internal/order/order.go
@@ -1,0 +1,16 @@
+package order
+
+import "time"
+
+// VIOLATION: reads the wall clock directly inside business logic.
+// CLAUDE.md bans this, but nothing mechanical catches it.
+func (o *Order) MarkPaid() {
+	o.PaidAt = time.Now() // should come from an injected Clock
+	o.Status = "paid"
+}
+
+type Order struct {
+	ID     string
+	Status string
+	PaidAt time.Time
+}

--- a/skills/devpilot-harness-engineering/evals/rubric.md
+++ b/skills/devpilot-harness-engineering/evals/rubric.md
@@ -1,0 +1,74 @@
+# Grading rubric — harness-engineering output quality
+
+Read this alongside the skill-creator grader contract (`agents/grader.md`). That
+file defines the mechanics — read the transcript, cite evidence, write
+`grading.json` with `text` / `passed` / `evidence`, no partial credit. This file
+adds the rules specific to grading **harness advice**, where the failure mode is
+not "wrong file" but "generic advice that looks right."
+
+## What these evals measure
+
+Whether the advice the skill produces is *better than baseline Claude's default
+knowledge* about agent harnesses. Every scenario is run twice — once with the
+skill loaded, once without (`baseline`) — against the same prompt. The signal is
+the **pass-rate delta**, not the absolute pass rate. An assertion both arms pass
+tells us nothing about the skill.
+
+## The non-discrimination rule (most important)
+
+Baseline Claude already knows the obvious moves: "write an AGENTS.md", "add a
+linter", "keep PRs small". Do **not** pass an assertion just because the output
+states the generic version of the right idea. Pass it only when the output
+demonstrates the skill's *distinctive* framing for that scenario:
+
+- **guide↔sensor pairing** — not "document the rule better" but "add a mechanical
+  check, and its output must tell the *agent* how to fix the violation."
+- **anti-speculation (Hashimoto)** — not "set up good docs" but "only AGENTS.md +
+  ARCHITECTURE.md now; add the rest *when you observe the agent getting that
+  wrong*."
+- **GC / compounding drift** — not "review more carefully" but "no single PR is
+  the culprit; add a background refactor pass / golden-principles sweep."
+- **depth-first sizing** — not "ask for smaller PRs" but "one block = one context
+  window = one reviewable PR, tracked in a plan index."
+- **progressive disclosure** — not "trim the docs" but "AGENTS.md is injected on
+  every turn; move the conditional detail into on-demand skills."
+- **tool/context bloat** — not "use fewer tools" but "tool descriptions burn
+  context every turn; scope per task, prefer CLIs the model already knows."
+
+When in doubt, ask: *would the baseline arm, with no skill, plausibly produce
+this same sentence?* If yes, the assertion is non-discriminating — fail it for
+the with-skill arm too unless the output goes beyond the generic version, and
+flag it under `eval_feedback`.
+
+## Negative assertions
+
+Some assertions are phrased as "does NOT do X" (e.g. "does not create all six
+root docs upfront"; "does not just reword the doc"; "does not say add more
+tools"). For these:
+
+- **PASS** = the output genuinely avoids the bad move *and* the avoidance looks
+  deliberate (it recommends the better alternative), not merely an omission
+  because the output was thin.
+- **FAIL** = the output does the bad thing, or hedges toward it ("you could
+  create those scaffolds now and fill them later" fails the anti-speculation
+  negative).
+
+Negative assertions are where baseline most often diverges from the skill — weight
+them when reading the delta.
+
+## Scoring guidance
+
+- No partial credit per assertion (grader contract). But a near-miss that states
+  the distinctive idea weakly should fail, with the gap quoted in `evidence`.
+- Reward *specificity tied to the scenario's planted defect* over breadth. An
+  answer that correctly diagnoses this repo's one real problem beats a generic
+  checklist that happens to contain the right item.
+- For the two fixture scenarios, the output must show it actually inspected the
+  files (cites the line count, names the violating files) — advice that would be
+  identical without reading the repo is a weaker pass at best.
+
+## Critiquing the evals
+
+Per the grader contract's Step 6, flag non-discriminating assertions you notice
+(both arms pass) and any distinctive idea the scenario *should* test but no
+assertion covers. These evals are new; that feedback is the point.


### PR DESCRIPTION
## What & why

Adds an **authored (not-yet-run)** eval suite for the `devpilot-harness-engineering` skill under `skills/devpilot-harness-engineering/evals/`. It measures whether the *advice the skill produces* beats baseline Claude's default harness knowledge — output quality, not triggering accuracy.

Six scenarios, each anchored to a **distinctive** idea of the skill so the lift over baseline is visible (the central risk for a guidance skill is non-discriminating assertions both arms pass):

| # | Distinctive idea | Type |
|---|---|---|
| 1 | guide↔sensor pairing | fixture |
| 2 | anti-speculation (Hashimoto) | prompt |
| 3 | compounding drift / GC loop | prompt |
| 4 | depth-first one-block=one-PR sizing | prompt |
| 5 | AGENTS.md progressive disclosure | fixture |
| 6 | tool/context bloat | prompt |

Each scenario carries 3–5 assertions including ≥1 **negative** assertion (e.g. "does NOT create all six root docs upfront"). Grading = per-scenario assertions **+** baseline lift; `rubric.md` adds the non-discrimination rule so generic advice both arms give isn't credited.

## Files

- `evals/evals.json` — 6 scenarios (skill-creator schema)
- `evals/rubric.md` — grader guidance (non-discrimination rule, negative-assertion scoring)
- `evals/README.md` — how a later session runs it
- `evals/fixtures/bloated-agents-md/` — ~160-line if-X-then-Y AGENTS.md; **own `go.mod`** so it stays out of the parent module
- `evals/fixtures/rule-without-sensor/` — documented ban + 2 violating files, no sensor
- `docs/exec-plans/active/2026-06-06-harness-skill-evals-design.md` + `PLANS.md` index line

## Review Guide

- **Start with** `docs/exec-plans/active/2026-06-06-harness-skill-evals-design.md` — the full design, the resolved decisions, and explicit non-goals.
- Then `evals/evals.json` (the scenarios + assertions) alongside `evals/rubric.md` (how they're meant to be graded). Read those two together — the assertions only make sense with the non-discrimination rule.
- The two `fixtures/` dirs are deliberately broken repos; their `README.md` states the planted defect and the correct advice.
- **Watch for:** `bloated-agents-md/go.mod` — it exists purely to keep the fixture's stub `.go` files out of the repo's `go build ./...` / `make test`. Without it, those packages leak into the parent module (verified before/after).

## Scope notes

- **Not registered in `skills/index.json`** — evals are dev-time artifacts, not shipped skill content (`git diff skills/index.json` is empty).
- Out of scope (noted in the spec's non-goals): running the suite, the `index.json` filename drift for this skill, and the stale "Available now" line in `SKILL.md`.

## Checklist

- [x] `make test` passes
- [x] `make lint` passes
- [x] `evals.json` validated (6 entries, ≥3 assertions + ≥1 negative each)
- [x] fixtures don't leak into parent module (`go list ./...` clean)
- [ ] (human) decide whether to run the suite and act on the +15pp signal from the trial run

🤖 Generated with [Claude Code](https://claude.com/claude-code)