### PR TITLE
feat(devpilot-learn): fetch verbatim source + coverage gate to stop over-compression

### DIFF
--- a/skills/devpilot-learn/SKILL.md
+++ b/skills/devpilot-learn/SKILL.md
@@ -38,12 +38,23 @@ than the source, because it adds a translation and quizzes beneath text it has k
 | `references/output-contract.md` | First — the output guarantees and hard constraints, especially the rule against over-compression. |
 | `references/workflow.md` | During execution — source fetching, segmentation, generation flow, save rules, and edge cases. |
 | `references/skeleton.md` | When ready to emit the HTML — the single-column verbatim-original → translation → quiz layout. |
+| `scripts/fetch_source.py` | When the source is a URL — fetches the page's **verbatim** text. Use this instead of `WebFetch`, which returns a summary and silently compresses the source. |
+| `scripts/extract_pdf.py` | When the source is a PDF — layout-aware **verbatim** extraction into real paragraphs + section headings (needs PyMuPDF). |
+| `scripts/check_coverage.py` | Before saving — the mechanical coverage gate; verifies every source section survives in the `.orig` blocks and names what to restore. |
 
 ## How to use this skill
 
 1. Read `references/output-contract.md` before writing anything.
-2. Follow `references/workflow.md` to fetch the source, segment it, and generate the artifact.
+2. Follow `references/workflow.md` to fetch the source (verbatim, into `source.txt`),
+   segment it, and generate the artifact.
 3. Load `references/skeleton.md` for the layout when you are ready to emit the final HTML file.
+4. Run `scripts/check_coverage.py source.txt <artifact.html>` before saving and restore
+   anything it flags — passing the gate is required.
 
 Keep `SKILL.md` as the entry point. Put detailed layout, workflow, and output spec
 in the reference files above rather than re-expanding them inline.
+
+**Helper dependencies (Python 3):** `fetch_source.py` uses BeautifulSoup (`bs4`) and
+degrades to the standard library if it is absent; `extract_pdf.py` needs PyMuPDF
+(`python3 -m pip install --user pymupdf`) and the workflow falls back to a plain `Read`
+of the PDF if it is missing. The scripts never hard-block the skill.

--- a/skills/devpilot-learn/references/output-contract.md
+++ b/skills/devpilot-learn/references/output-contract.md
@@ -57,6 +57,16 @@ is the failure mode this contract exists to prevent.
   aren't in that passage and do not editorialize.
 - Preserve source terminology. For statutes, cases, proper nouns, product/model/org
   names, keep the original term and add a common Chinese rendering only when it helps.
+- Build `.orig` from the source's real text, fetched verbatim. For URLs that means the
+  bundled `scripts/fetch_source.py`, for PDFs `scripts/extract_pdf.py` — **never**
+  `WebFetch`, which returns a summary of the page, not its words, so `.orig` built on it
+  is compressed before you begin. If extraction genuinely fails and you must fall back to
+  a summarized fetch, say so in the meta block (`基于摘要式抓取，非逐字原文 / Based on a
+  summarized fetch, not verbatim`); never pass summary text off as the verbatim original.
+- Coverage is gated mechanically, not by eye. Before saving you must run
+  `scripts/check_coverage.py source.txt <artifact.html>` and it must pass. It reports
+  which source sections/paragraphs are missing from your `.orig` blocks; restore them and
+  re-run until it passes. A failing gate means the artifact is not done.
 - Quizzes must be answerable from the source alone — never test outside knowledge.
 - Quizzes are bilingual, never single-language. A question in only one language (or
   bilingual answer content under Chinese-only labels like a bare `节后小测` / `查看答案`)

--- a/skills/devpilot-learn/references/workflow.md
+++ b/skills/devpilot-learn/references/workflow.md
@@ -5,16 +5,52 @@ producing the close-reading artifact.
 
 ## 1. Identify and fetch the source
 
+However the source arrives, capture its **verbatim** text into a working file
+`source.txt` in the output directory. You close-read from that file, and the coverage
+gate in step 5 checks your artifact against it — so the bundled fetch/extract helpers
+write the text you must quote in `.orig`.
+
 The user provides one of:
 
-- **URL** — use `WebFetch`. If the page is paywalled, mostly navigation, or too thin,
-  tell the user the source is weak and continue only with what is actually accessible.
-- **PDF** (`.pdf`) — use the `Read` tool with the file path. **Read the whole document**,
-  not just the first pages. You cannot close-read text you never loaded, so cover every
-  section before writing.
-- **Word doc** (`.docx`) — convert with `textutil -convert txt <file> -stdout` (macOS) or
-  `pandoc <file> -t plain` as fallback.
-- **Text / Markdown** (`.txt`, `.md`) or **pasted text** — read directly.
+- **URL** — fetch the page's **verbatim** text with this skill's bundled helper, **not**
+  with `WebFetch`. Run it by absolute path from the skill's base directory and save it:
+
+  ```
+  python3 <skill-dir>/scripts/fetch_source.py "<url>" > source.txt
+  ```
+
+  It writes the article's actual words to `source.txt` (this is the text your `.orig`
+  blocks must quote) and a one-line JSON diagnostic to stderr.
+
+  **Why not `WebFetch`:** `WebFetch` returns a model-generated *summary* of the page, not
+  its words — for long articles it drops or paraphrases almost everything, so any `.orig`
+  built on it is already compressed before you start. The helper exists to hand you the
+  real text instead.
+
+  Read the diagnostic and act on it:
+  - `"thin": false` → trust stdout as the source text and close-read it.
+  - `"thin": true`, a non-zero exit, or an `"error"` → extraction failed or the page was
+    too sparse (paywall, JS-only rendering, bot wall). Only then fall back to `WebFetch`
+    for whatever text is accessible, **and tag the artifact honestly**: add to the meta
+    block `本资料基于摘要式抓取，非逐字原文 / Based on a summarized fetch, not verbatim`.
+    Never present summarized text as if it were the verbatim original.
+- **PDF** (`.pdf`) — extract the **verbatim** text with the bundled layout-aware helper,
+  which reconstructs real paragraphs and marks section headings (`## heading`) so the
+  coverage gate can see your section structure:
+
+  ```
+  python3 <skill-dir>/scripts/extract_pdf.py "<file.pdf>" > source.txt
+  ```
+
+  It needs PyMuPDF (`python3 -m pip install --user pymupdf`). Read the JSON diagnostic on
+  stderr. If it exits non-zero (e.g. exit `3` = PyMuPDF missing) or reports `"thin": true`,
+  fall back to reading the PDF with the `Read` tool — **read the whole document**, every
+  section, and write that text to `source.txt` yourself. Either way you must end up with
+  the full verbatim text on disk before writing.
+- **Word doc** (`.docx`) — `textutil -convert txt <file> -stdout > source.txt` (macOS) or
+  `pandoc <file> -t plain -o source.txt` as fallback.
+- **Text / Markdown** (`.txt`, `.md`) or **pasted text** — copy it verbatim into
+  `source.txt`.
 
 For long sources, read in passes if needed, but do not start writing until you have seen
 the full source end to end.
@@ -68,23 +104,39 @@ sections (drop it for short single-section sources).
 
 ### Guard against over-compression
 
-The recurring failure mode is summarizing instead of close-reading. Before saving, sanity
--check: a reader should be able to follow the source's full argument from your `.orig`
-blocks alone, in order. If whole sections of the source are missing, or your `.orig`
-blocks are one-line snippets where the source had full paragraphs, you have summarized —
-go back and restore the original text. The artifact is normally **larger** than the source,
-not smaller.
+The recurring failure mode is summarizing instead of close-reading. A reader should be
+able to follow the source's full argument from your `.orig` blocks alone, in order. If
+whole sections of the source are missing, or your `.orig` blocks are one-line snippets
+where the source had full paragraphs, you have summarized — restore the original text. The
+artifact is normally **larger** than the source, not smaller. Step 5's coverage gate
+enforces this mechanically; passing it is required, not optional.
 
-## 5. Save and present
+## 5. Run the coverage gate, then save
 
-Save with the `Write` tool to the current working directory unless the user says otherwise.
+Before you save, **verify coverage mechanically** — don't rely on eyeballing it. Write
+the artifact to its intended path, then run the gate against `source.txt`:
+
+```
+python3 <skill-dir>/scripts/check_coverage.py source.txt <artifact.html>
+```
+
+It prints per-section coverage and lists any source paragraphs missing from your `.orig`
+blocks. **If it exits non-zero** (a section was dropped, or overall coverage is below
+threshold), restore the listed paragraphs as new `.orig` + `.zh` passages in the right
+section, then re-run until it passes. The gate already excludes references and
+figure/table dumps, so the paragraphs it names are real prose you skipped — put them back,
+don't argue with it.
+
+Then save with the `Write` tool to the current working directory unless the user says
+otherwise.
 
 Naming convention:
 
 - For files: `study-guide-[original-filename].html`
 - For URLs: `study-guide-[slugified-domain-or-title].html`
 
-Tell the user the saved file path.
+Tell the user the saved file path. (The `source.txt` working file can be left in place or
+removed; it is not the deliverable.)
 
 ## Edge cases
 

--- a/skills/devpilot-learn/scripts/check_coverage.py
+++ b/skills/devpilot-learn/scripts/check_coverage.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Section-level coverage gate: did the artifact keep every section, or drop some?
+
+The skill's standing failure mode is *coverage compression* — the model keeps the
+`.orig` blocks it writes verbatim, but silently skips whole sections of the source.
+Instructions alone don't stop this. This gate measures coverage per source section and
+names the paragraphs that went missing, so they can be restored before saving.
+
+It relies on the source text carrying `## heading` markers (as emitted by extract_pdf.py
+and fetch_source.py). End-matter — References / Bibliography / Acknowledgments and
+everything after — is excluded, since the skill legitimately drops it.
+
+Usage:
+    python3 check_coverage.py <source.txt> <artifact.html> [--threshold 0.85]
+
+Output (stdout): a per-section coverage table, then the source paragraphs absent from
+every `.orig` block (the ones to restore).
+Exit: 0 if overall coverage >= threshold AND no substantive section was fully dropped;
+otherwise 1.
+"""
+
+import argparse
+import re
+import sys
+
+# Paragraphs shorter than this (words) are captions/noise — not held to the coverage bar.
+MIN_PARA_WORDS = 25
+# A source paragraph is "covered" when a run of this many of its words appears in .orig.
+WINDOW = 12
+# Headings that begin end-matter the skill legitimately drops.
+ENDMATTER = re.compile(
+    r"^\s*(references|bibliography|works cited|参考文献|acknowledge?ments?|致谢)\b", re.I)
+
+
+def normalize(text):
+    text = re.sub(r"\s+", " ", text.lower())
+    return re.sub(r"[^\w\s]", "", text)
+
+
+_CAPTION = re.compile(r"^\s*(figure|fig\.?|table|algorithm|listing)\s*\d", re.I)
+_CITE = re.compile(r"\([^)]*\b(?:19|20)\d{2}[^)]*\)")
+
+
+def is_noncontent(para):
+    """Figure/table captions, affiliations, and citation/taxonomy enumerations —
+    not prose to close-read, so excluded from the coverage denominator."""
+    words = para.split()
+    if not words:
+        return True
+    if _CAPTION.match(para) or "@" in para:        # caption / email-affiliation line
+        return True
+    digits = sum(1 for w in words if re.fullmatch(r"[\d.,%§()/+-]+", w))
+    if digits / len(words) > 0.25:                 # table dump
+        return True
+    cites = len(_CITE.findall(para))               # "Name (Author et al., 2022)" lists
+    if cites >= 4 and len(words) / cites < 14:      # citation-dense enumeration, not prose
+        return True
+    return False
+
+
+def parse_sections(path):
+    """Return [(title, [paragraph, ...]), ...], stopping at end-matter."""
+    raw = open(path, encoding="utf-8", errors="replace").read()
+    sections, title, paras = [], "(preamble)", []
+    for block in re.split(r"\n\s*\n", raw):
+        block = block.strip()
+        if not block:
+            continue
+        if block.startswith("## "):
+            head = block[3:].strip()
+            if ENDMATTER.match(head):
+                if paras:
+                    sections.append((title, paras))
+                return sections  # cut end-matter and everything after
+            if paras:
+                sections.append((title, paras))
+            title, paras = head, []
+        else:
+            paras.append(block)
+    if paras:
+        sections.append((title, paras))
+    return sections
+
+
+def artifact_orig_text(path):
+    try:
+        from bs4 import BeautifulSoup
+        soup = BeautifulSoup(open(path, encoding="utf-8", errors="replace").read(),
+                             "html.parser")
+        blocks = [e.get_text(" ", strip=True) for e in soup.select(".orig")]
+        if blocks:
+            return " ".join(blocks)
+    except ImportError:
+        pass
+    html = open(path, encoding="utf-8", errors="replace").read()
+    blocks = re.findall(r'class=["\']orig["\'][^>]*>(.*?)</', html, re.S)
+    return " ".join(re.sub(r"<[^>]+>", " ", b) for b in blocks)
+
+
+def is_covered(para, orig_norm):
+    words = normalize(para).split()
+    if len(words) < WINDOW:
+        return normalize(para) in orig_norm
+    for start in (0, max(0, len(words) // 2 - WINDOW // 2), len(words) - WINDOW):
+        if " ".join(words[start:start + WINDOW]) in orig_norm:
+            return True
+    return False
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("source")
+    ap.add_argument("artifact")
+    ap.add_argument("--threshold", type=float, default=0.85)
+    args = ap.parse_args()
+
+    sections = parse_sections(args.source)
+    orig_norm = normalize(artifact_orig_text(args.artifact))
+
+    total = covered = 0
+    dropped_sections, missing = [], []
+    rows = []
+    for title, paras in sections:
+        gradable = [p for p in paras
+                    if len(p.split()) >= MIN_PARA_WORDS and not is_noncontent(p)]
+        if not gradable:
+            continue
+        cov = [p for p in gradable if is_covered(p, orig_norm)]
+        total += len(gradable)
+        covered += len(cov)
+        rows.append((title, len(cov), len(gradable)))
+        if not cov:
+            dropped_sections.append(title)
+        missing.extend(p for p in gradable if p not in cov)
+
+    if total == 0:
+        print("No substantive prose sections found — check the source.txt path/format.")
+        return 1
+    ratio = covered / total
+
+    print("Section coverage gate")
+    for title, c, n in rows:
+        flag = "  <-- DROPPED" if c == 0 else ("  (partial)" if c < n else "")
+        print(f"  {c}/{n:<3} {title[:60]}{flag}")
+    print(f"\n  overall: {covered}/{total} paragraphs = {ratio:.1%} "
+          f"(threshold {args.threshold:.0%})")
+
+    if missing:
+        print("\nSource paragraphs NOT represented in any .orig block — restore these:")
+        for i, p in enumerate(missing, 1):
+            print(f"\n  [{i}] {' '.join(p.split())[:200]}...")
+
+    failed = ratio < args.threshold or dropped_sections
+    if failed:
+        if dropped_sections:
+            print("\nDropped sections: " + ", ".join(dropped_sections))
+        print(f"\nFAIL: restore the missing paragraphs above, then re-run.")
+        return 1
+    print("\nPASS: coverage meets threshold and no section was dropped.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/devpilot-learn/scripts/extract_pdf.py
+++ b/skills/devpilot-learn/scripts/extract_pdf.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Extract a PDF's text VERBATIM with layout awareness — real paragraphs and headings.
+
+Plain text extraction (e.g. pypdf) of a multi-column or academic PDF returns page-blobs,
+not paragraphs, so the model can't reliably copy `.orig` from it and a coverage gate
+can't tell which sections were dropped. This uses PyMuPDF's font/coordinate data to
+reconstruct paragraphs and detect section headings (emitted as `## heading`), giving the
+skill clean, segmentable verbatim text.
+
+Usage:
+    python3 extract_pdf.py <file.pdf>
+
+Output:
+    stdout — title line, blank line, then body: `## heading` lines and blank-line-
+             separated verbatim paragraphs, in reading order (column-aware).
+    stderr — one JSON diagnostic line: {"method","word_count","pages","sections","thin","title"}.
+
+Exit: 0 normal; 1 on read/parse failure; 3 if PyMuPDF is not installed (with a pip hint).
+The caller (workflow.md) falls back to a plain `Read` of the PDF on a non-zero exit, and
+tags the artifact if the fallback text is too thin to close-read.
+"""
+
+import json
+import re
+import sys
+from collections import Counter
+
+THIN_WORD_THRESHOLD = 120
+# A line is a heading candidate when its font is this much larger than body text.
+HEADING_SIZE_RATIO = 1.12
+# Headings are short; longer lines at heading size are usually emphasized prose.
+HEADING_MAX_WORDS = 14
+
+
+def body_font_size(doc):
+    """Most common span size, weighted by character count — i.e. the body text size."""
+    sizes = Counter()
+    for page in doc:
+        for block in page.get_text("dict").get("blocks", []):
+            for line in block.get("lines", []):
+                for span in line.get("spans", []):
+                    sizes[round(span["size"], 1)] += len(span["text"])
+    return sizes.most_common(1)[0][0] if sizes else 10.0
+
+
+def ordered_blocks(page):
+    """Text blocks in reading order, column-aware for 2-column layouts."""
+    blocks = [b for b in page.get_text("dict").get("blocks", []) if b.get("lines")]
+    if not blocks:
+        return []
+    page_mid = page.rect.width / 2
+    centers = [(b["bbox"][0] + b["bbox"][2]) / 2 for b in blocks]
+    # Two columns if blocks sit clearly on both sides of the page midline.
+    two_col = any(c < page_mid * 0.9 for c in centers) and any(c > page_mid * 1.1 for c in centers)
+    def key(b):
+        cx = (b["bbox"][0] + b["bbox"][2]) / 2
+        col = 0 if (not two_col or cx < page_mid) else 1
+        return (col, round(b["bbox"][1]))
+    return sorted(blocks, key=key)
+
+
+def block_text_and_size(block):
+    lines, max_size = [], 0.0
+    for line in block["lines"]:
+        spans = line.get("spans", [])
+        if spans:
+            max_size = max(max_size, max(s["size"] for s in spans))
+        lines.append("".join(s["text"] for s in spans))
+    text = "\n".join(lines)
+    text = re.sub(r"-\n(?=\w)", "", text)   # join hyphenated line breaks
+    text = re.sub(r"\s*\n\s*", " ", text)    # collapse intra-paragraph line breaks
+    return text.strip(), max_size
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write('{"error": "usage: extract_pdf.py <file.pdf>"}\n')
+        return 1
+    path = sys.argv[1]
+    try:
+        import fitz  # PyMuPDF
+    except ImportError:
+        sys.stderr.write(json.dumps({
+            "error": "PyMuPDF not installed",
+            "hint": "python3 -m pip install --user pymupdf",
+        }) + "\n")
+        return 3
+    try:
+        doc = fitz.open(path)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(json.dumps({"error": "open failed: %s" % e}) + "\n")
+        return 1
+
+    body = body_font_size(doc)
+    title = (doc.metadata or {}).get("title") or ""
+    page_count = len(doc)
+    out, sections = [], 0
+    for page in doc:
+        for block in ordered_blocks(page):
+            text, size = block_text_and_size(block)
+            if not text:
+                continue
+            is_heading = (size >= body * HEADING_SIZE_RATIO
+                          and len(text.split()) <= HEADING_MAX_WORDS)
+            if is_heading:
+                out.append("## " + text)
+                sections += 1
+            else:
+                out.append(text)
+    doc.close()
+
+    body_text = "\n\n".join(out)
+    word_count = len(body_text.split())
+    sys.stderr.write(json.dumps({
+        "method": "pymupdf", "word_count": word_count, "pages": page_count,
+        "sections": sections, "thin": word_count < THIN_WORD_THRESHOLD, "title": title,
+    }) + "\n")
+    if title:
+        sys.stdout.write(title + "\n\n")
+    sys.stdout.write(body_text + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/devpilot-learn/scripts/fetch_source.py
+++ b/skills/devpilot-learn/scripts/fetch_source.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Fetch a URL and extract its main article text VERBATIM.
+
+This exists because WebFetch returns model-summarized content, not the source's
+actual words — so `.orig` blocks built on WebFetch are compressed before the skill
+ever runs. This script returns the real text instead.
+
+Usage:
+    python3 fetch_source.py <url>
+
+Output:
+    stdout  — extracted verbatim text (title line, blank line, then body).
+    stderr  — one JSON diagnostic line: {"method","word_count","thin","title","final_url"}.
+
+Contract for the caller (workflow.md):
+    - Exit 0 with "thin": false  → trust stdout as the verbatim source text.
+    - Exit 0 with "thin": true   → extraction was weak; fall back to WebFetch and
+                                   TAG the artifact "based on a summarized fetch,
+                                   not verbatim".
+    - Non-zero exit              → fetch failed entirely; fall back to WebFetch (tagged).
+
+No third-party services and no network egress beyond the target URL. Standard library
+plus BeautifulSoup (bs4) when available; degrades to a stdlib-only parser otherwise.
+"""
+
+import gzip
+import io
+import json
+import sys
+import urllib.request
+
+# A page that yields fewer words than this is treated as a failed/thin extraction,
+# so the caller degrades honestly instead of close-reading a stub.
+THIN_WORD_THRESHOLD = 120
+
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+      "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36")
+
+# Containers that never hold article prose; dropped before extraction.
+BOILERPLATE_TAGS = ("script", "style", "noscript", "nav", "header", "footer",
+                    "aside", "form", "figure", "button", "svg", "iframe")
+
+# Class/id tokens for sidebars, nav boxes, info boxes, comments, share/promo
+# widgets. Matched as whole tokens (so "header" won't catch "headline") and dropped
+# before extraction. Common across MediaWiki, WordPress, and most news CMSes.
+NOISE_CLASSES = frozenset((
+    "navbox", "sidebar", "vertical-navbox", "infobox", "hatnote", "mw-editsection",
+    "reference", "reflist", "toc", "mw-jump-link", "noprint", "navigation",
+    "breadcrumb", "breadcrumbs", "menu", "related", "related-articles", "comments",
+    "comment", "share", "sharing", "social", "social-share", "cookie",
+    "cookie-banner", "newsletter", "subscribe", "promo", "advertisement", "ads",
+    "sponsor",
+))
+BLOCK_TAGS = ("p", "h1", "h2", "h3", "h4", "h5", "h6", "li", "blockquote", "pre")
+
+
+def fetch_html(url):
+    req = urllib.request.Request(url, headers={"User-Agent": UA,
+                                               "Accept-Language": "en,zh;q=0.9"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        final_url = resp.geturl()
+        raw = resp.read()
+        if resp.headers.get("Content-Encoding", "").lower() == "gzip":
+            raw = gzip.GzipFile(fileobj=io.BytesIO(raw)).read()
+        charset = resp.headers.get_content_charset() or "utf-8"
+    return raw.decode(charset, errors="replace"), final_url
+
+
+def extract_with_bs4(html):
+    from bs4 import BeautifulSoup
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.title.get_text(strip=True) if soup.title else ""
+    for tag in soup(list(BOILERPLATE_TAGS)):
+        tag.decompose()
+    for el in soup.find_all(attrs={"class": True}):
+        try:
+            if set(el.get("class") or []) & NOISE_CLASSES:
+                el.decompose()
+        except Exception:  # noqa: BLE001 — already detached by a parent's decompose
+            pass
+    for el in soup.select("[role=navigation], [role=note], [role=complementary]"):
+        el.decompose()
+    for br in soup.find_all("br"):       # legacy pages delimit paragraphs with <br>
+        br.replace_with("\n")
+
+    # Prefer the real article container. Semantic tags first, then the content-wrapper
+    # class/id conventions most CMSes and wikis use; fall back to the body only when
+    # none match (e.g. minimalist legacy pages).
+    root = None
+    for sel in ("article", "main", "[role=main]", "[itemprop=articleBody]",
+                "#mw-content-text", ".mw-parser-output", ".post-content",
+                ".entry-content", ".article-body", ".article__body", ".story-body"):
+        node = soup.select_one(sel)
+        if node and len(node.get_text(strip=True)) > 200:
+            root = node
+            break
+    if root is None:
+        root = soup.body or soup
+
+    # Primary path: structured block extraction. Keeps headings (## markers, so the
+    # skill can segment) and lists. Works for modern, well-marked-up HTML.
+    lines = []
+    for b in root.find_all(BLOCK_TAGS):
+        txt = b.get_text(" ", strip=True)
+        if not txt:
+            continue
+        if b.name in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            lines.append("\n## " + txt)
+        elif b.name == "li":
+            lines.append("- " + txt)
+        else:
+            lines.append(txt)
+    body = "\n\n".join(lines)
+
+    # Fallback path: legacy pages (e.g. <font> + <br>) where prose isn't in block
+    # tags at all. Take the container's full text and split into paragraphs on the
+    # newlines we inserted for <br> and the block boundaries.
+    if len(body.split()) < THIN_WORD_THRESHOLD:
+        raw = root.get_text()
+        paras = [ln.strip() for ln in raw.split("\n") if len(ln.strip()) > 1]
+        body = "\n\n".join(paras)
+    return title, body, "bs4"
+
+
+def extract_with_stdlib(html):
+    """Fallback when bs4 is unavailable: crude tag strip via HTMLParser."""
+    from html.parser import HTMLParser
+
+    class Stripper(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.skip = 0
+            self.title_mode = False
+            self.title = ""
+            self.parts = []
+
+        def handle_starttag(self, tag, attrs):
+            if tag in BOILERPLATE_TAGS:
+                self.skip += 1
+            if tag == "title":
+                self.title_mode = True
+            if tag in ("p", "br", "div", "li") + ("h1", "h2", "h3", "h4", "h5", "h6"):
+                self.parts.append("\n")
+
+        def handle_endtag(self, tag):
+            if tag in BOILERPLATE_TAGS and self.skip:
+                self.skip -= 1
+            if tag == "title":
+                self.title_mode = False
+
+        def handle_data(self, data):
+            if self.title_mode:
+                self.title += data
+            elif not self.skip and data.strip():
+                self.parts.append(data.strip())
+
+    p = Stripper()
+    p.feed(html)
+    text = " ".join(part for part in p.parts).replace(" \n ", "\n").strip()
+    paras = [ln.strip() for ln in text.split("\n") if len(ln.strip()) > 1]
+    return p.title.strip(), "\n\n".join(paras), "stdlib"
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write('{"error": "usage: fetch_source.py <url>"}\n')
+        return 2
+    url = sys.argv[1]
+    try:
+        html, final_url = fetch_html(url)
+    except Exception as e:  # noqa: BLE001 — any fetch failure means "fall back".
+        sys.stderr.write(json.dumps({"error": "fetch failed: %s" % e}) + "\n")
+        return 1
+
+    try:
+        title, body, method = extract_with_bs4(html)
+    except ImportError:
+        title, body, method = extract_with_stdlib(html)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(json.dumps({"error": "extract failed: %s" % e}) + "\n")
+        return 1
+
+    word_count = len(body.split())
+    thin = word_count < THIN_WORD_THRESHOLD
+    sys.stderr.write(json.dumps({
+        "method": method, "word_count": word_count, "thin": thin,
+        "title": title, "final_url": final_url,
+    }) + "\n")
+
+    if title:
+        sys.stdout.write(title + "\n\n")
+    sys.stdout.write(body + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

`devpilot-learn` is supposed to be a **close-reading** artifact — it must keep the source's *actual words* in `.orig` blocks. In practice it was heavily compressing sources, in **two independent ways**:

1. **Fetch-side (URLs):** the workflow fetched URLs with `WebFetch`, which returns a model-generated *summary* of the page, not its words. For long articles it drops/paraphrases almost everything, so `.orig` was built on already-compressed text. Proven cold: on an 11,471-word essay, `WebFetch` returned **0 verbatim words** (it refused and emitted a ~150-word "key themes" summary).
2. **Generation-side (all sources, incl. PDF — `WebFetch`-independent):** even with the full verbatim text in context, the model silently **dropped whole sections**. A diligent run on a 15-page paper kept the prose it wrote verbatim but skipped ~a quarter of it.

Instructions alone (the contract was already full of "don't compress") couldn't stop this, so this PR adds **mechanical guarantees**.

## Changes

**New helper scripts** (`skills/devpilot-learn/scripts/`, Python 3):
- **`fetch_source.py`** — verbatim URL extraction via `curl`/`urllib` + BeautifulSoup (readability-style container selection, `<br>`/legacy-page handling, nav/boilerplate stripping). Local-only, **no third-party services**, degrades to a stdlib parser if `bs4` is absent. Replaces `WebFetch` for URLs.
- **`extract_pdf.py`** — layout-aware PDF extraction (PyMuPDF) that reconstructs real paragraphs and detects section headings (`## heading`) via font size, column-aware for 2-column papers. Exits `3` with a pip hint if PyMuPDF is missing.
- **`check_coverage.py`** — section-level coverage gate. Parses `source.txt` `##` sections (excluding References/figures/tables), checks each source paragraph appears verbatim in some `.orig` block, prints a per-section table, names dropped prose, and **hard-fails** below threshold (default 85%) or if any section is fully dropped.

**Docs rewired:**
- `references/workflow.md` — every source type now lands its **verbatim** text in `source.txt` (URL→`fetch_source.py`, PDF→`extract_pdf.py`, docx/txt→copied), `WebFetch` is forbidden (tagged fallback only), and a coverage-gate step is required before saving.
- `references/output-contract.md` — verbatim-fetch and the passing coverage gate are now non-negotiable rules.
- `SKILL.md` — files table, how-to steps, and a helper-dependency note (`bs4`, PyMuPDF; both degrade gracefully).

## Verification (RED → GREEN)
- **Fetch:** `WebFetch` → 0 verbatim words on the test essay; `fetch_source.py` → 11,471. A subagent following the updated skill used `fetch_source.py`, not `WebFetch`.
- **Gate:** correctly **FAILs** a dropped-section artifact (81%, names the missing section) and **PASSes** a complete one (96.4%).
- **End-to-end:** a subagent ran the full updated pipeline on the 15-page PDF — extracted via `extract_pdf.py` (9,074 verbatim words), generated, and passed the gate on the first try (96.4%, all 12 prose sections covered). Independently re-verified: gate PASS, 44/50 `.orig` blocks match the source verbatim (the rest differ only by PDF ligatures like `Deﬁnition`→`Definition`).
- All three scripts pass `python3 -m py_compile`.

## Review Guide
- **Start with `references/workflow.md`** — it's the control flow that ties the scripts together (source → `source.txt` → generate → gate → save). The diff there is the behavioral change.
- Then skim the three scripts in this order: `fetch_source.py` (URL path), `extract_pdf.py` (PDF path), `check_coverage.py` (the gate). The gate's non-content filters (`is_noncontent`, `ENDMATTER`) are the trickiest bit — they exist to avoid false-flagging references/tables as "dropped prose."
- `output-contract.md` / `SKILL.md` are doc updates that mirror the workflow.

### Notes for reviewers (human)
- [x] **New dependency: PyMuPDF** for the PDF path. The script and workflow fall back to a plain `Read` of the PDF if it's not installed, so it's not a hard requirement — but confirm you're OK adding it to the skill's footprint.
- [x] No Go code changed; `skills/index.json` not touched (existing skill, not a new one).
- [x] The gate uses an 85% coverage threshold and still lists ~2 table-row false-positives on dense academic PDFs (doesn't affect the pass/fail verdict) — sanity-check the threshold feels right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)