### PR TITLE
fix(pr-creator): make skill safe to run concurrently

### DIFF
--- a/.claude/skills/devpilot-pr-creator/SKILL.md
+++ b/.claude/skills/devpilot-pr-creator/SKILL.md
@@ -14,6 +14,8 @@ license: Complete terms in LICENSE.txt
 **Core principle:** Read the actual diff before writing anything. Every sentence in the description
 must come from code you read, not from branch names or assumptions.
 
+**Operating mode: automatic by default.** Do not stop to confirm routine choices (branch name, commit message, draft body) — derive them from the diff and execute. Only stop for the destructive / ambiguous cases listed under [Hard Stops](#hard-stops). Showing a draft "for approval" before creating is **not** a hard stop; the user can `gh pr edit` after the fact.
+
 ## Quick Reference
 
 | Action | GitHub | GitLab |
@@ -25,29 +27,102 @@ must come from code you read, not from branch names or assumptions.
 | Draft | `--draft` | `--draft` |
 | Push | `git push -u origin HEAD` | `git push -u origin HEAD` |
 
+## Worktree / autonomous invocation
+
+Detect both up front — they change preflight rules.
+
+```bash
+git rev-parse --git-dir            # contains "/worktrees/" → you are in a linked worktree
+git worktree list                  # confirms which worktree is which
+```
+
+**You are in autonomous mode** when this skill was invoked by a parent skill (e.g. `devpilot-resolve-issues`, `devpilot-auto-feature`) rather than directly by a human. In autonomous mode:
+- The "stop and ask the user" gates below become "return control to the parent with the question" — never deadlock waiting for human input that isn't coming.
+- Replace "show the draft to the user before creating" with "include the draft in your final response" so the parent skill can surface it.
+- Do not `cd` out of the worktree; the parent owns cwd.
+
+**Base branch.** Always diff and log against `origin/<default-branch>` (typically `origin/main`), not local `main`. In a worktree the local `main` ref may be stale or absent. Run `git fetch origin <default-branch>` before reading the diff so the comparison is honest.
+
+## Concurrency safety
+
+This skill can run **several times at once** — a parent skill (`devpilot-resolve-issues`, `devpilot-auto-feature`) may fan out parallel agents that each open a PR. Concurrent runs corrupt each other only when they **mutate shared repo state** in the **same working directory**: `git checkout -b`, staging, and committing all move the shared `HEAD`/index, so two runs racing in one checkout clobber each other's branch and staged files. Reads (`git fetch`, `git diff`, `git log`, `gh pr list`) are safe to overlap.
+
+Follow these rules whenever concurrency is possible (autonomous mode, or the user says runs overlap):
+
+- **Never mutate a working tree you do not own.** If you would need `git checkout`/`git checkout -b`/`git switch` to get onto a branch — i.e. you are on `main`/`master` in a shared checkout — do **not** switch in place. Create an isolated worktree instead and do all mutation there:
+  ```bash
+  git fetch origin <default-branch> --quiet
+  git worktree add -b <branch> ../pr-<branch> origin/<default-branch>   # isolated HEAD + index
+  cd ../pr-<branch>                                                     # then stage/commit/push here
+  ```
+  If you were **already handed a dedicated branch/worktree** (the common autonomous case — you are on a feature branch in a linked worktree), you already own it; stage and commit in place, no new worktree needed.
+- **Make the branch name collision-proof.** Deterministic naming (below) makes two parallel runs on similar diffs pick the *same* name and collide on push. In concurrent/autonomous mode, append a short unique suffix to the derived slug — the issue/task number when the parent provides one, otherwise the short HEAD SHA: `<type>/<slug>-<issue-or-sha>`. Never reuse `Date.now()`-style timestamps.
+- **Let push, not a pre-check, arbitrate the race.** Two runs may both pass `git ls-remote` and then both push the same ref. Rely on the non-fast-forward push *rejection* as the signal — if `git push -u origin HEAD` is rejected, re-fetch and inspect per [Hard Stops](#hard-stops); never force-push to resolve it.
+- **Clean up an isolated worktree** you created once the PR is open: `git worktree remove ../pr-<branch>` (skip if it still holds uncommitted work).
+
 ## Preflight Checks
 
 Before anything else, run these in parallel:
 
 ```bash
-git remote get-url origin          # detect platform (github.com → gh, gitlab.com → glab)
-git rev-parse --abbrev-ref HEAD    # current branch
-git status                         # uncommitted changes?
-git log <base>..HEAD --oneline     # commits ahead of base
-gh pr list --head <branch>         # existing PR? (or glab mr list --source-branch)
+git remote get-url origin                    # detect platform (github.com → gh, gitlab.com → glab)
+git rev-parse --abbrev-ref HEAD              # current branch
+git rev-parse --git-dir                      # worktree detection (see above)
+git fetch origin <default-branch> --quiet    # refresh base ref
+git status                                   # working tree state
+git log origin/<default-branch>..HEAD --oneline   # commits ahead of base
+git diff --name-only origin/<default-branch>...HEAD  # files in the PR
+git ls-remote --heads origin <branch>        # branch already on origin?
+gh pr list --head <branch>                   # existing PR? (or glab mr list --source-branch)
 ```
 
-**Stop and ask the user if:**
-- Current branch is `main`/`master` — you cannot PR from main into main. Ask if they want to create a feature branch first. **Never** use `git reset`, `git push --force`, or any history rewriting on main — not even as an "option." If the work is already pushed to main, tell the user the PR opportunity has passed for this change.
-- There are uncommitted changes — ask if they want to commit first or exclude them.
-- There are no commits ahead of base — nothing to PR.
-- There's already an open PR for this branch — switch to **update flow** (see below).
+### Auto-recover: on main/master
+
+If `HEAD` is on `main`/`master`, **do not stop** — recover automatically:
+
+1. Confirm none of the local commits ahead of base have been pushed to `origin/main`. If `git log origin/main..HEAD` is empty AND the working tree is clean, there is nothing to PR — exit. If commits ahead of base have **already been pushed to origin/main**, stop: the PR window has passed (see Hard Stops).
+2. Pick a feature branch name (see [Branch naming](#branch-naming)).
+3. `git checkout -b <name>` — this carries any uncommitted changes onto the new branch and leaves `main` untouched. **Concurrency:** if other runs may share this checkout (autonomous/parallel mode), do NOT `git checkout -b` in place — isolate in a worktree per [Concurrency safety](#concurrency-safety).
+4. If there are uncommitted changes that belong in the PR, `git add` the relevant files (those whose paths overlap the intended PR scope) and commit with a conventional-commit message derived from the diff. Leave unrelated dirty files alone.
+5. Continue with the normal flow.
+
+**Never** run `git reset`, `git push --force`, `git push --force-with-lease`, or any history rewrite on `main`/`master` — not as a recovery, not as an "option," not ever.
+
+### Auto-recover: dirty working tree overlapping the PR diff
+
+If modified/staged files overlap the PR diff, **do not stop** — stage and commit them as part of the PR with a conventional-commit message derived from the changes. Files outside the PR diff stay untouched.
+
+### Hard Stops
+
+These are the *only* cases where you must stop. In autonomous mode, return the question to the parent instead of blocking:
+
+- **Work already pushed to `origin/main`/`origin/master`.** The PR window for those commits has passed. Do not try to "rescue" it with history rewriting. Tell the user.
+- **No commits ahead of base AND no uncommitted changes.** Nothing to PR.
+- **Open PR already exists for this branch.** Switch to **update flow** (see below) — this isn't really a stop, just a branch in logic.
+- **Remote branch diverged.** `git log HEAD..origin/<branch>` is non-empty after fetching. Reconcile by inspecting; never force-push.
+
+**Do NOT block on:** untracked files, or modified files outside the PR diff. These are common in worktrees (test artifacts, scratch logs, leftovers from a parent agent) and are already excluded from `origin/<base>...HEAD`. Note them in your report and proceed.
+
+### Branch naming
+
+Derive deterministically — do not ask:
+
+1. If there are commits ahead of base, parse the latest commit subject. Take its conventional prefix (`feat`, `fix`, `chore`, `docs`, `refactor`) and slugify the rest: `<type>/<kebab-slug>` (max ~50 chars).
+2. Otherwise (only uncommitted changes), pick the prefix from the change shape — `fix:` for bug language in modified code, `docs:` for `.md`-only, `chore:` for config/tooling, else `feat:`. Slug from the most-changed top-level directory or filename stem.
+3. If a branch by that name already exists locally, append `-2`, `-3`, etc.
+4. **Concurrent/autonomous mode:** deterministic slugs collide when parallel runs share a base. Append a unique suffix — the parent-supplied issue/task number if available, else the short HEAD SHA (`git rev-parse --short HEAD`): `<type>/<slug>-<issue-or-sha>`. See [Concurrency safety](#concurrency-safety).
+
+**Branch already on origin, but no open PR** (common after a draft-escalation push from `devpilot-resolve-issues`):
+1. Only enter this branch if `git ls-remote --heads origin <branch>` returned a SHA. If it was empty, skip — `git push -u origin HEAD` will create the remote ref normally.
+2. `git fetch origin <branch>` — see if remote has commits you don't.
+3. If `git log HEAD..origin/<branch>` is non-empty, stop — the remote diverged. Reconcile by inspecting; never force-push.
+4. Otherwise `git push -u origin HEAD` will fast-forward (or be a no-op). Then create the PR normally.
 
 ## Read the Diff (Required)
 
 ```bash
-git diff <base>...HEAD             # full diff
-git log <base>..HEAD --oneline     # commit history
+git diff origin/<default-branch>...HEAD   # full diff (always vs origin, not local)
+git log origin/<default-branch>..HEAD --oneline
 ```
 
 **You MUST read and understand the actual changes before writing the description.**
@@ -103,7 +178,7 @@ If no project template exists, **read ONE template** based on what you found in 
 - Leave "For Reviewers (human)" items unchecked — those are for humans
 - For bug fixes, describe the bug, root cause, and fix separately
 
-**Show the draft to the user before creating or updating.** Let them edit the title and body.
+**Do not stop to "show the draft for approval."** Write the strongest title and body you can from the diff and create the PR directly. Report the URL afterward; the user can `gh pr edit <number>` if they want to tweak. In autonomous mode (invoked by a parent skill), include the final body inline in your response so the parent can surface it.
 
 ## Create and Report
 
@@ -132,7 +207,7 @@ glab mr view <number>              # GitLab
 - **Reviewer feedback** on description → address the specific feedback while keeping the rest.
 - **Draft → Ready** → update description if it was a WIP placeholder, then mark ready.
 
-**4. Show draft to user, then execute:**
+**4. Execute the update directly** (do not stop for approval):
 ```bash
 gh pr edit <number> --title "..." --body "..."    # GitHub
 glab mr update <number> --title "..." --description "..."  # GitLab
@@ -156,7 +231,24 @@ glab mr update <number> --draft=false  # GitLab
 | Leaving irrelevant sections as "N/A" | Remove the section entirely |
 | Force-pushing main to create a retroactive branch | Never offer this as an option. If work is on main and pushed, the PR opportunity has passed |
 | Creating duplicate PR for branch with existing PR | Check `gh pr list --head <branch>` first — update instead |
+| Blocking on untracked/unstaged files unrelated to the PR | Only block when the dirty files appear in `origin/<base>...HEAD`. Untracked debris in a worktree is common and already excluded |
+| Diffing against local `main` in a worktree | Local `main` may be stale or absent in a worktree — always use `origin/<default-branch>` |
+| Force-pushing because the branch already exists on origin | Fetch first; if remote diverged, reconcile, never force. Fast-forward push is fine |
 | Appending to PR description instead of rewriting | Re-read the full diff and write a cohesive description covering all commits |
+| Stopping to ask "should I create a feature branch?" when on main | Don't. Auto-create per [Auto-recover: on main](#auto-recover-on-mainmaster). The only main-related stop is when the work was already pushed to `origin/main` |
+| Stopping to "show the draft for approval" before creating | Don't. Create directly; user edits after via `gh pr edit` |
+| Asking the user to pick a branch name | Derive it per [Branch naming](#branch-naming). Don't prompt |
+
+## Red Flags — you are over-confirming
+
+If you catch yourself about to write any of these, stop and just execute:
+
+- "Want me to create a feature branch?"
+- "Here's the draft — should I proceed?"
+- "What should I name the branch?"
+- "Should I commit these changes first?"
+
+The only legitimate stops are listed under [Hard Stops](#hard-stops). Everything else is automatic.
 
 ## Tips
 

--- a/skills/devpilot-pr-creator/SKILL.md
+++ b/skills/devpilot-pr-creator/SKILL.md
@@ -43,6 +43,23 @@ git worktree list                  # confirms which worktree is which
 
 **Base branch.** Always diff and log against `origin/<default-branch>` (typically `origin/main`), not local `main`. In a worktree the local `main` ref may be stale or absent. Run `git fetch origin <default-branch>` before reading the diff so the comparison is honest.
 
+## Concurrency safety
+
+This skill can run **several times at once** — a parent skill (`devpilot-resolve-issues`, `devpilot-auto-feature`) may fan out parallel agents that each open a PR. Concurrent runs corrupt each other only when they **mutate shared repo state** in the **same working directory**: `git checkout -b`, staging, and committing all move the shared `HEAD`/index, so two runs racing in one checkout clobber each other's branch and staged files. Reads (`git fetch`, `git diff`, `git log`, `gh pr list`) are safe to overlap.
+
+Follow these rules whenever concurrency is possible (autonomous mode, or the user says runs overlap):
+
+- **Never mutate a working tree you do not own.** If you would need `git checkout`/`git checkout -b`/`git switch` to get onto a branch — i.e. you are on `main`/`master` in a shared checkout — do **not** switch in place. Create an isolated worktree instead and do all mutation there:
+  ```bash
+  git fetch origin <default-branch> --quiet
+  git worktree add -b <branch> ../pr-<branch> origin/<default-branch>   # isolated HEAD + index
+  cd ../pr-<branch>                                                     # then stage/commit/push here
+  ```
+  If you were **already handed a dedicated branch/worktree** (the common autonomous case — you are on a feature branch in a linked worktree), you already own it; stage and commit in place, no new worktree needed.
+- **Make the branch name collision-proof.** Deterministic naming (below) makes two parallel runs on similar diffs pick the *same* name and collide on push. In concurrent/autonomous mode, append a short unique suffix to the derived slug — the issue/task number when the parent provides one, otherwise the short HEAD SHA: `<type>/<slug>-<issue-or-sha>`. Never reuse `Date.now()`-style timestamps.
+- **Let push, not a pre-check, arbitrate the race.** Two runs may both pass `git ls-remote` and then both push the same ref. Rely on the non-fast-forward push *rejection* as the signal — if `git push -u origin HEAD` is rejected, re-fetch and inspect per [Hard Stops](#hard-stops); never force-push to resolve it.
+- **Clean up an isolated worktree** you created once the PR is open: `git worktree remove ../pr-<branch>` (skip if it still holds uncommitted work).
+
 ## Preflight Checks
 
 Before anything else, run these in parallel:
@@ -65,7 +82,7 @@ If `HEAD` is on `main`/`master`, **do not stop** — recover automatically:
 
 1. Confirm none of the local commits ahead of base have been pushed to `origin/main`. If `git log origin/main..HEAD` is empty AND the working tree is clean, there is nothing to PR — exit. If commits ahead of base have **already been pushed to origin/main**, stop: the PR window has passed (see Hard Stops).
 2. Pick a feature branch name (see [Branch naming](#branch-naming)).
-3. `git checkout -b <name>` — this carries any uncommitted changes onto the new branch and leaves `main` untouched.
+3. `git checkout -b <name>` — this carries any uncommitted changes onto the new branch and leaves `main` untouched. **Concurrency:** if other runs may share this checkout (autonomous/parallel mode), do NOT `git checkout -b` in place — isolate in a worktree per [Concurrency safety](#concurrency-safety).
 4. If there are uncommitted changes that belong in the PR, `git add` the relevant files (those whose paths overlap the intended PR scope) and commit with a conventional-commit message derived from the diff. Leave unrelated dirty files alone.
 5. Continue with the normal flow.
 
@@ -93,6 +110,7 @@ Derive deterministically — do not ask:
 1. If there are commits ahead of base, parse the latest commit subject. Take its conventional prefix (`feat`, `fix`, `chore`, `docs`, `refactor`) and slugify the rest: `<type>/<kebab-slug>` (max ~50 chars).
 2. Otherwise (only uncommitted changes), pick the prefix from the change shape — `fix:` for bug language in modified code, `docs:` for `.md`-only, `chore:` for config/tooling, else `feat:`. Slug from the most-changed top-level directory or filename stem.
 3. If a branch by that name already exists locally, append `-2`, `-3`, etc.
+4. **Concurrent/autonomous mode:** deterministic slugs collide when parallel runs share a base. Append a unique suffix — the parent-supplied issue/task number if available, else the short HEAD SHA (`git rev-parse --short HEAD`): `<type>/<slug>-<issue-or-sha>`. See [Concurrency safety](#concurrency-safety).
 
 **Branch already on origin, but no open PR** (common after a draft-escalation push from `devpilot-resolve-issues`):
 1. Only enter this branch if `git ls-remote --heads origin <branch>` returned a SHA. If it was empty, skip — `git push -u origin HEAD` will create the remote ref normally.


### PR DESCRIPTION
## What & why

The `devpilot-pr-creator` skill couldn't be run concurrently. When a parent skill (`devpilot-resolve-issues`, `devpilot-auto-feature`) fans out parallel agents that each open a PR, the runs corrupted each other because they:

1. **Mutated shared repo state in one checkout** — `git checkout -b`, staging, and committing all move the shared `HEAD`/index, so parallel runs in the same working directory clobber each other's branch and staged files.
2. **Derived colliding branch names** — deterministic naming makes two parallel runs on similar diffs pick the *same* branch, colliding on push.

This PR is docs-only (the skill is a Markdown instruction file); it adds explicit concurrency rules so overlapping invocations stay isolated.

## Changes

- **New "Concurrency safety" section** in `SKILL.md`:
  - Never mutate a working tree you don't own; when on `main`/`master` in a shared checkout, isolate branch creation in a `git worktree add` instead of `git checkout -b` in place.
  - When already handed a dedicated branch/worktree (the common autonomous case), commit in place — no extra worktree.
  - Let the non-fast-forward push *rejection* arbitrate the race rather than a pre-check; never force-push to resolve it.
  - Clean up any worktree the run created once the PR is open.
- **Branch naming:** append a unique suffix (parent-supplied issue/task number, else short HEAD SHA) in concurrent/autonomous mode so parallel runs don't collide.
- **Auto-recover-on-main:** cross-references the new isolation rule at the `git checkout -b` step.
- Synced the installed `.claude/skills/devpilot-pr-creator/SKILL.md` copy (it was also stale versus `skills/`, so its diff is larger).

## Review Guide

- Start with `skills/devpilot-pr-creator/SKILL.md` — the new **Concurrency safety** section is the substance; everything else cross-references it.
- The `.claude/skills/...` copy is a byte-identical mirror of `skills/...` (verified with `diff`); its larger diff is because it was previously out of sync, not a separate change.
- No code, no build/lint surface touched — this is instruction text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgzqdfd5qpH1DM3SVLqsmq)_