### PR TITLE
feat(devpilot-learn): fan out large sources by section batch

### DIFF
--- a/skills/devpilot-learn/SKILL.md
+++ b/skills/devpilot-learn/SKILL.md
@@ -40,6 +40,7 @@ than the source, because it adds a translation and quizzes beneath text it has k
 | `references/skeleton.md` | When ready to emit the HTML — the single-column verbatim-original → translation → quiz layout. |
 | `scripts/fetch_source.py` | When the source is a URL — fetches the page's **verbatim** text. Use this instead of `WebFetch`, which returns a summary and silently compresses the source. |
 | `scripts/extract_pdf.py` | When the source is a PDF — layout-aware **verbatim** extraction into real paragraphs + section headings (needs PyMuPDF). |
+| `scripts/batch_sections.py` | When the source is large (≥ ~6k words or ≥ 25 sections) — groups it into ordered, word-budgeted batches so you can fan out one subagent per batch instead of emitting the whole artifact in one output-limited pass. |
 | `scripts/check_coverage.py` | Before saving — the mechanical coverage gate; verifies every source section survives in the `.orig` blocks and names what to restore. |
 
 ## How to use this skill

--- a/skills/devpilot-learn/references/workflow.md
+++ b/skills/devpilot-learn/references/workflow.md
@@ -81,6 +81,14 @@ Within each section, note:
 
 ## 4. Build the artifact
 
+**First decide whether to fan out.** Large sources don't fail the coverage gate, but
+generating the whole artifact in one pass bumps the model's per-response output limit:
+the agent gets terser toward the end and the run drags (a 12k-word source took ~37 min
+serially and only finished by switching to a fragile append loop). When `source.txt` is
+roughly **≥ 6,000 words or ≥ 25 sections** (check the extract diagnostic's `word_count`
+/ `sections`, or `grep -c '^## ' source.txt`), build it with the section-batch fan-out
+in **"Large sources"** below instead of one pass. Otherwise build it in one pass:
+
 Load `skeleton.md` and follow its layout. For each section, in source order:
 
 1. Reproduce the section's substantive paragraphs **verbatim** in `.orig` blocks. Keep
@@ -110,6 +118,53 @@ whole sections of the source are missing, or your `.orig` blocks are one-line sn
 where the source had full paragraphs, you have summarized — restore the original text. The
 artifact is normally **larger** than the source, not smaller. Step 5's coverage gate
 enforces this mechanically; passing it is required, not optional.
+
+### Large sources: fan out by section batch
+
+When step 4 routed you here, split the work so no single agent has to emit the whole
+artifact in one response. You stay the **orchestrator**: you own the shell and the final
+test, and you dispatch one subagent per batch to produce the section fragments verbatim.
+
+1. **Batch the source.** Run the bundled helper against `source.txt`:
+
+   ```
+   python3 <skill-dir>/scripts/batch_sections.py source.txt --max-words 2500 > batches.json
+   ```
+
+   It groups consecutive `## ` sections into ordered, word-budgeted batches (never
+   splitting or reordering a section) and prints JSON: `num_batches` and a `batches`
+   array, each with `index`, `headings`, `words`, and the verbatim `text` to reproduce.
+   (If `source.txt` has no `## ` headings — e.g. an unstructured page — segment it into
+   `## ` sections yourself first, per step 3, then re-run.)
+
+2. **Assign anchor ids.** Walk every section heading across all batches in order and give
+   it a stable id `sec-1`, `sec-2`, … You own these ids: the `目录` you build must link to
+   them, so each subagent must use the exact id you hand it for each of its headings.
+
+3. **Dispatch one subagent per batch, in parallel** (one message, multiple Agent calls —
+   wall-clock then tracks the slowest batch, not the sum). Give each subagent:
+   - this skill's `references/output-contract.md` and `references/skeleton.md` to read,
+   - **only its batch's `text`** (its verbatim slice — it must not see or invent other
+     sections), plus the `heading → sec-N` id map for its headings,
+   - instructions to emit **only the section fragments** for its headings, in order:
+     for each heading a `<h2 id="sec-N">…</h2>` followed by the `.passage`
+     (verbatim `.orig` → faithful `.zh`), sparse `.note` glosses, and a bilingual
+     `节后小测` — exactly as the one-pass per-section rules above require. **No**
+     `<head>`, `<h1>`, `.meta`, `.toc`, `总测`, or `<body>` wrapper — fragments only.
+   - a reminder to keep `.orig` blocks verbatim and large; it is reproducing, not
+     summarizing, and it has output budget to spare because it only owns a few sections.
+
+4. **Stitch.** Concatenate the returned fragments into `<main>` strictly in batch-index
+   then heading order — this preserves source order. Wrap them in the shell from
+   `skeleton.md`: `<head>`/`<style>`, `<h1>`, the `.meta` block, and a `.toc` linking to
+   every `sec-N`.
+
+5. **Write the final test yourself.** The `总测` spans the whole source, so build it from
+   `source.txt` (which you hold) — or dispatch one extra subagent given the full
+   `source.txt` for just the `总测`. Append it after the stitched sections.
+
+The coverage gate in step 5 still runs against the assembled file and is still required —
+fan-out changes how the artifact is produced, not the bar it must clear.
 
 ## 5. Run the coverage gate, then save
 

--- a/skills/devpilot-learn/scripts/batch_sections.py
+++ b/skills/devpilot-learn/scripts/batch_sections.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Group a verbatim source.txt into ordered, word-budgeted batches for fan-out.
+
+When a source is large, generating the whole close-reading artifact in one pass
+bumps the model's per-response output limit: the agent gets terser toward the end
+and the run drags. This helper splits the *already-extracted* verbatim text into
+consecutive batches small enough that one subagent can reproduce each batch in full
+without hitting that limit. The orchestrator dispatches one subagent per batch,
+stitches the fragments back in source order, and runs the coverage gate as usual.
+
+Input: a source.txt whose sections are marked with `## heading` lines (this is what
+extract_pdf.py emits; for other sources, add `## ` headings or segment by topic
+first). Anything before the first `## ` heading is treated as preamble and attached
+to the first batch.
+
+Output: a single JSON object on stdout:
+  {
+    "max_words": 2500,
+    "total_words": 12121,
+    "num_sections": 67,
+    "num_batches": 6,
+    "batches": [
+      {"index": 0, "headings": ["...", "..."], "words": 2310, "text": "## ...\n\n..."},
+      ...
+    ]
+  }
+Each batch's "text" is the verbatim slice (heading lines included) the subagent
+must reproduce. Batches never split a section and never reorder the source.
+
+Usage:
+  python3 batch_sections.py source.txt [--max-words N]
+
+--max-words defaults to 2500 source words per batch. A single section larger than
+the budget still becomes its own batch (never split mid-section); its word count
+will exceed --max-words and that is expected.
+"""
+
+import argparse
+import json
+import re
+import sys
+
+HEADING = re.compile(r"^##\s+(.*\S)\s*$")
+
+
+def split_sections(text):
+    """Return (preamble, [(heading, body_text), ...]) preserving order."""
+    lines = text.splitlines(keepends=True)
+    preamble = []
+    sections = []  # list of [heading, [lines...]]
+    current = None
+    for line in lines:
+        m = HEADING.match(line.rstrip("\n"))
+        if m:
+            current = [m.group(1), [line]]
+            sections.append(current)
+        elif current is None:
+            preamble.append(line)
+        else:
+            current[1].append(line)
+    return "".join(preamble), [(h, "".join(b)) for h, b in sections]
+
+
+def word_count(s):
+    return len(s.split())
+
+
+def batch(preamble, sections, max_words):
+    batches = []
+    cur_headings, cur_text, cur_words = [], [], 0
+
+    def flush():
+        nonlocal cur_headings, cur_text, cur_words
+        if cur_headings:
+            batches.append(
+                {
+                    "index": len(batches),
+                    "headings": cur_headings,
+                    "words": cur_words,
+                    "text": "".join(cur_text).rstrip("\n") + "\n",
+                }
+            )
+        cur_headings, cur_text, cur_words = [], [], 0
+
+    for heading, body in sections:
+        w = word_count(body)
+        # Start a new batch when the current one is non-empty and would overflow.
+        if cur_headings and cur_words + w > max_words:
+            flush()
+        cur_headings.append(heading)
+        cur_text.append(body)
+        cur_words += w
+    flush()
+
+    # Attach preamble (title/intro before the first heading) to the first batch.
+    if preamble.strip() and batches:
+        batches[0]["text"] = preamble.rstrip("\n") + "\n\n" + batches[0]["text"]
+        batches[0]["words"] += word_count(preamble)
+    return batches
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Batch a source.txt for fan-out.")
+    ap.add_argument("source", help="path to the verbatim source.txt")
+    ap.add_argument("--max-words", type=int, default=2500,
+                    help="target max source words per batch (default 2500)")
+    args = ap.parse_args()
+
+    with open(args.source, encoding="utf-8") as f:
+        text = f.read()
+
+    preamble, sections = split_sections(text)
+    if not sections:
+        print(json.dumps({"error": "no '## ' section headings found; "
+                          "add headings or segment by topic first"}),
+              file=sys.stderr)
+        return 2
+
+    batches = batch(preamble, sections, args.max_words)
+    out = {
+        "max_words": args.max_words,
+        "total_words": word_count(text),
+        "num_sections": len(sections),
+        "num_batches": len(batches),
+        "batches": batches,
+    }
+    json.dump(out, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

On large sources, the `devpilot-learn` skill had a single agent generate the entire close-reading artifact in one pass. That bumps the model's per-response output limit: the agent gets terser toward the end and the run drags. A **12k-word / 67-section** source took **~37 min** serially and only finished by falling back to a fragile incremental-append loop.

Crucially, the coverage gate stayed at **100%** throughout — so this is a **generation-reliability and latency** problem, not a fidelity/over-compression one. (The premise that prompted this — "263KB PDF → half-size HTML" — turned out to be a measurement artifact: 263KB is PDF container size; the actual verbatim text was 35KB, and the artifact was 3.6× that.)

This PR adds an opt-in **section-batch fan-out** path for large sources.

## Changes

- **`scripts/batch_sections.py` (new)** — groups an already-extracted `source.txt` into ordered, word-budgeted batches at `## ` heading boundaries. Never splits or reorders a section; a lone over-budget section becomes its own batch. Emits JSON (`num_batches` + per-batch `index`/`headings`/`words`/verbatim `text`) for the orchestrator to fan out over. Preamble before the first heading attaches to batch 0.
- **`references/workflow.md`** — step 4 now routes sources **≥ ~6,000 words or ≥ 25 sections** to a fan-out flow: the orchestrator owns the shell (`<head>`/meta/`目录`/`总测`) and assigns stable `sec-N` anchor ids; one subagent per batch reproduces **only** its sections' verbatim fragments (`<h2>` + `.passage` + sparse `.note` + bilingual `节后小测`), dispatched in parallel. The step-5 coverage gate is unchanged and still required.
- **`SKILL.md`** — files table lists the new helper.

## Verification (ran the fan-out end-to-end on the 12k-word source)

| | one-pass (before) | fan-out (this PR) |
|---|---|---|
| wall-clock | ~37 min | **~3.7 min** (5 parallel workers, ~10×) |
| hit output limit | yes — append workaround | **no** |
| coverage gate | 100% | **100% (182/182)** |
| artifact words | 18,772 | **22,892** (fuller) |
| structure | — | 66 TOC anchors all matched, 231 `.orig` ↔ 231 `.zh`, 63 节后小测 + 总测 |

`batch_sections.py` round-trips all 67 section headings across 6 batches with order preserved. All skill scripts `py_compile` clean.

## Review Guide

- **Start with `references/workflow.md`** — the new "Large sources: fan out by section batch" subsection is the heart of the change; check the orchestrator/worker split and the anchor-id contract (orchestrator owns `sec-N` ids, workers must use the ones handed to them, so TOC links resolve).
- Then **`scripts/batch_sections.py`** — watch the batching invariant: consecutive `## ` sections grouped under `--max-words` (default 2500), never split mid-section, never reordered; preamble folds into batch 0.
- Watch for: the fan-out is **opt-in by size threshold** — small sources still build in one pass, unchanged. The coverage gate is deliberately left untouched (it already enforces fidelity regardless of how the artifact is produced).

## For Reviewers (human)
- [x] Sanity-check the ~6k-word / 25-section fan-out threshold feels right
- [x] Confirm the orchestrator-owns-`总测` split is acceptable (vs. an extra subagent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)