### PR TITLE
feat(devpilot-learn): make quizzes bilingual

### DIFF
--- a/skills/devpilot-learn/evals/evals.json
+++ b/skills/devpilot-learn/evals/evals.json
@@ -12,7 +12,8 @@
         "The HTML contains source metadata and a structured summary layout",
         "The HTML uses either bilingual digest structure or another clearly defined learning-oriented structure chosen from the skill",
         "The HTML contains at least one summary-oriented section and one supporting detail section",
-        "The HTML includes a source link back to the original URL"
+        "The HTML includes a source link back to the original URL",
+        "Any quizzes are bilingual: each question appears in the source's original language with a Chinese translation directly beneath it, and quiz labels are bilingual (e.g. 查看答案 / Show answer) rather than Chinese-only"
       ]
     },
     {
@@ -39,7 +40,8 @@
         "The HTML file is self-contained with no external CSS or JS dependencies",
         "The HTML contains source-aware metadata for the PDF",
         "The HTML contains structured summary content",
-        "The HTML references the source PDF filename"
+        "The HTML references the source PDF filename",
+        "Any quizzes are bilingual: each question appears in the source's original language with a Chinese translation directly beneath it, and quiz labels are bilingual (e.g. 查看答案 / Show answer) rather than Chinese-only"
       ]
     },
     {

--- a/skills/devpilot-learn/references/output-contract.md
+++ b/skills/devpilot-learn/references/output-contract.md
@@ -18,8 +18,15 @@ Three pillars, in this rhythm, repeated section by section:
 2. **Chinese translation** (`.zh`) — a faithful translation sitting directly *below*
    each original passage (never in a second column). This is where interpretation
    lives; keep it accurate to the passage above it.
-3. **Quizzes** — short `节后小测` after each section and a `总测` at the end, every
-   answer hidden inside a `<details>` element so it stays collapsed until opened.
+3. **Quizzes** — short `节后小测 / Section Quiz` after each section and a
+   `总测 / Final Test` at the end, every answer hidden inside a `<details>` element so
+   it stays collapsed until opened. **Quizzes follow the same bilingual rhythm as the
+   passages**: each question appears in the source's original language with a faithful
+   Chinese translation directly beneath it (exactly as `.orig` → `.zh`), the answer and
+   explanation are given in both languages, and the structural labels are bilingual
+   (`查看答案 / Show answer`, `答案/Answer`, `解析/Explanation`). When the source is
+   already Chinese, the question needs no second line — same as a Chinese passage needs
+   no translation.
 
 Optional, used sparingly: `.note` glosses for individual terms or hard phrases that
 genuinely need explanation.
@@ -51,5 +58,10 @@ is the failure mode this contract exists to prevent.
 - Preserve source terminology. For statutes, cases, proper nouns, product/model/org
   names, keep the original term and add a common Chinese rendering only when it helps.
 - Quizzes must be answerable from the source alone — never test outside knowledge.
+- Quizzes are bilingual, never single-language. A question in only one language (or
+  bilingual answer content under Chinese-only labels like a bare `节后小测` / `查看答案`)
+  is a defect: pair the source-language question with a Chinese translation and use the
+  bilingual labels above. The lone exception is a source that is already Chinese, where
+  the question is simply Chinese.
 - If the source is thin, paywalled, or partly inaccessible, degrade honestly: keep the
   close-reading structure over whatever text you actually have, and say so. Don't pad.

--- a/skills/devpilot-learn/references/skeleton.md
+++ b/skills/devpilot-learn/references/skeleton.md
@@ -100,6 +100,14 @@ rhythm and the single-column flow.
     .quiz h3 { margin: 0 0 .6em; color: #1a3d6e; }
     .quiz ol { margin: 0; padding-left: 1.4em; }
     .quiz li { margin: 1em 0; }
+    /* question original + its Chinese translation (mirrors .orig / .zh) */
+    .quiz .q { margin: 0 0 .35em; }
+    .quiz .q-zh {
+      margin: 0 0 .2em;
+      padding-left: .75em;
+      border-left: 3px solid #c9b27a;
+      color: #4d4127;
+    }
     .final-test { background: #fff7e9; border-color: #e8d6ab; }
     .final-test h2 { border-left-color: #b8860b; color: #8a5a00; }
 
@@ -164,15 +172,16 @@ rhythm and the single-column flow.
   <div class="note"><b>[term / 术语]</b>：[简短中文注解]</div>
 
   <div class="quiz">
-    <h3>节后小测</h3>
+    <h3>节后小测 / Section Quiz</h3>
     <ol>
       <li>
-        <p>[Question grounded only in this section]</p>
+        <p class="q">[Question in the source's original language, grounded only in this section]</p>
+        <p class="q-zh">[该问题的中文翻译]</p>
         <details class="answer">
-          <summary>查看答案</summary>
+          <summary>查看答案 / Show answer</summary>
           <div class="answer-body">
-            <p><span class="label">答案：</span>[answer]</p>
-            <p><span class="label">解析：</span>[short explanation pointing back to the passage]</p>
+            <p><span class="label">答案/Answer：</span>[answer, original language + 中文]</p>
+            <p><span class="label">解析/Explanation：</span>[short explanation pointing back to the passage, original language + 中文]</p>
           </div>
         </details>
       </li>
@@ -185,12 +194,13 @@ rhythm and the single-column flow.
     <h2 id="final-test">总测 / Final Test</h2>
     <ol>
       <li>
-        <p>[Comprehensive question spanning the whole source]</p>
+        <p class="q">[Comprehensive question, source's original language, spanning the whole source]</p>
+        <p class="q-zh">[该问题的中文翻译]</p>
         <details class="answer">
-          <summary>查看答案</summary>
+          <summary>查看答案 / Show answer</summary>
           <div class="answer-body">
-            <p><span class="label">答案：</span>[answer]</p>
-            <p><span class="label">解析：</span>[short explanation grounded in the source]</p>
+            <p><span class="label">答案/Answer：</span>[answer, original language + 中文]</p>
+            <p><span class="label">解析/Explanation：</span>[short explanation grounded in the source, original language + 中文]</p>
           </div>
         </details>
       </li>
@@ -208,5 +218,8 @@ Guidance:
   interpretation happens — keep it faithful.
 - Keep large portions of the original; don't reduce a section to one quoted line.
 - Use `.note` sparingly — only for terms or phrases that genuinely need a gloss.
+- Quizzes are bilingual like the passages: `.q` is the question in the source's original
+  language, `.q-zh` is its Chinese translation directly beneath, and answers/labels carry
+  both languages. Omit `.q-zh` only when the source is already Chinese.
 - Every quiz answer goes inside `<details>` so it stays collapsed by default.
 - Drop the `.toc` block for short, single-section sources.

--- a/skills/devpilot-learn/references/workflow.md
+++ b/skills/devpilot-learn/references/workflow.md
@@ -52,11 +52,16 @@ Load `skeleton.md` and follow its layout. For each section, in source order:
    or compress them into a single line.
 2. Put a faithful Chinese translation in a `.zh` block directly below each `.orig`.
 3. Add `.note` glosses sparingly, only where a term or phrase needs explanation.
-4. End the section with a `节后小测` containing 1–3 questions, each answer hidden in a
-   `<details>` element.
+4. End the section with a `节后小测 / Section Quiz` containing 1–3 questions, each answer
+   hidden in a `<details>` element. Make the quiz **bilingual**, mirroring the
+   `.orig` → `.zh` rhythm: write each question in the source's original language with a
+   faithful Chinese translation directly beneath it, give the answer and explanation in
+   both languages, and use the bilingual labels (`查看答案 / Show answer`, `答案/Answer`,
+   `解析/Explanation`). If the source is already Chinese, the question stays Chinese-only —
+   same as a Chinese passage needs no translation.
 
-Then close with a `总测 / Final Test` spanning the whole source, same `<details>` answer
-pattern.
+Then close with a `总测 / Final Test` spanning the whole source, same bilingual questions
+and `<details>` answer pattern.
 
 Keep the meta block at the top and a `目录` table of contents when the source has several
 sections (drop it for short single-section sources).


### PR DESCRIPTION
## What changed

The `devpilot-learn` skill's quizzes were hard-locked to Chinese — Chinese-only labels (`节后小测`, `查看答案`, `答案`, `解析`) and single-language questions with **no translation pairing** — even when the artifact targeted English output (e.g. eval #3's explicit "Output in English"). That left the quizzes out of step with the rest of the close-reading design, where every passage carries a verbatim original (`.orig`) plus a Chinese translation (`.zh`).

This makes quizzes follow the same `orig→zh` rhythm:

- **Bilingual labels** — `节后小测 / Section Quiz`, `总测 / Final Test`, `查看答案 / Show answer`, `答案/Answer`, `解析/Explanation`
- **Bilingual questions** — each question in the source's original language with a faithful Chinese translation directly beneath (`.q` / `.q-zh`, mirroring `.orig` / `.zh`)
- **Bilingual answers/explanations** — given in both languages
- **Exception** — a source that is already Chinese keeps a single Chinese question line, same as a Chinese passage needs no translation

## Files

- `references/output-contract.md` — quizzes now specified as bilingual in the three-pillars section; added a non-negotiable rule that a single-language quiz is a defect (with the Chinese-source exception).
- `references/workflow.md` — step 4 now instructs bilingual section + final quizzes.
- `references/skeleton.md` — quiz markup rewritten to `.q` / `.q-zh` + bilingual labels; added `.quiz .q` / `.quiz .q-zh` CSS for the question-translation line.
- `evals/evals.json` — added a bilingual-quiz expectation to the two English-output evals (#1, #3).

## How it was validated (skill TDD)

- **RED** — Ran the current skill on an English source with "output in English"; confirmed Chinese-only labels and single-language questions (no `orig`+`zh` pairing).
- **GREEN** — Re-ran the same scenario with the edited skill; quizzes now produce bilingual labels, source-language question + Chinese translation beneath, and bilingual answers/explanations.
- `evals.json` validated as well-formed JSON.

## Review Guide

- Start with **`references/output-contract.md`** — it defines the new contract (the bilingual rule + the Chinese-source exception). Everything else implements it.
- Then **`references/skeleton.md`** for the concrete markup/CSS the model emits, and **`references/workflow.md`** for the generation instruction.
- Watch for: the **Chinese-source exception** is stated in all three files — confirm it reads consistently (a Chinese source should *not* get a redundant duplicate question line).
- No Go code touched; change is skill-content markdown + evals JSON only.

## Note for reviewers (not in this PR)

`.claude/skills/devpilot-learn/` is a stale older generation of this skill (the pre-close-reading "digest" version, no quizzes, no `references/`). These edits apply only to the canonical `skills/devpilot-learn/`. Resyncing the installed copy is a separate, larger change.

## For Reviewers (human)

- [x] Bilingual quiz layout reads well when rendered (labels + question pair + answers)
- [x] Chinese-source exception wording is unambiguous across the three reference files

🤖 Generated with [Claude Code](https://claude.com/claude-code)